### PR TITLE
fix: use board id instead of board code in optimization requirements

### DIFF
--- a/scripts/seed_boards.py
+++ b/scripts/seed_boards.py
@@ -1,0 +1,236 @@
+"""Seed script: borra los tableros existentes e inserta 20 nuevos."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.modules.boards.model import BoardModel
+from src.shared.database import SessionLocal
+
+BOARDS = [
+    # Colores puros
+    {
+        "code": "MEL-18-BL",
+        "name": "Melamina 18mm Blanco Polar",
+        "description": "Melamina blanco polar liso, uso general en muebles",
+        "length": 2440,
+        "width": 1220,
+        "thickness": 18,
+        "grain_direction": None,
+        "price": 52.00,
+    },
+    {
+        "code": "MEL-18-NG",
+        "name": "Melamina 18mm Negro Azabache",
+        "description": "Melamina negro azabache, acabado mate",
+        "length": 2440,
+        "width": 1220,
+        "thickness": 18,
+        "grain_direction": None,
+        "price": 54.00,
+    },
+    {
+        "code": "MEL-18-GR",
+        "name": "Melamina 18mm Gris Perla",
+        "description": "Melamina gris perla liso para mobiliario moderno",
+        "length": 2440,
+        "width": 1220,
+        "thickness": 18,
+        "grain_direction": None,
+        "price": 54.00,
+    },
+    {
+        "code": "MEL-18-AN",
+        "name": "Melamina 18mm Antracita",
+        "description": "Melamina antracita oscuro acabado suave",
+        "length": 2440,
+        "width": 1220,
+        "thickness": 18,
+        "grain_direction": None,
+        "price": 55.00,
+    },
+    {
+        "code": "MEL-18-BG",
+        "name": "Melamina 18mm Beige Arena",
+        "description": "Melamina beige arena, tono cálido neutro",
+        "length": 2440,
+        "width": 1220,
+        "thickness": 18,
+        "grain_direction": None,
+        "price": 52.00,
+    },
+    {
+        "code": "MEL-18-AZ",
+        "name": "Melamina 18mm Azul Océano",
+        "description": "Melamina azul océano para acentos y frentes",
+        "length": 2440,
+        "width": 1220,
+        "thickness": 18,
+        "grain_direction": None,
+        "price": 56.00,
+    },
+    {
+        "code": "MEL-18-VD",
+        "name": "Melamina 18mm Verde Salvia",
+        "description": "Melamina verde salvia tendencia nórdica",
+        "length": 2440,
+        "width": 1220,
+        "thickness": 18,
+        "grain_direction": None,
+        "price": 56.00,
+    },
+    {
+        "code": "MEL-15-BL",
+        "name": "Melamina 15mm Blanco Polar",
+        "description": "Melamina blanco polar 15mm para laterales y fondos",
+        "length": 2440,
+        "width": 1220,
+        "thickness": 15,
+        "grain_direction": None,
+        "price": 44.00,
+    },
+    {
+        "code": "MEL-25-BL",
+        "name": "Melamina 25mm Blanco Polar",
+        "description": "Melamina blanco polar 25mm para mesones y repisas",
+        "length": 2440,
+        "width": 1220,
+        "thickness": 25,
+        "grain_direction": None,
+        "price": 68.00,
+    },
+    {
+        "code": "MEL-25-NG",
+        "name": "Melamina 25mm Negro Azabache",
+        "description": "Melamina negro azabache 25mm para tops y mesones",
+        "length": 2440,
+        "width": 1220,
+        "thickness": 25,
+        "grain_direction": None,
+        "price": 70.00,
+    },
+    # Maderados
+    {
+        "code": "MEL-18-RB",
+        "name": "Melamina 18mm Roble Natural",
+        "description": "Melamina maderada roble natural veta horizontal",
+        "length": 2440,
+        "width": 1220,
+        "thickness": 18,
+        "grain_direction": "H",
+        "price": 58.00,
+    },
+    {
+        "code": "MEL-18-WN",
+        "name": "Melamina 18mm Nogal Oscuro",
+        "description": "Melamina maderada nogal oscuro veta fina",
+        "length": 2440,
+        "width": 1220,
+        "thickness": 18,
+        "grain_direction": "H",
+        "price": 60.00,
+    },
+    {
+        "code": "MEL-18-TC",
+        "name": "Melamina 18mm Teca Dorada",
+        "description": "Melamina maderada teca dorada acabado cálido",
+        "length": 2440,
+        "width": 1220,
+        "thickness": 18,
+        "grain_direction": "H",
+        "price": 62.00,
+    },
+    {
+        "code": "MEL-18-WG",
+        "name": "Melamina 18mm Wengué",
+        "description": "Melamina maderada wengué veta pronunciada oscura",
+        "length": 2440,
+        "width": 1220,
+        "thickness": 18,
+        "grain_direction": "H",
+        "price": 62.00,
+    },
+    {
+        "code": "MEL-18-HP",
+        "name": "Melamina 18mm Haya Perla",
+        "description": "Melamina maderada haya perla tono claro suave",
+        "length": 2440,
+        "width": 1220,
+        "thickness": 18,
+        "grain_direction": "H",
+        "price": 58.00,
+    },
+    {
+        "code": "MEL-18-PN",
+        "name": "Melamina 18mm Pino Nórdico",
+        "description": "Melamina maderada pino nórdico veta clara natural",
+        "length": 2440,
+        "width": 1220,
+        "thickness": 18,
+        "grain_direction": "V",
+        "price": 56.00,
+    },
+    {
+        "code": "MEL-18-CE",
+        "name": "Melamina 18mm Cerezo",
+        "description": "Melamina maderada cerezo tono rojizo cálido",
+        "length": 2440,
+        "width": 1220,
+        "thickness": 18,
+        "grain_direction": "H",
+        "price": 60.00,
+    },
+    {
+        "code": "MEL-18-AC",
+        "name": "Melamina 18mm Acacia",
+        "description": "Melamina maderada acacia veta irregular moderna",
+        "length": 2440,
+        "width": 1220,
+        "thickness": 18,
+        "grain_direction": "H",
+        "price": 61.00,
+    },
+    {
+        "code": "MEL-25-RB",
+        "name": "Melamina 25mm Roble Natural",
+        "description": "Melamina maderada roble natural 25mm para mesones",
+        "length": 2440,
+        "width": 1220,
+        "thickness": 25,
+        "grain_direction": "H",
+        "price": 74.00,
+    },
+    {
+        "code": "MEL-25-WN",
+        "name": "Melamina 25mm Nogal Oscuro",
+        "description": "Melamina maderada nogal oscuro 25mm para tops",
+        "length": 2440,
+        "width": 1220,
+        "thickness": 25,
+        "grain_direction": "H",
+        "price": 76.00,
+    },
+]
+
+
+def main():
+    db = SessionLocal()
+    try:
+        deleted = db.query(BoardModel).delete()
+        print(f"Eliminados {deleted} tableros existentes.")
+
+        boards = [BoardModel(**data) for data in BOARDS]
+        db.add_all(boards)
+        db.commit()
+        print(f"Insertados {len(boards)} tableros nuevos.")
+    except Exception as e:
+        db.rollback()
+        print(f"Error: {e}")
+        raise
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/modules/optimizations/proforma.py
+++ b/src/modules/optimizations/proforma.py
@@ -121,7 +121,7 @@ class ProformaService:
                         f"{req.get('width', 0)} mm",
                         f"{req.get('height', 0)} mm",
                         str(req.get("quantity", 1)),
-                        req.get("board_id", "N/A"),
+                        req.get("board_code", "N/A"),
                         (req.get("label") or "-")[:20],
                     ]
                 )

--- a/src/modules/optimizations/schemas.py
+++ b/src/modules/optimizations/schemas.py
@@ -11,7 +11,7 @@ class Requirement(CamelModel):
     height: PositiveInt
     width: PositiveInt
     quantity: PositiveInt = Field(default=1, le=10000)
-    board_id: str
+    board_id: int
     label: Optional[str] = None
     allow_rotation: bool = True
 

--- a/src/modules/optimizations/service.py
+++ b/src/modules/optimizations/service.py
@@ -51,11 +51,13 @@ class OptimizationService:
         )
 
         solutions = []
+        board_codes: Dict[int, str] = {}
         for board_id, board_requirements in requirements_by_board.items():
-            board = self.board_service.get_by_code(board_id)
+            board = self.board_service.get(board_id)
             if board is None:
                 raise EntityNotFoundError("Board", board_id)
 
+            board_codes[board_id] = board.code
             solutions.append(
                 self._optimize(
                     pieces=board_requirements,
@@ -64,12 +66,12 @@ class OptimizationService:
                 )
             )
 
-        return self._save_optimization(request, solutions)
+        return self._save_optimization(request, solutions, board_codes)
 
     def _group_requirements_by_board(
         self, requirements: List[Requirement]
-    ) -> Dict[str, List[Requirement]]:
-        """Agrupa los requerimientos por código de tablero."""
+    ) -> Dict[int, List[Requirement]]:
+        """Agrupa los requerimientos por ID de tablero."""
         requirements_by_board = defaultdict(list)
         for req in requirements:
             requirements_by_board[req.board_id].append(req)
@@ -100,7 +102,7 @@ class OptimizationService:
             try:
                 piece_objects.append(
                     Piece(
-                        id=p.board_id or f"piece_{i+1}",
+                        id=p.label or f"piece_{i+1}",
                         width=p.width,
                         height=p.height,
                         quantity=p.quantity,
@@ -124,6 +126,7 @@ class OptimizationService:
         self,
         request: OptimizeRequest,
         solutions: List[Tuple[List[CuttingLayout], List[Piece]]],
+        board_codes: Dict[int, str],
     ) -> OptimizationModel:
         """Guarda los resultados de la optimización en la base de datos."""
         total_boards_used = sum(len(layouts) for layouts, _ in solutions)
@@ -131,7 +134,10 @@ class OptimizationService:
         optimization = OptimizationModel(
             total_boards_used=total_boards_used,
             total_boards_cost=0,
-            requirements=[r.model_dump() for r in request.requirements],
+            requirements=[
+                {**r.model_dump(), "board_code": board_codes.get(r.board_id, "N/A")}
+                for r in request.requirements
+            ],
             solution=[
                 layout.to_dict() for layouts, _ in solutions for layout in layouts
             ],

--- a/tests/test_optimizations.py
+++ b/tests/test_optimizations.py
@@ -28,7 +28,7 @@ def _create_board(client, code="MEL18"):
     ).json()
 
 
-def _optimize_payload(client_id, board_code="MEL18"):
+def _optimize_payload(client_id, board_id):
     return {
         "clientId": client_id,
         "requirements": [
@@ -37,7 +37,7 @@ def _optimize_payload(client_id, board_code="MEL18"):
                 "width": 600,
                 "height": 400,
                 "quantity": 2,
-                "boardId": board_code,
+                "boardId": board_id,
                 "label": "Puerta",
                 "allowRotation": True,
             }
@@ -47,10 +47,11 @@ def _optimize_payload(client_id, board_code="MEL18"):
 
 def test_optimize_returns_solution(client):
     created_client = _create_client(client)
-    _create_board(client)
+    created_board = _create_board(client)
 
     resp = client.post(
-        "/api/v1/optimize/", json=_optimize_payload(created_client["id"])
+        "/api/v1/optimize/",
+        json=_optimize_payload(created_client["id"], created_board["id"]),
     )
     assert resp.status_code == 200
     data = resp.json()
@@ -64,17 +65,18 @@ def test_optimize_unknown_board_returns_404(client):
     created_client = _create_client(client)
     resp = client.post(
         "/api/v1/optimize/",
-        json=_optimize_payload(created_client["id"], board_code="NOPE"),
+        json=_optimize_payload(created_client["id"], board_id=99999),
     )
     assert resp.status_code == 404
-    assert "Board NOPE" in resp.json()["detail"]
+    assert "Board 99999" in resp.json()["detail"]
 
 
 def test_proforma_pdf_and_base64(client):
     created_client = _create_client(client)
-    _create_board(client)
+    created_board = _create_board(client)
     optimization = client.post(
-        "/api/v1/optimize/", json=_optimize_payload(created_client["id"])
+        "/api/v1/optimize/",
+        json=_optimize_payload(created_client["id"], created_board["id"]),
     ).json()
     opt_id = optimization["id"]
 


### PR DESCRIPTION
  Replace board_id field type from str to int in the Requirement schema so
  the API receives the board's primary key directly. Update the service to
  look up boards by id via CRUDService.get() instead of get_by_code().
  Enrich saved requirements with board_code so the proforma PDF still
  displays the human-readable code. Fix piece id assignment to use the
  label field instead of board_id. Update n8n agent system prompt and
  buscar_catalogo tool description to send the integer id as boardId.