### PR TITLE
fix: calculate total boards cost in optimization

### DIFF
--- a/src/cutting/models.py
+++ b/src/cutting/models.py
@@ -151,6 +151,7 @@ class CuttingLayout:
                 "height": self.material.height,
                 "thickness": self.material.thickness,
                 "area": self.material.area,
+                "cost_per_unit": self.material.cost_per_unit,
             },
             "placed_pieces": [p.to_dict() for p in self.placed_pieces],
             "statistics": {

--- a/src/modules/optimizations/service.py
+++ b/src/modules/optimizations/service.py
@@ -130,10 +130,15 @@ class OptimizationService:
     ) -> OptimizationModel:
         """Guarda los resultados de la optimización en la base de datos."""
         total_boards_used = sum(len(layouts) for layouts, _ in solutions)
+        total_boards_cost = sum(
+            layout.material.cost_per_unit
+            for layouts, _ in solutions
+            for layout in layouts
+        )
 
         optimization = OptimizationModel(
             total_boards_used=total_boards_used,
-            total_boards_cost=0,
+            total_boards_cost=total_boards_cost,
             requirements=[
                 {**r.model_dump(), "board_code": board_codes.get(r.board_id, "N/A")}
                 for r in request.requirements

--- a/tests/test_optimizations.py
+++ b/tests/test_optimizations.py
@@ -61,6 +61,22 @@ def test_optimize_returns_solution(client):
     assert "placedPieces" in data["solution"][0]
 
 
+def test_optimize_computes_total_boards_cost(client):
+    """El costo total debe ser nº de tableros usados * precio del tablero."""
+    created_client = _create_client(client)
+    created_board = _create_board(client)
+
+    resp = client.post(
+        "/api/v1/optimize/",
+        json=_optimize_payload(created_client["id"], created_board["id"]),
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["totalBoardsUsed"] >= 1
+    assert data["totalBoardsCost"] == pytest.approx(data["totalBoardsUsed"] * 45.5)
+    assert data["totalBoardsCost"] > 0
+
+
 def test_optimize_unknown_board_returns_404(client):
     created_client = _create_client(client)
     resp = client.post(


### PR DESCRIPTION
  total_boards_cost was hardcoded to 0 when saving an optimization, so the
  proforma always showed /opt/homebrew/bin/zsh.00. Now it sums each layout's cost_per_unit
  (board price per used sheet). Also expose cost_per_unit in the layout
  serialization and add a test covering the computed cost.