### PR TITLE
feat: pre-compute grouped materials summary in optimization service

### DIFF
--- a/alembic/versions/a1b2c3d4e5f6_add_materials_summary_to_optimizations.py
+++ b/alembic/versions/a1b2c3d4e5f6_add_materials_summary_to_optimizations.py
@@ -1,0 +1,28 @@
+"""add materials_summary to optimizations
+
+Revision ID: a1b2c3d4e5f6
+Revises: 034fa987138e
+Create Date: 2026-06-01 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, None] = "034fa987138e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "optimizations",
+        sa.Column("materials_summary", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("optimizations", "materials_summary")

--- a/src/modules/optimizations/model.py
+++ b/src/modules/optimizations/model.py
@@ -16,6 +16,7 @@ class OptimizationModel(Base):
     total_boards_cost: Mapped[float] = mapped_column(Float)
     requirements: Mapped[dict] = mapped_column(JSON)
     solution: Mapped[dict] = mapped_column(JSON)
+    materials_summary: Mapped[dict] = mapped_column(JSON, nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     client_id: Mapped[int] = mapped_column(ForeignKey("clients.id"))

--- a/src/modules/optimizations/proforma.py
+++ b/src/modules/optimizations/proforma.py
@@ -166,55 +166,50 @@ class ProformaService:
         story.append(Paragraph("RESUMEN DE MATERIALES", heading_style))
 
         solutions = optimization.solution
-        materials_summary = {}
-
-        if isinstance(solutions, list):
-            for sol in solutions:
-                material = sol.get("material", {})
-                mat_id = material.get("id", "N/A")
-
-                if mat_id not in materials_summary:
-                    materials_summary[mat_id] = {
-                        "id": mat_id,
-                        "width": material.get("width", 0),
-                        "height": material.get("height", 0),
-                        "thickness": material.get("thickness", 0),
-                        "count": 0,
-                        "area": material.get("area", 0),
-                        "efficiency": [],
-                    }
-
-                materials_summary[mat_id]["count"] += 1
-                stats = sol.get("statistics", {})
-                materials_summary[mat_id]["efficiency"].append(
-                    stats.get("efficiency", 0)
-                )
+        materials_summary = optimization.materials_summary
 
         mat_data = [
-            ["Tablero", "Dimensiones", "Cantidad", "Área Total", "Eficiencia Prom."]
+            [
+                "Código",
+                "Nombre",
+                "Dimensiones",
+                "Cant.",
+                "Área Total",
+                "Efic. Prom.",
+                "P. Unit.",
+                "Subtotal",
+            ]
         ]
 
-        for mat_id, mat_info in materials_summary.items():
-            avg_efficiency = (
-                sum(mat_info["efficiency"]) / len(mat_info["efficiency"])
-                if mat_info["efficiency"]
-                else 0
-            )
-            total_area = mat_info["area"] * mat_info["count"] / 1_000_000
-
-            mat_data.append(
-                [
-                    str(mat_id),
-                    f"{mat_info['width']:.0f} x {mat_info['height']:.0f} mm",
-                    str(mat_info["count"]),
-                    f"{total_area:.2f} m²",
-                    f"{avg_efficiency:.1f}%",
-                ]
-            )
+        if isinstance(materials_summary, list) and materials_summary:
+            for entry in materials_summary:
+                mat_data.append(
+                    [
+                        entry.get("board_code", "N/A"),
+                        entry.get("board_name", "N/A")[:22],
+                        f"{entry.get('width', 0):.0f}×{entry.get('height', 0):.0f} mm",
+                        str(entry.get("count", 0)),
+                        f"{entry.get('total_area_m2', 0):.2f} m²",
+                        f"{entry.get('avg_efficiency', 0):.1f}%",
+                        f"${entry.get('cost_per_unit', 0):.2f}",
+                        f"${entry.get('total_cost', 0):.2f}",
+                    ]
+                )
+        else:
+            mat_data.append(["Sin datos de materiales", "", "", "", "", "", "", ""])
 
         mat_table = Table(
             mat_data,
-            colWidths=[1.2 * inch, 1.5 * inch, 1 * inch, 1.2 * inch, 1.1 * inch],
+            colWidths=[
+                0.8 * inch,
+                1.4 * inch,
+                1.2 * inch,
+                0.5 * inch,
+                0.8 * inch,
+                0.7 * inch,
+                0.7 * inch,
+                0.8 * inch,
+            ],
         )
         mat_table.setStyle(
             TableStyle(
@@ -223,11 +218,11 @@ class ProformaService:
                     ("TEXTCOLOR", (0, 0), (-1, 0), colors.whitesmoke),
                     ("ALIGN", (0, 0), (-1, -1), "CENTER"),
                     ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
-                    ("FONTSIZE", (0, 0), (-1, 0), 10),
+                    ("FONTSIZE", (0, 0), (-1, 0), 9),
                     ("FONTNAME", (0, 1), (-1, -1), "Helvetica"),
-                    ("FONTSIZE", (0, 1), (-1, -1), 9),
-                    ("BOTTOMPADDING", (0, 0), (-1, -1), 8),
-                    ("TOPPADDING", (0, 0), (-1, -1), 8),
+                    ("FONTSIZE", (0, 1), (-1, -1), 8),
+                    ("BOTTOMPADDING", (0, 0), (-1, -1), 6),
+                    ("TOPPADDING", (0, 0), (-1, -1), 6),
                     ("GRID", (0, 0), (-1, -1), 0.5, colors.grey),
                     (
                         "ROWBACKGROUNDS",

--- a/src/modules/optimizations/schemas.py
+++ b/src/modules/optimizations/schemas.py
@@ -6,6 +6,20 @@ from src.modules.clients.schemas import ClientResponse
 from src.shared.schemas import CamelModel
 
 
+class MaterialSummary(CamelModel):
+    board_id: int
+    board_code: str
+    board_name: str
+    width: float
+    height: float
+    thickness: float
+    count: int
+    total_area_m2: float
+    avg_efficiency: float
+    cost_per_unit: float
+    total_cost: float
+
+
 class Requirement(CamelModel):
     index: NonNegativeInt
     height: PositiveInt
@@ -63,3 +77,6 @@ class OptimizeResponse(CamelModel):
     total_boards_used: int = Field(..., description="Total number of boards used")
     total_boards_cost: float = Field(..., description="Total cost of boards used")
     solution: List[Solution] = Field(..., description="Optimization solution details")
+    materials_summary: Optional[List[MaterialSummary]] = Field(
+        default=None, description="Aggregated materials grouped by board type"
+    )

--- a/src/modules/optimizations/service.py
+++ b/src/modules/optimizations/service.py
@@ -52,12 +52,14 @@ class OptimizationService:
 
         solutions = []
         board_codes: Dict[int, str] = {}
+        board_names: Dict[int, str] = {}
         for board_id, board_requirements in requirements_by_board.items():
             board = self.board_service.get(board_id)
             if board is None:
                 raise EntityNotFoundError("Board", board_id)
 
             board_codes[board_id] = board.code
+            board_names[board_id] = board.name
             solutions.append(
                 self._optimize(
                     pieces=board_requirements,
@@ -66,7 +68,7 @@ class OptimizationService:
                 )
             )
 
-        return self._save_optimization(request, solutions, board_codes)
+        return self._save_optimization(request, solutions, board_codes, board_names)
 
     def _group_requirements_by_board(
         self, requirements: List[Requirement]
@@ -122,11 +124,53 @@ class OptimizationService:
         )
         return optimizer.optimize(piece_objects)
 
+    def _build_materials_summary(
+        self,
+        solutions: List[Tuple[List[CuttingLayout], List[Piece]]],
+        board_codes: Dict[int, str],
+        board_names: Dict[int, str],
+    ) -> List[dict]:
+        """Agrega los layouts por tipo de tablero con métricas y costos."""
+        summary: Dict[int, dict] = {}
+        for layouts, _ in solutions:
+            for layout in layouts:
+                # MultiSheetGuillotineOptimizer genera IDs con formato "{board_id}_{sheet_n}"
+                bid = int(str(layout.material.id).split("_")[0])
+                if bid not in summary:
+                    summary[bid] = {
+                        "board_id": bid,
+                        "board_code": board_codes.get(bid, "N/A"),
+                        "board_name": board_names.get(bid, "N/A"),
+                        "width": layout.material.width,
+                        "height": layout.material.height,
+                        "thickness": layout.material.thickness,
+                        "count": 0,
+                        "total_area_m2": 0.0,
+                        "_efficiencies": [],
+                        "cost_per_unit": layout.material.cost_per_unit,
+                        "total_cost": 0.0,
+                    }
+                entry = summary[bid]
+                entry["count"] += 1
+                entry["total_area_m2"] += round(layout.material.area / 1_000_000, 4)
+                entry["_efficiencies"].append(layout.efficiency * 100)
+                entry["total_cost"] += layout.material.cost_per_unit
+
+        result = []
+        for entry in summary.values():
+            effs = entry.pop("_efficiencies")
+            entry["avg_efficiency"] = round(sum(effs) / len(effs), 2) if effs else 0.0
+            entry["total_area_m2"] = round(entry["total_area_m2"], 4)
+            entry["total_cost"] = round(entry["total_cost"], 2)
+            result.append(entry)
+        return result
+
     def _save_optimization(
         self,
         request: OptimizeRequest,
         solutions: List[Tuple[List[CuttingLayout], List[Piece]]],
         board_codes: Dict[int, str],
+        board_names: Dict[int, str],
     ) -> OptimizationModel:
         """Guarda los resultados de la optimización en la base de datos."""
         total_boards_used = sum(len(layouts) for layouts, _ in solutions)
@@ -146,6 +190,9 @@ class OptimizationService:
             solution=[
                 layout.to_dict() for layouts, _ in solutions for layout in layouts
             ],
+            materials_summary=self._build_materials_summary(
+                solutions, board_codes, board_names
+            ),
             client_id=request.client_id,
         )
         self.db.add(optimization)

--- a/tests/test_optimizations.py
+++ b/tests/test_optimizations.py
@@ -123,3 +123,25 @@ def test_service_rejects_empty_requirements(db_session):
 def test_service_get_or_404(db_session):
     with pytest.raises(EntityNotFoundError):
         OptimizationService(db_session).get_or_404(123456)
+
+
+def test_optimize_includes_materials_summary(client):
+    """materials_summary agrupa por tipo de tablero con código, cantidad y costo."""
+    created_client = _create_client(client)
+    created_board = _create_board(client, code="MEL18")
+
+    resp = client.post(
+        "/api/v1/optimize/",
+        json=_optimize_payload(created_client["id"], created_board["id"]),
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+
+    summary = data.get("materialsSummary")
+    assert summary is not None and len(summary) == 1
+
+    entry = summary[0]
+    assert entry["boardCode"] == "MEL18"
+    assert entry["boardName"] == "Melamina MEL18"
+    assert entry["count"] == data["totalBoardsUsed"]
+    assert entry["totalCost"] == pytest.approx(data["totalBoardsCost"])


### PR DESCRIPTION
  Store a pre-aggregated materials_summary on OptimizationModel so the
  proforma can render board groups (code, name, count, cost) without doing
  any cost-domain calculations itself. Fixes the proforma listing each
  physical board as a separate row instead of grouping by board type.