### PR TITLE
feat: standardize optimization I/O naming and dimension convention

### DIFF
--- a/alembic/versions/c3d4e5f6a7b8_rename_solution_to_layouts.py
+++ b/alembic/versions/c3d4e5f6a7b8_rename_solution_to_layouts.py
@@ -1,0 +1,23 @@
+"""rename solution to layouts in optimizations
+
+Revision ID: c3d4e5f6a7b8
+Revises: a1b2c3d4e5f6
+Create Date: 2026-06-01 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "c3d4e5f6a7b8"
+down_revision: Union[str, None] = "a1b2c3d4e5f6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column("optimizations", "solution", new_column_name="layouts")
+
+
+def downgrade() -> None:
+    op.alter_column("optimizations", "layouts", new_column_name="solution")

--- a/alembic/versions/d4e5f6a7b8c9_rename_board_length_to_height.py
+++ b/alembic/versions/d4e5f6a7b8c9_rename_board_length_to_height.py
@@ -1,0 +1,23 @@
+"""rename board length to height
+
+Revision ID: d4e5f6a7b8c9
+Revises: c3d4e5f6a7b8
+Create Date: 2026-06-01 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "d4e5f6a7b8c9"
+down_revision: Union[str, None] = "c3d4e5f6a7b8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column("boards", "length", new_column_name="height")
+
+
+def downgrade() -> None:
+    op.alter_column("boards", "height", new_column_name="length")

--- a/src/cutting/models.py
+++ b/src/cutting/models.py
@@ -124,6 +124,7 @@ class CuttingLayout:
     material: Material
     placed_pieces: List[PlacedPiece] = field(default_factory=list)
     remainders: List[Rectangle] = field(default_factory=list)
+    sheet_number: int = 1
 
     @property
     def used_area(self) -> float:
@@ -146,7 +147,8 @@ class CuttingLayout:
         """Convierte a diccionario para serialización"""
         return {
             "material": {
-                "id": self.material.id,
+                "board_id": self.material.id,
+                "sheet_number": self.sheet_number,
                 "width": self.material.width,
                 "height": self.material.height,
                 "thickness": self.material.thickness,

--- a/src/cutting/optimizer.py
+++ b/src/cutting/optimizer.py
@@ -413,7 +413,7 @@ class MultiSheetGuillotineOptimizer:
             sheet_count += 1
 
             material = Material(
-                id=f"{self.material_template.id}_{sheet_count}",
+                id=self.material_template.id,
                 width=self.material_template.width,
                 height=self.material_template.height,
                 thickness=self.material_template.thickness,
@@ -438,6 +438,7 @@ class MultiSheetGuillotineOptimizer:
                     material=material,
                     placed_pieces=placed,
                     remainders=optimizer.remainders,
+                    sheet_number=sheet_count,
                 )
                 self.layouts.append(layout)
                 remaining_pieces = unplaced

--- a/src/modules/boards/model.py
+++ b/src/modules/boards/model.py
@@ -15,7 +15,7 @@ class BoardModel(Base):
     code: Mapped[str] = mapped_column(String(32), unique=True)
     name: Mapped[str] = mapped_column(String(128), unique=True)
     description: Mapped[Optional[str]] = mapped_column(String(256))
-    length: Mapped[int] = mapped_column(Integer)
+    height: Mapped[int] = mapped_column(Integer)
     width: Mapped[int] = mapped_column(Integer)
     thickness: Mapped[int] = mapped_column(Integer)
     grain_direction: Mapped[Optional[str]] = mapped_column(String(4))

--- a/src/modules/boards/schemas.py
+++ b/src/modules/boards/schemas.py
@@ -11,8 +11,12 @@ class BoardBase(CamelModel):
     description: Optional[str] = Field(
         None, max_length=256, description="Board description"
     )
-    length: PositiveInt = Field(..., description="Board length in mm")
-    width: PositiveInt = Field(..., description="Board width in mm")
+    height: PositiveInt = Field(
+        ..., description="Board height (largo, primera medida) in mm"
+    )
+    width: PositiveInt = Field(
+        ..., description="Board width (ancho, segunda medida) in mm"
+    )
     thickness: PositiveInt = Field(..., description="Board thickness in mm")
     grain_direction: Optional[str] = Field(
         None, description="Grain direction of the board"
@@ -36,8 +40,12 @@ class BoardUpdate(CamelModel):
     description: Optional[str] = Field(
         None, max_length=256, description="Board description"
     )
-    length: Optional[PositiveInt] = Field(None, description="Board length in mm")
-    width: Optional[PositiveInt] = Field(None, description="Board width in mm")
+    height: Optional[PositiveInt] = Field(
+        None, description="Board height (largo, primera medida) in mm"
+    )
+    width: Optional[PositiveInt] = Field(
+        None, description="Board width (ancho, segunda medida) in mm"
+    )
     thickness: Optional[PositiveInt] = Field(None, description="Board thickness in mm")
     grain_direction: Optional[str] = Field(
         None, description="Grain direction of the board"

--- a/src/modules/optimizations/model.py
+++ b/src/modules/optimizations/model.py
@@ -15,7 +15,7 @@ class OptimizationModel(Base):
     total_boards_used: Mapped[int] = mapped_column(Integer)
     total_boards_cost: Mapped[float] = mapped_column(Float)
     requirements: Mapped[dict] = mapped_column(JSON)
-    solution: Mapped[dict] = mapped_column(JSON)
+    layouts: Mapped[dict] = mapped_column(JSON)
     materials_summary: Mapped[dict] = mapped_column(JSON, nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)

--- a/src/modules/optimizations/proforma.py
+++ b/src/modules/optimizations/proforma.py
@@ -112,14 +112,14 @@ class ProformaService:
 
         requirements = optimization.requirements
         if isinstance(requirements, list):
-            req_data = [["#", "Ancho", "Alto", "Cantidad", "Tablero", "Etiqueta"]]
+            req_data = [["#", "Alto", "Ancho", "Cantidad", "Tablero", "Etiqueta"]]
 
             for idx, req in enumerate(requirements, 1):
                 req_data.append(
                     [
                         str(idx),
-                        f"{req.get('width', 0)} mm",
                         f"{req.get('height', 0)} mm",
+                        f"{req.get('width', 0)} mm",
                         str(req.get("quantity", 1)),
                         req.get("board_code", "N/A"),
                         (req.get("label") or "-")[:20],
@@ -165,7 +165,7 @@ class ProformaService:
 
         story.append(Paragraph("RESUMEN DE MATERIALES", heading_style))
 
-        solutions = optimization.solution
+        layouts = optimization.layouts
         materials_summary = optimization.materials_summary
 
         mat_data = [
@@ -187,7 +187,7 @@ class ProformaService:
                     [
                         entry.get("board_code", "N/A"),
                         entry.get("board_name", "N/A")[:22],
-                        f"{entry.get('width', 0):.0f}×{entry.get('height', 0):.0f} mm",
+                        f"{entry.get('height', 0):.0f}×{entry.get('width', 0):.0f} mm",
                         str(entry.get("count", 0)),
                         f"{entry.get('total_area_m2', 0):.2f} m²",
                         f"{entry.get('avg_efficiency', 0):.1f}%",
@@ -262,9 +262,9 @@ class ProformaService:
         story.append(Paragraph("DISPOSICIÓN DE CORTES", heading_style))
         story.append(Spacer(1, 0.1 * inch))
 
-        if isinstance(solutions, list) and len(solutions) > 0:
+        if isinstance(layouts, list) and len(layouts) > 0:
             img_buffer = VisualizationService.generate_cutting_layout_image(
-                solutions, width=2400, height=1600
+                layouts, width=2400, height=1600
             )
             img = Image(img_buffer, width=6.5 * inch, height=4.3 * inch)
             story.append(img)

--- a/src/modules/optimizations/schemas.py
+++ b/src/modules/optimizations/schemas.py
@@ -10,8 +10,8 @@ class MaterialSummary(CamelModel):
     board_id: int
     board_code: str
     board_name: str
-    width: float
     height: float
+    width: float
     thickness: float
     count: int
     total_area_m2: float
@@ -21,13 +21,25 @@ class MaterialSummary(CamelModel):
 
 
 class Requirement(CamelModel):
-    index: NonNegativeInt
-    height: PositiveInt
-    width: PositiveInt
+    priority: NonNegativeInt = Field(
+        ..., description="Cutting priority; higher values are placed first"
+    )
+    height: PositiveInt = Field(
+        ..., description="Piece height (alto, primera medida) in mm"
+    )
+    width: PositiveInt = Field(
+        ..., description="Piece width (ancho, segunda medida) in mm"
+    )
     quantity: PositiveInt = Field(default=1, le=10000)
-    board_id: int
-    label: Optional[str] = None
-    allow_rotation: bool = True
+    board_id: int = Field(..., description="Target board ID for this piece")
+    label: Optional[str] = Field(default=None, description="Human-friendly piece label")
+    can_rotate: bool = Field(
+        default=True,
+        description=(
+            "If true, the optimizer may swap height↔width (rotate 90°) to improve "
+            "yield. Set false for pieces with a fixed orientation (grain/pattern)."
+        ),
+    )
 
 
 class OptimizeRequest(CamelModel):
@@ -38,9 +50,12 @@ class OptimizeRequest(CamelModel):
 
 
 class Material(CamelModel):
-    id: int = Field(..., description="Unique identifier for the material")
-    width: float = Field(..., description="Width of the material")
-    height: float = Field(..., description="Height of the material")
+    board_id: int = Field(..., description="Board ID this sheet was cut from")
+    sheet_number: int = Field(
+        ..., description="Sheet number within the board (1-based)"
+    )
+    height: float = Field(..., description="Height of the material (alto)")
+    width: float = Field(..., description="Width of the material (ancho)")
     thickness: float = Field(..., description="Thickness of the material")
     area: float = Field(..., description="Area of the material")
 
@@ -49,25 +64,45 @@ class PlacedPiece(CamelModel):
     piece_id: str = Field(..., description="Unique identifier for the placed piece")
     x: float = Field(..., description="X position of the placed piece")
     y: float = Field(..., description="Y position of the placed piece")
-    width: float = Field(..., description="Width of the placed piece")
-    height: float = Field(..., description="Height of the placed piece")
+    height: float = Field(
+        ..., description="Height of the placed piece (alto, after rotation)"
+    )
+    width: float = Field(
+        ..., description="Width of the placed piece (ancho, after rotation)"
+    )
     rotated: bool = Field(..., description="Indicates if the piece is rotated")
+    original_height: float = Field(
+        ..., description="Piece height (alto) before rotation"
+    )
+    original_width: float = Field(
+        ..., description="Piece width (ancho) before rotation"
+    )
 
 
 class Remainder(CamelModel):
     x: float = Field(..., description="X position of the remainder")
     y: float = Field(..., description="Y position of the remainder")
-    width: float = Field(..., description="Width of the remainder")
-    height: float = Field(..., description="Height of the remainder")
+    height: float = Field(..., description="Height of the remainder (alto)")
+    width: float = Field(..., description="Width of the remainder (ancho)")
 
 
-class Solution(CamelModel):
-    material: Material = Field(..., description="Material used in the solution")
+class LayoutStatistics(CamelModel):
+    used_area: float = Field(..., description="Total area occupied by placed pieces")
+    waste_area: float = Field(..., description="Unused area of the sheet")
+    efficiency: float = Field(..., description="Material usage efficiency (percentage)")
+    pieces_count: int = Field(..., description="Number of pieces placed on the sheet")
+
+
+class Layout(CamelModel):
+    material: Material = Field(..., description="Material/sheet used in this layout")
     placed_pieces: List[PlacedPiece] = Field(
-        ..., description="List of placed pieces in the solution"
+        ..., description="Pieces placed on this sheet"
+    )
+    statistics: LayoutStatistics = Field(
+        ..., description="Usage metrics for this sheet"
     )
     remainders: List[Remainder] = Field(
-        ..., description="List of remainders in the solution"
+        ..., description="Leftover rectangles on this sheet"
     )
 
 
@@ -76,7 +111,9 @@ class OptimizeResponse(CamelModel):
     client: ClientResponse = Field(..., description="Client information")
     total_boards_used: int = Field(..., description="Total number of boards used")
     total_boards_cost: float = Field(..., description="Total cost of boards used")
-    solution: List[Solution] = Field(..., description="Optimization solution details")
+    layouts: List[Layout] = Field(
+        ..., description="Per-sheet cutting layouts of the optimization"
+    )
     materials_summary: Optional[List[MaterialSummary]] = Field(
         default=None, description="Aggregated materials grouped by board type"
     )

--- a/src/modules/optimizations/service.py
+++ b/src/modules/optimizations/service.py
@@ -50,7 +50,7 @@ class OptimizationService:
             right_trim=config.RIGHT_TRIM,
         )
 
-        solutions = []
+        board_results = []
         board_codes: Dict[int, str] = {}
         board_names: Dict[int, str] = {}
         for board_id, board_requirements in requirements_by_board.items():
@@ -60,7 +60,7 @@ class OptimizationService:
 
             board_codes[board_id] = board.code
             board_names[board_id] = board.name
-            solutions.append(
+            board_results.append(
                 self._optimize(
                     pieces=board_requirements,
                     board=board,
@@ -68,7 +68,7 @@ class OptimizationService:
                 )
             )
 
-        return self._save_optimization(request, solutions, board_codes, board_names)
+        return self._save_optimization(request, board_results, board_codes, board_names)
 
     def _group_requirements_by_board(
         self, requirements: List[Requirement]
@@ -94,7 +94,7 @@ class OptimizationService:
         material = Material(
             id=board.id,
             width=board.width,
-            height=board.length,
+            height=board.height,
             thickness=board.thickness,
             cost_per_unit=board.price,
         )
@@ -108,8 +108,8 @@ class OptimizationService:
                         width=p.width,
                         height=p.height,
                         quantity=p.quantity,
-                        can_rotate=p.allow_rotation,
-                        priority=p.index,
+                        can_rotate=p.can_rotate,
+                        priority=p.priority,
                     )
                 )
             except ValueError as e:
@@ -126,16 +126,15 @@ class OptimizationService:
 
     def _build_materials_summary(
         self,
-        solutions: List[Tuple[List[CuttingLayout], List[Piece]]],
+        board_results: List[Tuple[List[CuttingLayout], List[Piece]]],
         board_codes: Dict[int, str],
         board_names: Dict[int, str],
     ) -> List[dict]:
         """Agrega los layouts por tipo de tablero con métricas y costos."""
         summary: Dict[int, dict] = {}
-        for layouts, _ in solutions:
+        for layouts, _ in board_results:
             for layout in layouts:
-                # MultiSheetGuillotineOptimizer genera IDs con formato "{board_id}_{sheet_n}"
-                bid = int(str(layout.material.id).split("_")[0])
+                bid = layout.material.id
                 if bid not in summary:
                     summary[bid] = {
                         "board_id": bid,
@@ -168,15 +167,15 @@ class OptimizationService:
     def _save_optimization(
         self,
         request: OptimizeRequest,
-        solutions: List[Tuple[List[CuttingLayout], List[Piece]]],
+        board_results: List[Tuple[List[CuttingLayout], List[Piece]]],
         board_codes: Dict[int, str],
         board_names: Dict[int, str],
     ) -> OptimizationModel:
         """Guarda los resultados de la optimización en la base de datos."""
-        total_boards_used = sum(len(layouts) for layouts, _ in solutions)
+        total_boards_used = sum(len(layouts) for layouts, _ in board_results)
         total_boards_cost = sum(
             layout.material.cost_per_unit
-            for layouts, _ in solutions
+            for layouts, _ in board_results
             for layout in layouts
         )
 
@@ -187,11 +186,11 @@ class OptimizationService:
                 {**r.model_dump(), "board_code": board_codes.get(r.board_id, "N/A")}
                 for r in request.requirements
             ],
-            solution=[
-                layout.to_dict() for layouts, _ in solutions for layout in layouts
+            layouts=[
+                layout.to_dict() for layouts, _ in board_results for layout in layouts
             ],
             materials_summary=self._build_materials_summary(
-                solutions, board_codes, board_names
+                board_results, board_codes, board_names
             ),
             client_id=request.client_id,
         )

--- a/src/modules/optimizations/visualization.py
+++ b/src/modules/optimizations/visualization.py
@@ -7,13 +7,13 @@ from PIL import Image, ImageDraw, ImageFont
 class VisualizationService:
     @staticmethod
     def generate_cutting_layout_image(
-        solutions: List[dict], width: int = 2400, height: int = 1600
+        layouts: List[dict], width: int = 2400, height: int = 1600
     ) -> io.BytesIO:
         boards_per_row = 2
         board_margin = 60
         info_height = 100
 
-        num_boards = len(solutions)
+        num_boards = len(layouts)
         num_rows = (num_boards + boards_per_row - 1) // boards_per_row
 
         total_height = (
@@ -41,11 +41,11 @@ class VisualizationService:
 
         y_offset = info_height
 
-        for idx, solution in enumerate(solutions):
+        for idx, layout in enumerate(layouts):
             row = idx // boards_per_row
             col = idx % boards_per_row
 
-            material = solution.get("material", {})
+            material = layout.get("material", {})
             board_width = material.get("width", 1220)
             board_height = material.get("height", 2440)
 
@@ -82,7 +82,7 @@ class VisualizationService:
                 (board_x + 10, board_y - 25), board_label, fill="black", font=label_font
             )
 
-            efficiency = solution.get("statistics", {}).get("efficiency", 0)
+            efficiency = layout.get("statistics", {}).get("efficiency", 0)
             efficiency_text = f"Eficiencia: {efficiency:.1f}%"
             draw.text(
                 (board_x + 200, board_y - 25),
@@ -91,7 +91,7 @@ class VisualizationService:
                 font=small_font,
             )
 
-            placed_pieces = solution.get("placed_pieces", [])
+            placed_pieces = layout.get("placed_pieces", [])
             for piece in placed_pieces:
                 px = board_x + int(piece["x"] * scale)
                 py = board_y + int(piece["y"] * scale)
@@ -105,7 +105,7 @@ class VisualizationService:
                     width=2,
                 )
 
-                piece_label = f"{int(piece['width'])}x{int(piece['height'])}"
+                piece_label = f"{int(piece['height'])}x{int(piece['width'])}"
                 text_bbox = draw.textbbox((0, 0), piece_label, font=small_font)
                 text_width = text_bbox[2] - text_bbox[0]
                 text_height = text_bbox[3] - text_bbox[1]
@@ -117,7 +117,7 @@ class VisualizationService:
                         (text_x, text_y), piece_label, fill="black", font=small_font
                     )
 
-            remainders = solution.get("remainders", [])
+            remainders = layout.get("remainders", [])
             for remainder in remainders:
                 rx = board_x + int(remainder["x"] * scale)
                 ry = board_y + int(remainder["y"] * scale)

--- a/tests/test_boards.py
+++ b/tests/test_boards.py
@@ -6,7 +6,7 @@ def _payload(code="MEL18", name="Melamina 18mm"):
         "code": code,
         "name": name,
         "description": "Tablero estándar",
-        "length": 2440,
+        "height": 2440,
         "width": 1220,
         "thickness": 18,
         "grainDirection": "v",

--- a/tests/test_cutting.py
+++ b/tests/test_cutting.py
@@ -72,6 +72,7 @@ def test_guillotine_places_pieces_and_reports_efficiency():
         material=material,
         placed_pieces=placed,
         remainders=optimizer.remainders,
+        sheet_number=1,
     )
     assert layout.used_area == 600 * 400
     assert layout.waste_area == material.area - layout.used_area
@@ -79,7 +80,8 @@ def test_guillotine_places_pieces_and_reports_efficiency():
 
     as_dict = layout.to_dict()
     assert as_dict["statistics"]["pieces_count"] == 1
-    assert as_dict["material"]["id"] == "m1"
+    assert as_dict["material"]["board_id"] == "m1"
+    assert as_dict["material"]["sheet_number"] == 1
 
 
 def test_guillotine_empty_pieces_returns_empty():
@@ -117,8 +119,11 @@ def test_multisheet_uses_several_sheets_when_needed():
     assert len(layouts) >= 2
     assert remaining == []
     assert all(isinstance(layout, CuttingLayout) for layout in layouts)
-    # El id del material incluye el número de hoja.
-    assert layouts[0].material.id == "board_1"
+    # El material conserva el board_id original; el número de hoja vive en el layout.
+    assert layouts[0].material.id == "board"
+    assert [layout.sheet_number for layout in layouts] == list(
+        range(1, len(layouts) + 1)
+    )
 
 
 def test_multisheet_empty_returns_empty():

--- a/tests/test_optimizations.py
+++ b/tests/test_optimizations.py
@@ -20,7 +20,7 @@ def _create_board(client, code="MEL18"):
         json={
             "code": code,
             "name": f"Melamina {code}",
-            "length": 2440,
+            "height": 2440,
             "width": 1220,
             "thickness": 18,
             "price": 45.5,
@@ -33,19 +33,19 @@ def _optimize_payload(client_id, board_id):
         "clientId": client_id,
         "requirements": [
             {
-                "index": 0,
-                "width": 600,
+                "priority": 0,
                 "height": 400,
+                "width": 600,
                 "quantity": 2,
                 "boardId": board_id,
                 "label": "Puerta",
-                "allowRotation": True,
+                "canRotate": True,
             }
         ],
     }
 
 
-def test_optimize_returns_solution(client):
+def test_optimize_returns_layouts(client):
     created_client = _create_client(client)
     created_board = _create_board(client)
 
@@ -57,8 +57,13 @@ def test_optimize_returns_solution(client):
     data = resp.json()
     assert data["client"]["id"] == created_client["id"]
     assert data["totalBoardsUsed"] >= 1
-    assert len(data["solution"]) >= 1
-    assert "placedPieces" in data["solution"][0]
+    assert len(data["layouts"]) >= 1
+    layout = data["layouts"][0]
+    assert "placedPieces" in layout
+    assert layout["material"]["boardId"] == created_board["id"]
+    assert layout["material"]["sheetNumber"] == 1
+    assert "efficiency" in layout["statistics"]
+    assert layout["placedPieces"][0]["originalWidth"] == 600
 
 
 def test_optimize_computes_total_boards_cost(client):


### PR DESCRIPTION
    - Rename optimization  column/field to  (singular→plural, reflects content)
    - Replace compound material id with explicit  +  fields
    - Expose  block (efficiency, used/waste area, pieces count) in API response
    - Rename  →  to match industry convention (first measure = alto)
    - Reorder all dimension fields to height-first (alto, primera medida) across schemas
    - Rename  →  and  →  in Requirement input
    - Fix proforma and visualization displays to show Alto×Ancho order
    - Add two Alembic migrations for the column renames