### PR TITLE
feat: redesign proforma PDF and cutting diagram

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,10 @@ DATABASE_URL=sqlite:///./cutter_local.db
 # DATABASE_URL=postgresql://user:password@localhost:5432/cutter_db
 # Para MySQL (ejemplo):
 # DATABASE_URL=mysql://user:password@localhost:3306/cutter_db
+
+# Datos de la empresa (aparecen en la proforma PDF)
+COMPANY_NAME=EMPRESA MADERABLE S.A.
+COMPANY_RUC=1234567890001
+COMPANY_ADDRESS=Av. Principal 123
+COMPANY_PHONE=(02) 234-5678
+COMPANY_EMAIL=info@maderable.com

--- a/src/modules/optimizations/proforma.py
+++ b/src/modules/optimizations/proforma.py
@@ -1,12 +1,14 @@
 import io
 from datetime import datetime
+from typing import List
 
 from reportlab.lib import colors
-from reportlab.lib.enums import TA_CENTER
+from reportlab.lib.enums import TA_LEFT, TA_RIGHT
 from reportlab.lib.pagesizes import A4
 from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
 from reportlab.lib.units import inch
 from reportlab.platypus import (
+    HRFlowable,
     Image,
     Paragraph,
     SimpleDocTemplate,
@@ -17,6 +19,36 @@ from reportlab.platypus import (
 
 from src.modules.optimizations.model import OptimizationModel
 from src.modules.optimizations.visualization import VisualizationService
+from src.shared.config import config
+
+# Paleta de marca de la proforma.
+BRAND_BLUE = colors.HexColor("#1976D2")
+DARK_BLUE = colors.HexColor("#0D47A1")
+LIGHT_BLUE = colors.HexColor("#E3F2FD")
+ZEBRA_GREY = colors.HexColor("#F5F5F5")
+TEXT_GREY = colors.HexColor("#424242")
+
+PAGE_WIDTH, _ = A4
+LEFT_MARGIN = RIGHT_MARGIN = 0.5 * inch
+CONTENT_WIDTH = PAGE_WIDTH - LEFT_MARGIN - RIGHT_MARGIN
+
+
+def _draw_page_footer(canvas, doc) -> None:
+    """Dibuja el pie con la marca de generación y el número de página."""
+    canvas.saveState()
+    canvas.setFont("Helvetica", 8)
+    canvas.setFillColor(colors.grey)
+    canvas.drawString(
+        LEFT_MARGIN,
+        0.35 * inch,
+        f"Generado el {datetime.now().strftime('%d/%m/%Y %H:%M')}",
+    )
+    canvas.drawRightString(
+        PAGE_WIDTH - RIGHT_MARGIN,
+        0.35 * inch,
+        f"Página {canvas.getPageNumber()}",
+    )
+    canvas.restoreState()
 
 
 class ProformaService:
@@ -24,96 +56,186 @@ class ProformaService:
     def generate_proforma_pdf(optimization: OptimizationModel) -> io.BytesIO:
         buffer = io.BytesIO()
         doc = SimpleDocTemplate(
-            buffer, pagesize=A4, topMargin=0.5 * inch, bottomMargin=0.5 * inch
+            buffer,
+            pagesize=A4,
+            topMargin=0.5 * inch,
+            bottomMargin=0.6 * inch,
+            leftMargin=LEFT_MARGIN,
+            rightMargin=RIGHT_MARGIN,
+        )
+
+        styles = getSampleStyleSheet()
+        heading_style = ParagraphStyle(
+            "SectionHeading",
+            parent=styles["Heading2"],
+            fontSize=13,
+            textColor=DARK_BLUE,
+            spaceAfter=2,
+            spaceBefore=4,
+            fontName="Helvetica-Bold",
+        )
+        cell_style = ParagraphStyle(
+            "Cell",
+            parent=styles["Normal"],
+            fontSize=9,
+            leading=11,
+            textColor=TEXT_GREY,
+            alignment=TA_LEFT,
         )
 
         story = []
-        styles = getSampleStyleSheet()
+        story.extend(ProformaService._build_header(optimization, styles))
+        story.append(Spacer(1, 0.25 * inch))
 
-        title_style = ParagraphStyle(
-            "CustomTitle",
-            parent=styles["Heading1"],
-            fontSize=24,
-            textColor=colors.HexColor("#1976D2"),
-            spaceAfter=30,
-            alignment=TA_CENTER,
-            fontName="Helvetica-Bold",
+        story.extend(_section("INFORMACIÓN DEL CLIENTE", heading_style))
+        story.append(ProformaService._build_client_table(optimization))
+        story.append(Spacer(1, 0.25 * inch))
+
+        story.extend(_section("DETALLE DE REQUERIMIENTOS", heading_style))
+        story.append(
+            ProformaService._build_requirements_table(optimization, cell_style)
         )
+        story.append(Spacer(1, 0.25 * inch))
 
-        heading_style = ParagraphStyle(
-            "CustomHeading",
-            parent=styles["Heading2"],
-            fontSize=14,
-            textColor=colors.HexColor("#424242"),
-            spaceAfter=12,
-            spaceBefore=12,
-            fontName="Helvetica-Bold",
-        )
+        story.extend(_section("RESUMEN DE MATERIALES", heading_style))
+        story.append(ProformaService._build_materials_table(optimization, cell_style))
+        story.append(Spacer(1, 0.2 * inch))
+        story.append(ProformaService._build_totals_table(optimization))
 
-        normal_style = styles["Normal"]
-        normal_style.fontSize = 10
-
-        story.append(Paragraph("PROFORMA DE OPTIMIZACIÓN DE CORTES", title_style))
         story.append(Spacer(1, 0.3 * inch))
+        story.extend(_section("DISPOSICIÓN DE CORTES", heading_style))
+        story.append(Spacer(1, 0.08 * inch))
+        layout_image = ProformaService._build_layout_image(optimization)
+        if layout_image is not None:
+            story.append(layout_image)
 
-        company_data = [
-            ["EMPRESA MADERABLE S.A.", ""],
-            ["RUC: 1234567890001", f'Fecha: {datetime.now().strftime("%d/%m/%Y")}'],
-            ["Dirección: Av. Principal 123", f"Proforma N°: {optimization.id:06d}"],
-            ["Teléfono: (02) 234-5678", ""],
-            ["Email: info@maderable.com", ""],
+        story.append(Spacer(1, 0.3 * inch))
+        story.append(
+            Paragraph(
+                "Esta proforma es válida por 15 días. Los precios no incluyen IVA.",
+                ParagraphStyle(
+                    "Note",
+                    parent=styles["Normal"],
+                    fontSize=8,
+                    textColor=colors.grey,
+                    alignment=TA_LEFT,
+                ),
+            )
+        )
+
+        doc.build(story, onFirstPage=_draw_page_footer, onLaterPages=_draw_page_footer)
+        buffer.seek(0)
+        return buffer
+
+    @staticmethod
+    def _build_header(optimization: OptimizationModel, styles) -> List:
+        """Encabezado tipo factura: datos de empresa + bloque PROFORMA."""
+        name_style = ParagraphStyle(
+            "CompanyName",
+            parent=styles["Normal"],
+            fontSize=18,
+            leading=22,
+            textColor=colors.white,
+            fontName="Helvetica-Bold",
+        )
+        detail_style = ParagraphStyle(
+            "CompanyDetail",
+            parent=styles["Normal"],
+            fontSize=9,
+            leading=13,
+            textColor=colors.white,
+        )
+        proforma_title_style = ParagraphStyle(
+            "ProformaTitle",
+            parent=styles["Normal"],
+            fontSize=16,
+            leading=20,
+            textColor=colors.white,
+            fontName="Helvetica-Bold",
+            alignment=TA_RIGHT,
+        )
+        proforma_detail_style = ParagraphStyle(
+            "ProformaDetail",
+            parent=styles["Normal"],
+            fontSize=10,
+            leading=15,
+            textColor=colors.white,
+            alignment=TA_RIGHT,
+        )
+
+        left_cell = [
+            Paragraph(config.COMPANY_NAME, name_style),
+            Spacer(1, 4),
+            Paragraph(
+                f"RUC: {config.COMPANY_RUC}<br/>"
+                f"{config.COMPANY_ADDRESS}<br/>"
+                f"Tel: {config.COMPANY_PHONE}<br/>"
+                f"{config.COMPANY_EMAIL}",
+                detail_style,
+            ),
+        ]
+        right_cell = [
+            Paragraph("PROFORMA", proforma_title_style),
+            Paragraph(
+                f"N° {optimization.id:06d}<br/>"
+                f"Fecha: {datetime.now().strftime('%d/%m/%Y')}",
+                proforma_detail_style,
+            ),
         ]
 
-        company_table = Table(company_data, colWidths=[3.5 * inch, 2.5 * inch])
-        company_table.setStyle(
+        header_table = Table(
+            [[left_cell, right_cell]],
+            colWidths=[CONTENT_WIDTH * 0.6, CONTENT_WIDTH * 0.4],
+        )
+        header_table.setStyle(
             TableStyle(
                 [
-                    ("FONTNAME", (0, 0), (-1, -1), "Helvetica"),
-                    ("FONTSIZE", (0, 0), (-1, -1), 9),
-                    ("TEXTCOLOR", (0, 0), (-1, -1), colors.HexColor("#424242")),
-                    ("ALIGN", (0, 0), (0, -1), "LEFT"),
-                    ("ALIGN", (1, 0), (1, -1), "RIGHT"),
-                    ("BOTTOMPADDING", (0, 0), (-1, -1), 6),
+                    ("BACKGROUND", (0, 0), (-1, -1), BRAND_BLUE),
+                    ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                    ("LEFTPADDING", (0, 0), (-1, -1), 16),
+                    ("RIGHTPADDING", (0, 0), (-1, -1), 16),
+                    ("TOPPADDING", (0, 0), (-1, -1), 14),
+                    ("BOTTOMPADDING", (0, 0), (-1, -1), 14),
                 ]
             )
         )
-        story.append(company_table)
-        story.append(Spacer(1, 0.3 * inch))
+        return [header_table]
 
-        story.append(Paragraph("INFORMACIÓN DEL CLIENTE", heading_style))
+    @staticmethod
+    def _build_client_table(optimization: OptimizationModel) -> Table:
         client = optimization.client
         client_name = (
             f"{client.first_name or ''} {client.last_name or ''}".strip() or "N/A"
         )
-
         client_data = [
             ["Nombre:", client_name],
             ["Identificador:", client.identifier or "N/A"],
             ["ID Cliente:", str(client.id)],
         ]
-
-        client_table = Table(client_data, colWidths=[1.5 * inch, 4.5 * inch])
+        client_table = Table(
+            client_data, colWidths=[1.5 * inch, CONTENT_WIDTH - 1.5 * inch]
+        )
         client_table.setStyle(
             TableStyle(
                 [
                     ("FONTNAME", (0, 0), (0, -1), "Helvetica-Bold"),
                     ("FONTNAME", (1, 0), (1, -1), "Helvetica"),
                     ("FONTSIZE", (0, 0), (-1, -1), 10),
-                    ("TEXTCOLOR", (0, 0), (-1, -1), colors.HexColor("#424242")),
+                    ("TEXTCOLOR", (0, 0), (-1, -1), TEXT_GREY),
+                    ("BACKGROUND", (0, 0), (0, -1), ZEBRA_GREY),
+                    ("TOPPADDING", (0, 0), (-1, -1), 6),
                     ("BOTTOMPADDING", (0, 0), (-1, -1), 6),
-                    ("BACKGROUND", (0, 0), (0, -1), colors.HexColor("#F5F5F5")),
+                    ("LEFTPADDING", (0, 0), (-1, -1), 8),
                 ]
             )
         )
-        story.append(client_table)
-        story.append(Spacer(1, 0.3 * inch))
+        return client_table
 
-        story.append(Paragraph("DETALLE DE REQUERIMIENTOS", heading_style))
-
+    @staticmethod
+    def _build_requirements_table(optimization: OptimizationModel, cell_style) -> Table:
         requirements = optimization.requirements
+        req_data = [["#", "Alto", "Ancho", "Cantidad", "Tablero", "Etiqueta"]]
         if isinstance(requirements, list):
-            req_data = [["#", "Alto", "Ancho", "Cantidad", "Tablero", "Etiqueta"]]
-
             for idx, req in enumerate(requirements, 1):
                 req_data.append(
                     [
@@ -122,52 +244,28 @@ class ProformaService:
                         f"{req.get('width', 0)} mm",
                         str(req.get("quantity", 1)),
                         req.get("board_code", "N/A"),
-                        (req.get("label") or "-")[:20],
+                        Paragraph(req.get("label") or "-", cell_style),
                     ]
                 )
 
-            req_table = Table(
-                req_data,
-                colWidths=[
-                    0.4 * inch,
-                    0.9 * inch,
-                    0.9 * inch,
-                    0.9 * inch,
-                    1 * inch,
-                    1.9 * inch,
-                ],
-            )
-            req_table.setStyle(
-                TableStyle(
-                    [
-                        ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#1976D2")),
-                        ("TEXTCOLOR", (0, 0), (-1, 0), colors.whitesmoke),
-                        ("ALIGN", (0, 0), (-1, -1), "CENTER"),
-                        ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
-                        ("FONTSIZE", (0, 0), (-1, 0), 10),
-                        ("FONTNAME", (0, 1), (-1, -1), "Helvetica"),
-                        ("FONTSIZE", (0, 1), (-1, -1), 9),
-                        ("BOTTOMPADDING", (0, 0), (-1, -1), 8),
-                        ("TOPPADDING", (0, 0), (-1, -1), 8),
-                        ("GRID", (0, 0), (-1, -1), 0.5, colors.grey),
-                        (
-                            "ROWBACKGROUNDS",
-                            (0, 1),
-                            (-1, -1),
-                            [colors.white, colors.HexColor("#F5F5F5")],
-                        ),
-                    ]
-                )
-            )
-            story.append(req_table)
+        req_table = Table(
+            req_data,
+            colWidths=[
+                0.4 * inch,
+                0.9 * inch,
+                0.9 * inch,
+                0.95 * inch,
+                1.0 * inch,
+                CONTENT_WIDTH - 4.15 * inch,
+            ],
+            repeatRows=1,
+        )
+        req_table.setStyle(_data_table_style(header_size=10, body_size=9))
+        return req_table
 
-        story.append(Spacer(1, 0.3 * inch))
-
-        story.append(Paragraph("RESUMEN DE MATERIALES", heading_style))
-
-        layouts = optimization.layouts
+    @staticmethod
+    def _build_materials_table(optimization: OptimizationModel, cell_style) -> Table:
         materials_summary = optimization.materials_summary
-
         mat_data = [
             [
                 "Código",
@@ -180,13 +278,12 @@ class ProformaService:
                 "Subtotal",
             ]
         ]
-
         if isinstance(materials_summary, list) and materials_summary:
             for entry in materials_summary:
                 mat_data.append(
                     [
                         entry.get("board_code", "N/A"),
-                        entry.get("board_name", "N/A")[:22],
+                        Paragraph(entry.get("board_name", "N/A"), cell_style),
                         f"{entry.get('height', 0):.0f}×{entry.get('width', 0):.0f} mm",
                         str(entry.get("count", 0)),
                         f"{entry.get('total_area_m2', 0):.2f} m²",
@@ -201,91 +298,95 @@ class ProformaService:
         mat_table = Table(
             mat_data,
             colWidths=[
-                0.8 * inch,
-                1.4 * inch,
-                1.2 * inch,
+                0.75 * inch,
+                CONTENT_WIDTH - 5.65 * inch,
+                1.1 * inch,
                 0.5 * inch,
                 0.8 * inch,
                 0.7 * inch,
                 0.7 * inch,
                 0.8 * inch,
             ],
+            repeatRows=1,
         )
-        mat_table.setStyle(
-            TableStyle(
-                [
-                    ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#1976D2")),
-                    ("TEXTCOLOR", (0, 0), (-1, 0), colors.whitesmoke),
-                    ("ALIGN", (0, 0), (-1, -1), "CENTER"),
-                    ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
-                    ("FONTSIZE", (0, 0), (-1, 0), 9),
-                    ("FONTNAME", (0, 1), (-1, -1), "Helvetica"),
-                    ("FONTSIZE", (0, 1), (-1, -1), 8),
-                    ("BOTTOMPADDING", (0, 0), (-1, -1), 6),
-                    ("TOPPADDING", (0, 0), (-1, -1), 6),
-                    ("GRID", (0, 0), (-1, -1), 0.5, colors.grey),
-                    (
-                        "ROWBACKGROUNDS",
-                        (0, 1),
-                        (-1, -1),
-                        [colors.white, colors.HexColor("#F5F5F5")],
-                    ),
-                ]
-            )
-        )
-        story.append(mat_table)
+        mat_table.setStyle(_data_table_style(header_size=9, body_size=8))
+        return mat_table
 
-        story.append(Spacer(1, 0.2 * inch))
-
+    @staticmethod
+    def _build_totals_table(optimization: OptimizationModel) -> Table:
         summary_data = [
             ["Total de tableros utilizados:", str(optimization.total_boards_used)],
             ["Costo total estimado:", f"${optimization.total_boards_cost:.2f}"],
         ]
-
-        summary_table = Table(summary_data, colWidths=[3.5 * inch, 2.5 * inch])
+        summary_table = Table(
+            summary_data, colWidths=[CONTENT_WIDTH - 2.0 * inch, 2.0 * inch]
+        )
         summary_table.setStyle(
             TableStyle(
                 [
-                    ("FONTNAME", (0, 0), (0, -1), "Helvetica-Bold"),
-                    ("FONTNAME", (1, 0), (1, -1), "Helvetica-Bold"),
+                    ("BACKGROUND", (0, 0), (-1, -1), LIGHT_BLUE),
+                    ("BOX", (0, 0), (-1, -1), 1, BRAND_BLUE),
+                    ("LINEBELOW", (0, 0), (-1, 0), 0.5, colors.HexColor("#BBDEFB")),
+                    ("FONTNAME", (0, 0), (-1, -1), "Helvetica-Bold"),
                     ("FONTSIZE", (0, 0), (-1, -1), 11),
-                    ("TEXTCOLOR", (0, 0), (-1, -1), colors.HexColor("#1976D2")),
+                    ("TEXTCOLOR", (0, 0), (-1, -1), DARK_BLUE),
                     ("ALIGN", (0, 0), (0, -1), "LEFT"),
                     ("ALIGN", (1, 0), (1, -1), "RIGHT"),
-                    ("BOTTOMPADDING", (0, 0), (-1, -1), 6),
+                    ("TOPPADDING", (0, 0), (-1, -1), 8),
+                    ("BOTTOMPADDING", (0, 0), (-1, -1), 8),
+                    ("LEFTPADDING", (0, 0), (-1, -1), 12),
+                    ("RIGHTPADDING", (0, 0), (-1, -1), 12),
                 ]
             )
         )
-        story.append(summary_table)
+        return summary_table
 
-        story.append(Spacer(1, 0.3 * inch))
-        story.append(Paragraph("DISPOSICIÓN DE CORTES", heading_style))
-        story.append(Spacer(1, 0.1 * inch))
+    @staticmethod
+    def _build_layout_image(optimization: OptimizationModel):
+        layouts = optimization.layouts
+        if not (isinstance(layouts, list) and layouts):
+            return None
 
-        if isinstance(layouts, list) and len(layouts) > 0:
-            img_buffer = VisualizationService.generate_cutting_layout_image(
-                layouts, width=2400, height=1600
-            )
-            img = Image(img_buffer, width=6.5 * inch, height=4.3 * inch)
-            story.append(img)
-
-        story.append(Spacer(1, 0.5 * inch))
-
-        footer_text = (
-            "Esta proforma es válida por 15 días. Los precios no incluyen IVA."
+        img_buffer, (img_w, img_h) = VisualizationService.generate_cutting_layout_image(
+            layouts, width=2400, height=1600
         )
-        footer_para = Paragraph(
-            footer_text,
-            ParagraphStyle(
-                "Footer",
-                parent=styles["Normal"],
-                fontSize=8,
-                textColor=colors.grey,
-                alignment=TA_CENTER,
-            ),
-        )
-        story.append(footer_para)
+        draw_width = CONTENT_WIDTH
+        draw_height = draw_width * (img_h / img_w)
+        max_height = 8.5 * inch
+        if draw_height > max_height:
+            draw_height = max_height
+            draw_width = draw_height * (img_w / img_h)
 
-        doc.build(story)
-        buffer.seek(0)
-        return buffer
+        image = Image(img_buffer, width=draw_width, height=draw_height)
+        image.hAlign = "CENTER"
+        return image
+
+
+def _section(title: str, heading_style) -> List:
+    """Título de sección con regla de color debajo."""
+    return [
+        Paragraph(title, heading_style),
+        HRFlowable(
+            width="100%", thickness=1.2, color=BRAND_BLUE, spaceBefore=2, spaceAfter=8
+        ),
+    ]
+
+
+def _data_table_style(header_size: int, body_size: int) -> TableStyle:
+    """Estilo común para tablas de datos con cabecera azul y filas zebra."""
+    return TableStyle(
+        [
+            ("BACKGROUND", (0, 0), (-1, 0), BRAND_BLUE),
+            ("TEXTCOLOR", (0, 0), (-1, 0), colors.whitesmoke),
+            ("ALIGN", (0, 0), (-1, -1), "CENTER"),
+            ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+            ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+            ("FONTSIZE", (0, 0), (-1, 0), header_size),
+            ("FONTNAME", (0, 1), (-1, -1), "Helvetica"),
+            ("FONTSIZE", (0, 1), (-1, -1), body_size),
+            ("TOPPADDING", (0, 0), (-1, -1), 7),
+            ("BOTTOMPADDING", (0, 0), (-1, -1), 7),
+            ("GRID", (0, 0), (-1, -1), 0.5, colors.grey),
+            ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.white, ZEBRA_GREY]),
+        ]
+    )

--- a/src/modules/optimizations/visualization.py
+++ b/src/modules/optimizations/visualization.py
@@ -1,17 +1,85 @@
 import io
-from typing import List
+from typing import List, Optional, Tuple
 
 from PIL import Image, ImageDraw, ImageFont
+
+# Rutas de fuentes a probar en orden (macOS primero, luego Linux/Docker).
+_FONT_CANDIDATES = [
+    "/System/Library/Fonts/Supplemental/Arial.ttf",
+    "/System/Library/Fonts/Helvetica.ttc",
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+    "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
+    "/Library/Fonts/Arial.ttf",
+]
+
+# Paleta del diagrama (alineada con la marca de la proforma).
+COLOR_TITLE = "#1976D2"
+COLOR_BOARD_OUTLINE = "#37474F"
+COLOR_PIECE_FILL = "#E3F2FD"
+COLOR_PIECE_OUTLINE = "#1976D2"
+COLOR_DIM = "#0D47A1"
+COLOR_LABEL = "#212121"
+COLOR_EFFICIENCY = "#2E7D32"
+COLOR_WASTE_FILL = "#FFEBEE"
+COLOR_WASTE_OUTLINE = "#D32F2F"
+
+
+def _load_font(size: int) -> ImageFont.FreeTypeFont:
+    """Carga una fuente TrueType escalable; cae al bitmap por defecto si no hay."""
+    for path in _FONT_CANDIDATES:
+        try:
+            return ImageFont.truetype(path, size)
+        except OSError:
+            continue
+    return ImageFont.load_default()
+
+
+def _text_size(text: str, font: ImageFont.ImageFont) -> Tuple[int, int]:
+    """Mide el ancho y alto de un texto con la fuente dada."""
+    bbox = ImageDraw.Draw(Image.new("RGBA", (1, 1))).textbbox((0, 0), text, font=font)
+    return bbox[2] - bbox[0], bbox[3] - bbox[1]
+
+
+def _text_image(
+    text: str, font: ImageFont.ImageFont, fill: str, pad: int = 2
+) -> Image.Image:
+    """Renderiza el texto en una imagen RGBA transparente (para pegar/rotar)."""
+    bbox = ImageDraw.Draw(Image.new("RGBA", (1, 1))).textbbox((0, 0), text, font=font)
+    tw, th = bbox[2] - bbox[0], bbox[3] - bbox[1]
+    img = Image.new("RGBA", (tw + 2 * pad, th + 2 * pad), (0, 0, 0, 0))
+    ImageDraw.Draw(img).text((pad - bbox[0], pad - bbox[1]), text, font=font, fill=fill)
+    return img
+
+
+def _fit_label(
+    text: str, font: ImageFont.ImageFont, max_width: int, max_height: int
+) -> Optional[str]:
+    """Devuelve la etiqueta (truncada con … si hace falta) o None si no entra."""
+    tw, th = _text_size(text, font)
+    if th > max_height or max_width < 24:
+        return None
+    if tw <= max_width:
+        return text
+    truncated = text
+    while truncated and _text_size(truncated + "…", font)[0] > max_width:
+        truncated = truncated[:-1]
+    return (truncated + "…") if truncated else None
 
 
 class VisualizationService:
     @staticmethod
     def generate_cutting_layout_image(
         layouts: List[dict], width: int = 2400, height: int = 1600
-    ) -> io.BytesIO:
+    ) -> Tuple[io.BytesIO, Tuple[int, int]]:
+        """Dibuja los tableros con sus piezas.
+
+        El alto de cada pieza se acota sobre el borde izquierdo (texto vertical) y el
+        ancho sobre el borde inferior; la etiqueta de la pieza va centrada. Devuelve el
+        buffer PNG y sus dimensiones en px para incrustarlo respetando la proporción.
+        """
         boards_per_row = 2
         board_margin = 60
-        info_height = 100
+        info_height = 180
 
         num_boards = len(layouts)
         num_rows = (num_boards + boards_per_row - 1) // boards_per_row
@@ -23,21 +91,13 @@ class VisualizationService:
         img = Image.new("RGB", (width, total_height), color="white")
         draw = ImageDraw.Draw(img)
 
-        try:
-            title_font = ImageFont.truetype("/System/Library/Fonts/Helvetica.ttc", 36)
-            label_font = ImageFont.truetype("/System/Library/Fonts/Helvetica.ttc", 20)
-            small_font = ImageFont.truetype("/System/Library/Fonts/Helvetica.ttc", 14)
-        except OSError:
-            title_font = ImageFont.load_default()
-            label_font = ImageFont.load_default()
-            small_font = ImageFont.load_default()
+        title_font = _load_font(44)
+        header_font = _load_font(26)
+        dim_font = _load_font(26)
+        label_font = _load_font(28)
+        legend_font = _load_font(24)
 
-        draw.text(
-            (width // 2 - 200, 30),
-            "Optimización de Cortes",
-            fill="black",
-            font=title_font,
-        )
+        VisualizationService._draw_header(draw, width, title_font, legend_font)
 
         y_offset = info_height
 
@@ -73,66 +133,138 @@ class VisualizationService:
                     board_x + scaled_board_width,
                     board_y + scaled_board_height,
                 ],
-                outline="black",
-                width=2,
+                outline=COLOR_BOARD_OUTLINE,
+                width=3,
             )
 
-            board_label = f"Tablero {idx + 1}"
+            board_label = (
+                f"Tablero {idx + 1}  ·  {int(board_height)}×{int(board_width)} mm"
+            )
             draw.text(
-                (board_x + 10, board_y - 25), board_label, fill="black", font=label_font
+                (board_x, board_y - 36), board_label, fill="black", font=header_font
             )
-
+            label_w, _ = _text_size(board_label, header_font)
             efficiency = layout.get("statistics", {}).get("efficiency", 0)
-            efficiency_text = f"Eficiencia: {efficiency:.1f}%"
             draw.text(
-                (board_x + 200, board_y - 25),
-                efficiency_text,
-                fill="green",
-                font=small_font,
+                (board_x + label_w + 30, board_y - 36),
+                f"Eficiencia: {efficiency:.1f}%",
+                fill=COLOR_EFFICIENCY,
+                font=header_font,
             )
 
-            placed_pieces = layout.get("placed_pieces", [])
-            for piece in placed_pieces:
-                px = board_x + int(piece["x"] * scale)
-                py = board_y + int(piece["y"] * scale)
-                pw = int(piece["width"] * scale)
-                ph = int(piece["height"] * scale)
-
-                draw.rectangle(
-                    [px, py, px + pw, py + ph],
-                    fill="#E3F2FD",
-                    outline="#1976D2",
-                    width=2,
+            for piece in layout.get("placed_pieces", []):
+                VisualizationService._draw_piece(
+                    img,
+                    draw,
+                    board_x,
+                    board_y,
+                    scale,
+                    piece,
+                    dim_font,
+                    label_font,
                 )
 
-                piece_label = f"{int(piece['height'])}x{int(piece['width'])}"
-                text_bbox = draw.textbbox((0, 0), piece_label, font=small_font)
-                text_width = text_bbox[2] - text_bbox[0]
-                text_height = text_bbox[3] - text_bbox[1]
-
-                if pw > text_width + 10 and ph > text_height + 10:
-                    text_x = px + (pw - text_width) // 2
-                    text_y = py + (ph - text_height) // 2
-                    draw.text(
-                        (text_x, text_y), piece_label, fill="black", font=small_font
-                    )
-
-            remainders = layout.get("remainders", [])
-            for remainder in remainders:
+            for remainder in layout.get("remainders", []):
                 rx = board_x + int(remainder["x"] * scale)
                 ry = board_y + int(remainder["y"] * scale)
                 rw = int(remainder["width"] * scale)
                 rh = int(remainder["height"] * scale)
-
                 if rw > 5 and rh > 5:
                     draw.rectangle(
                         [rx, ry, rx + rw, ry + rh],
-                        fill="#FFEBEE",
-                        outline="#D32F2F",
+                        fill=COLOR_WASTE_FILL,
+                        outline=COLOR_WASTE_OUTLINE,
                         width=1,
                     )
 
         buffer = io.BytesIO()
         img.save(buffer, format="PNG")
         buffer.seek(0)
-        return buffer
+        return buffer, (width, total_height)
+
+    @staticmethod
+    def _draw_header(
+        draw: ImageDraw.ImageDraw,
+        width: int,
+        title_font: ImageFont.ImageFont,
+        legend_font: ImageFont.ImageFont,
+    ) -> None:
+        """Dibuja el título centrado y la leyenda de colores."""
+        title = "Optimización de Cortes"
+        title_w, _ = _text_size(title, title_font)
+        draw.text(
+            ((width - title_w) // 2, 24), title, fill=COLOR_TITLE, font=title_font
+        )
+
+        legend = [
+            (COLOR_PIECE_FILL, COLOR_PIECE_OUTLINE, "Pieza"),
+            (COLOR_WASTE_FILL, COLOR_WASTE_OUTLINE, "Retazo / Desperdicio"),
+        ]
+        x = 60
+        box = 26
+        y = 92
+        for fill, outline, text in legend:
+            draw.rectangle(
+                [x, y, x + box, y + box], fill=fill, outline=outline, width=2
+            )
+            draw.text((x + box + 10, y), text, fill="black", font=legend_font)
+            tw, _ = _text_size(text, legend_font)
+            x += box + 10 + tw + 50
+
+    @staticmethod
+    def _draw_piece(
+        img: Image.Image,
+        draw: ImageDraw.ImageDraw,
+        board_x: int,
+        board_y: int,
+        scale: float,
+        piece: dict,
+        dim_font: ImageFont.ImageFont,
+        label_font: ImageFont.ImageFont,
+    ) -> None:
+        """Dibuja una pieza con el alto acotado a la izquierda, el ancho abajo y la
+        etiqueta al centro."""
+        px = board_x + int(piece["x"] * scale)
+        py = board_y + int(piece["y"] * scale)
+        pw = int(piece["width"] * scale)
+        ph = int(piece["height"] * scale)
+
+        draw.rectangle(
+            [px, py, px + pw, py + ph],
+            fill=COLOR_PIECE_FILL,
+            outline=COLOR_PIECE_OUTLINE,
+            width=2,
+        )
+
+        pad = 4
+
+        # Ancho (segunda medida) sobre el borde inferior, texto horizontal.
+        ancho = _text_image(str(int(piece["width"])), dim_font, COLOR_DIM)
+        if ancho.width <= pw - 2 * pad and ancho.height <= ph - 2 * pad:
+            img.paste(
+                ancho,
+                (px + (pw - ancho.width) // 2, py + ph - ancho.height - pad),
+                ancho,
+            )
+
+        # Alto (primera medida) sobre el borde izquierdo, texto vertical.
+        alto = _text_image(str(int(piece["height"])), dim_font, COLOR_DIM).rotate(
+            90, expand=True
+        )
+        if alto.height <= ph - 2 * pad and alto.width <= pw - 2 * pad:
+            img.paste(alto, (px + pad, py + (ph - alto.height) // 2), alto)
+
+        # Etiqueta de la pieza al centro (omitir las auto-generadas piece_N).
+        piece_id = str(piece.get("piece_id", ""))
+        if piece_id and not piece_id.startswith("piece_"):
+            label = _fit_label(piece_id, label_font, pw - 2 * pad, ph - 2 * pad)
+            if label:
+                label_img = _text_image(label, label_font, COLOR_LABEL)
+                img.paste(
+                    label_img,
+                    (
+                        px + (pw - label_img.width) // 2,
+                        py + (ph - label_img.height) // 2,
+                    ),
+                    label_img,
+                )

--- a/src/shared/config.py
+++ b/src/shared/config.py
@@ -70,6 +70,13 @@ class Config:
 
     OPT_RESULT_TTL_SECONDS = env.int("OPT_RESULT_TTL_SECONDS", 259200)
 
+    # Datos de la empresa para la proforma PDF
+    COMPANY_NAME = env("COMPANY_NAME", "EMPRESA MADERABLE S.A.")
+    COMPANY_RUC = env("COMPANY_RUC", "1234567890001")
+    COMPANY_ADDRESS = env("COMPANY_ADDRESS", "Av. Principal 123")
+    COMPANY_PHONE = env("COMPANY_PHONE", "(02) 234-5678")
+    COMPANY_EMAIL = env("COMPANY_EMAIL", "info@maderable.com")
+
     def get_cors_origins(self) -> List[str]:
         """Lista de orígenes permitidos para CORS."""
         return self.CORS_ORIGINS


### PR DESCRIPTION
    Place piece dimensions on the edges (height on the left side, width on
    the bottom) instead of a centered HxW label, and use the freed center
    for the piece label. Add an invoice-style header with configurable
    company data, section rules, wrapping table cells, a totals box, a color
    legend, per-page footer, and aspect-correct diagram embedding.