### PR TITLE
feat: deduplicate identical cut patterns in proforma PDF

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,10 @@ ENV PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1
 
 # Toolchain de compilación solo en el builder (no llega a la imagen final).
+# fonts-dejavu-core: fuente TrueType para el diagrama de cortes (Pillow). El stage
+# dev hereda de builder, así que aquí queda disponible para desarrollo/tests.
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends build-essential && \
+    apt-get install -y --no-install-recommends build-essential fonts-dejavu-core && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -48,6 +50,14 @@ ENV PYTHONUNBUFFERED=1 \
     PATH="/opt/venv/bin:$PATH"
 
 WORKDIR /src
+
+# fonts-dejavu-core: fuente TrueType para el diagrama de cortes (Pillow). La imagen
+# slim no trae fuentes; sin esto Pillow cae a su bitmap por defecto y se rompen las
+# tildes y el símbolo ×.
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends fonts-dejavu-core && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Copia el virtualenv ya construido (solo deps de producción, sin toolchain).
 COPY --from=builder /opt/venv /opt/venv

--- a/alembic/versions/b2c3d4e5f6a7_add_layout_groups_to_optimizations.py
+++ b/alembic/versions/b2c3d4e5f6a7_add_layout_groups_to_optimizations.py
@@ -1,0 +1,28 @@
+"""add layout_groups to optimizations
+
+Revision ID: b2c3d4e5f6a7
+Revises: d4e5f6a7b8c9
+Create Date: 2026-06-02 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "b2c3d4e5f6a7"
+down_revision: Union[str, None] = "d4e5f6a7b8c9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "optimizations",
+        sa.Column("layout_groups", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("optimizations", "layout_groups")

--- a/src/modules/optimizations/model.py
+++ b/src/modules/optimizations/model.py
@@ -17,6 +17,7 @@ class OptimizationModel(Base):
     requirements: Mapped[dict] = mapped_column(JSON)
     layouts: Mapped[dict] = mapped_column(JSON)
     materials_summary: Mapped[dict] = mapped_column(JSON, nullable=True)
+    layout_groups: Mapped[dict] = mapped_column(JSON, nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     client_id: Mapped[int] = mapped_column(ForeignKey("clients.id"))

--- a/src/modules/optimizations/patterns.py
+++ b/src/modules/optimizations/patterns.py
@@ -1,0 +1,84 @@
+"""Agrupación de layouts por patrón de corte.
+
+Varias hojas pueden compartir exactamente la misma disposición de cortes (misma
+geometría y mismas etiquetas de pieza). Estas utilidades detectan esos patrones
+repetidos para deduplicar la representación visual y el resumen, sin alterar el
+conteo físico de tableros.
+"""
+
+import re
+from typing import List, Tuple
+
+# El optimizador expande las piezas con sufijo de instancia ``_{i+1}`` cuando
+# ``quantity > 1`` (ver ``src/cutting/optimizer.py``). Para comparar patrones nos
+# interesa la etiqueta base, no la instancia concreta.
+_INSTANCE_SUFFIX = re.compile(r"_\d+$")
+
+
+def base_label(piece_id: str) -> str:
+    """Devuelve la etiqueta base quitando un único sufijo de instancia ``_N``."""
+    return _INSTANCE_SUFFIX.sub("", piece_id or "")
+
+
+def layout_signature(layout: dict) -> Tuple:
+    """Firma canónica del patrón de corte de un layout.
+
+    Dos layouts con la misma firma comparten geometría y etiquetas base de pieza.
+    Ignora el número de hoja, los remanentes (derivados de las piezas) y el sufijo
+    de instancia del ``piece_id``.
+    """
+    board_id = layout.get("material", {}).get("board_id")
+    pieces = [
+        (
+            base_label(str(piece.get("piece_id", ""))),
+            piece.get("x"),
+            piece.get("y"),
+            piece.get("width"),
+            piece.get("height"),
+            bool(piece.get("rotated", False)),
+        )
+        for piece in layout.get("placed_pieces", [])
+    ]
+    pieces.sort(key=lambda p: (p[1], p[2], p[3], p[4], p[0]))
+    return (board_id, tuple(pieces))
+
+
+def group_layouts(layouts: List[dict]) -> List[dict]:
+    """Agrupa los layouts por patrón de corte preservando el orden de aparición.
+
+    Devuelve una lista de grupos; cada grupo conserva el layout representativo
+    (el primero del patrón) y cuántas hojas lo comparten::
+
+        {
+            "pattern_id": 1,
+            "count": 5,
+            "sheet_numbers": [1, 2, 3, 4, 5],
+            "board_id": 18,
+            "layout": { ...layout representativo... },
+        }
+    """
+    groups: List[dict] = []
+    index_by_signature: dict = {}
+
+    for layout in layouts:
+        signature = layout_signature(layout)
+        sheet_number = layout.get("material", {}).get("sheet_number")
+
+        if signature in index_by_signature:
+            group = groups[index_by_signature[signature]]
+            group["count"] += 1
+            group["sheet_numbers"].append(sheet_number)
+            continue
+
+        index_by_signature[signature] = len(groups)
+        groups.append(
+            {
+                "pattern_id": len(groups) + 1,
+                "count": 1,
+                "sheet_numbers": [sheet_number],
+                "board_id": layout.get("material", {}).get("board_id"),
+                "layout": layout,
+            }
+        )
+
+    return groups

--- a/src/modules/optimizations/proforma.py
+++ b/src/modules/optimizations/proforma.py
@@ -10,6 +10,7 @@ from reportlab.lib.units import inch
 from reportlab.platypus import (
     HRFlowable,
     Image,
+    PageBreak,
     Paragraph,
     SimpleDocTemplate,
     Spacer,
@@ -18,6 +19,7 @@ from reportlab.platypus import (
 )
 
 from src.modules.optimizations.model import OptimizationModel
+from src.modules.optimizations.patterns import group_layouts
 from src.modules.optimizations.visualization import VisualizationService
 from src.shared.config import config
 
@@ -102,12 +104,10 @@ class ProformaService:
         story.append(Spacer(1, 0.2 * inch))
         story.append(ProformaService._build_totals_table(optimization))
 
-        story.append(Spacer(1, 0.3 * inch))
+        story.append(PageBreak())
         story.extend(_section("DISPOSICIÓN DE CORTES", heading_style))
         story.append(Spacer(1, 0.08 * inch))
-        layout_image = ProformaService._build_layout_image(optimization)
-        if layout_image is not None:
-            story.append(layout_image)
+        story.extend(ProformaService._build_layout_pages(optimization))
 
         story.append(Spacer(1, 0.3 * inch))
         story.append(
@@ -342,24 +342,40 @@ class ProformaService:
         return summary_table
 
     @staticmethod
-    def _build_layout_image(optimization: OptimizationModel):
+    def _build_layout_pages(optimization: OptimizationModel) -> List:
+        """Una imagen por patrón, cada una a página completa ocupando el máximo."""
         layouts = optimization.layouts
         if not (isinstance(layouts, list) and layouts):
-            return None
+            return []
 
-        img_buffer, (img_w, img_h) = VisualizationService.generate_cutting_layout_image(
-            layouts, width=2400, height=1600
-        )
-        draw_width = CONTENT_WIDTH
-        draw_height = draw_width * (img_h / img_w)
-        max_height = 8.5 * inch
-        if draw_height > max_height:
-            draw_height = max_height
-            draw_width = draw_height * (img_w / img_h)
+        # Usa los grupos persistidos; recompútalos para optimizaciones antiguas que
+        # se guardaron antes de existir el campo ``layout_groups``.
+        groups = optimization.layout_groups
+        if not (isinstance(groups, list) and groups):
+            groups = group_layouts(layouts)
 
-        image = Image(img_buffer, width=draw_width, height=draw_height)
-        image.hAlign = "CENTER"
-        return image
+        flowables: List = []
+        # Cada imagen ocupa casi toda la página; el tope deja sitio al encabezado de
+        # sección en la primera (las demás van solas tras un salto de página).
+        max_height = 9.3 * inch
+        for idx, group in enumerate(groups):
+            if idx > 0:
+                flowables.append(PageBreak())
+
+            img_buffer, (img_w, img_h) = VisualizationService.generate_layout_image(
+                group
+            )
+            draw_width = CONTENT_WIDTH
+            draw_height = draw_width * (img_h / img_w)
+            if draw_height > max_height:
+                draw_height = max_height
+                draw_width = draw_height * (img_w / img_h)
+
+            image = Image(img_buffer, width=draw_width, height=draw_height)
+            image.hAlign = "CENTER"
+            flowables.append(image)
+
+        return flowables
 
 
 def _section(title: str, heading_style) -> List:

--- a/src/modules/optimizations/schemas.py
+++ b/src/modules/optimizations/schemas.py
@@ -106,6 +106,16 @@ class Layout(CamelModel):
     )
 
 
+class LayoutGroup(CamelModel):
+    pattern_id: int = Field(..., description="1-based index of the unique cut pattern")
+    count: int = Field(..., description="Number of sheets sharing this pattern")
+    sheet_numbers: List[int] = Field(
+        ..., description="Sheet numbers that use this pattern"
+    )
+    board_id: int = Field(..., description="Board ID the pattern is cut from")
+    layout: Layout = Field(..., description="Representative layout for this pattern")
+
+
 class OptimizeResponse(CamelModel):
     id: int
     client: ClientResponse = Field(..., description="Client information")
@@ -116,4 +126,7 @@ class OptimizeResponse(CamelModel):
     )
     materials_summary: Optional[List[MaterialSummary]] = Field(
         default=None, description="Aggregated materials grouped by board type"
+    )
+    layout_groups: Optional[List[LayoutGroup]] = Field(
+        default=None, description="Cutting layouts deduplicated by identical pattern"
     )

--- a/src/modules/optimizations/service.py
+++ b/src/modules/optimizations/service.py
@@ -15,6 +15,7 @@ from src.cutting import (
 from src.modules.boards.model import BoardModel
 from src.modules.boards.service import BoardService
 from src.modules.optimizations.model import OptimizationModel
+from src.modules.optimizations.patterns import group_layouts
 from src.modules.optimizations.schemas import OptimizeRequest, Requirement
 from src.shared.config import config
 from src.shared.database import get_db
@@ -179,6 +180,10 @@ class OptimizationService:
             for layout in layouts
         )
 
+        layout_dicts = [
+            layout.to_dict() for layouts, _ in board_results for layout in layouts
+        ]
+
         optimization = OptimizationModel(
             total_boards_used=total_boards_used,
             total_boards_cost=total_boards_cost,
@@ -186,12 +191,11 @@ class OptimizationService:
                 {**r.model_dump(), "board_code": board_codes.get(r.board_id, "N/A")}
                 for r in request.requirements
             ],
-            layouts=[
-                layout.to_dict() for layouts, _ in board_results for layout in layouts
-            ],
+            layouts=layout_dicts,
             materials_summary=self._build_materials_summary(
                 board_results, board_codes, board_names
             ),
+            layout_groups=group_layouts(layout_dicts),
             client_id=request.client_id,
         )
         self.db.add(optimization)

--- a/src/modules/optimizations/visualization.py
+++ b/src/modules/optimizations/visualization.py
@@ -1,7 +1,9 @@
 import io
-from typing import List, Optional, Tuple
+from typing import Optional, Tuple
 
 from PIL import Image, ImageDraw, ImageFont
+
+from src.modules.optimizations.patterns import base_label
 
 # Rutas de fuentes a probar en orden (macOS primero, luego Linux/Docker).
 _FONT_CANDIDATES = [
@@ -13,7 +15,6 @@ _FONT_CANDIDATES = [
 ]
 
 # Paleta del diagrama (alineada con la marca de la proforma).
-COLOR_TITLE = "#1976D2"
 COLOR_BOARD_OUTLINE = "#37474F"
 COLOR_PIECE_FILL = "#E3F2FD"
 COLOR_PIECE_OUTLINE = "#1976D2"
@@ -68,148 +69,121 @@ def _fit_label(
 
 class VisualizationService:
     @staticmethod
-    def generate_cutting_layout_image(
-        layouts: List[dict], width: int = 2400, height: int = 1600
+    def generate_layout_image(
+        group: dict, target_long: int = 2000
     ) -> Tuple[io.BytesIO, Tuple[int, int]]:
-        """Dibuja los tableros con sus piezas.
+        """Dibuja un único patrón de corte ocupando todo el lienzo.
 
-        El alto de cada pieza se acota sobre el borde izquierdo (texto vertical) y el
-        ancho sobre el borde inferior; la etiqueta de la pieza va centrada. Devuelve el
-        buffer PNG y sus dimensiones en px para incrustarlo respetando la proporción.
+        El lienzo adopta el aspecto del tablero para que, incrustado a página
+        completa, lo llene al máximo. El alto de cada pieza se acota sobre el borde
+        izquierdo (texto vertical) y el ancho sobre el borde inferior; la etiqueta va
+        centrada. Devuelve el buffer PNG y sus dimensiones en px para incrustarlo
+        respetando la proporción.
         """
-        boards_per_row = 2
-        board_margin = 60
-        info_height = 180
+        layout = group.get("layout", group)
+        count = group.get("count", 1)
+        material = layout.get("material", {})
+        board_width = material.get("width", 1220)
+        board_height = material.get("height", 2440)
 
-        num_boards = len(layouts)
-        num_rows = (num_boards + boards_per_row - 1) // boards_per_row
+        margin = 60
+        info_height = 150
 
-        total_height = (
-            info_height + num_rows * (height // num_rows + board_margin) + board_margin
-        )
+        scale = target_long / max(board_width, board_height)
+        scaled_board_width = int(board_width * scale)
+        scaled_board_height = int(board_height * scale)
 
-        img = Image.new("RGB", (width, total_height), color="white")
+        canvas_width = scaled_board_width + 2 * margin
+        canvas_height = info_height + scaled_board_height + 2 * margin
+
+        img = Image.new("RGB", (canvas_width, canvas_height), color="white")
         draw = ImageDraw.Draw(img)
 
-        title_font = _load_font(44)
-        header_font = _load_font(26)
+        header_font = _load_font(36)
         dim_font = _load_font(26)
-        label_font = _load_font(28)
-        legend_font = _load_font(24)
+        label_font = _load_font(30)
+        legend_font = _load_font(32)
 
-        VisualizationService._draw_header(draw, width, title_font, legend_font)
+        VisualizationService._draw_legend(draw, margin, 24, legend_font)
 
-        y_offset = info_height
+        board_x = margin
+        board_y = info_height
 
-        for idx, layout in enumerate(layouts):
-            row = idx // boards_per_row
-            col = idx % boards_per_row
+        badge = f"  ·  ×{count}" if count > 1 else ""
+        board_label = (
+            f"Tablero {group.get('pattern_id', 1)}{badge}  ·  "
+            f"{int(board_height)}×{int(board_width)} mm"
+        )
+        draw.text((board_x, board_y - 48), board_label, fill="black", font=header_font)
+        label_w, _ = _text_size(board_label, header_font)
+        efficiency = layout.get("statistics", {}).get("efficiency", 0)
+        draw.text(
+            (board_x + label_w + 30, board_y - 48),
+            f"Eficiencia: {efficiency:.1f}%",
+            fill=COLOR_EFFICIENCY,
+            font=header_font,
+        )
 
-            material = layout.get("material", {})
-            board_width = material.get("width", 1220)
-            board_height = material.get("height", 2440)
+        draw.rectangle(
+            [
+                board_x,
+                board_y,
+                board_x + scaled_board_width,
+                board_y + scaled_board_height,
+            ],
+            outline=COLOR_BOARD_OUTLINE,
+            width=3,
+        )
 
-            available_width = (
-                width - (boards_per_row + 1) * board_margin
-            ) // boards_per_row
-            available_height = (
-                total_height - info_height - (num_rows + 1) * board_margin
-            ) // num_rows
-
-            scale_x = available_width / board_width
-            scale_y = available_height / board_height
-            scale = min(scale_x, scale_y) * 0.9
-
-            scaled_board_width = int(board_width * scale)
-            scaled_board_height = int(board_height * scale)
-
-            board_x = board_margin + col * (available_width + board_margin)
-            board_y = y_offset + row * (available_height + board_margin)
-
-            draw.rectangle(
-                [
-                    board_x,
-                    board_y,
-                    board_x + scaled_board_width,
-                    board_y + scaled_board_height,
-                ],
-                outline=COLOR_BOARD_OUTLINE,
-                width=3,
+        for piece in layout.get("placed_pieces", []):
+            VisualizationService._draw_piece(
+                img, draw, board_x, board_y, scale, piece, dim_font, label_font
             )
 
-            board_label = (
-                f"Tablero {idx + 1}  ·  {int(board_height)}×{int(board_width)} mm"
-            )
-            draw.text(
-                (board_x, board_y - 36), board_label, fill="black", font=header_font
-            )
-            label_w, _ = _text_size(board_label, header_font)
-            efficiency = layout.get("statistics", {}).get("efficiency", 0)
-            draw.text(
-                (board_x + label_w + 30, board_y - 36),
-                f"Eficiencia: {efficiency:.1f}%",
-                fill=COLOR_EFFICIENCY,
-                font=header_font,
-            )
-
-            for piece in layout.get("placed_pieces", []):
-                VisualizationService._draw_piece(
-                    img,
-                    draw,
-                    board_x,
-                    board_y,
-                    scale,
-                    piece,
-                    dim_font,
-                    label_font,
+        for remainder in layout.get("remainders", []):
+            rx = board_x + int(remainder["x"] * scale)
+            ry = board_y + int(remainder["y"] * scale)
+            rw = int(remainder["width"] * scale)
+            rh = int(remainder["height"] * scale)
+            if rw > 5 and rh > 5:
+                draw.rectangle(
+                    [rx, ry, rx + rw, ry + rh],
+                    fill=COLOR_WASTE_FILL,
+                    outline=COLOR_WASTE_OUTLINE,
+                    width=1,
                 )
-
-            for remainder in layout.get("remainders", []):
-                rx = board_x + int(remainder["x"] * scale)
-                ry = board_y + int(remainder["y"] * scale)
-                rw = int(remainder["width"] * scale)
-                rh = int(remainder["height"] * scale)
-                if rw > 5 and rh > 5:
-                    draw.rectangle(
-                        [rx, ry, rx + rw, ry + rh],
-                        fill=COLOR_WASTE_FILL,
-                        outline=COLOR_WASTE_OUTLINE,
-                        width=1,
-                    )
 
         buffer = io.BytesIO()
         img.save(buffer, format="PNG")
         buffer.seek(0)
-        return buffer, (width, total_height)
+        return buffer, (canvas_width, canvas_height)
 
     @staticmethod
-    def _draw_header(
+    def _draw_legend(
         draw: ImageDraw.ImageDraw,
-        width: int,
-        title_font: ImageFont.ImageFont,
+        x: int,
+        y: int,
         legend_font: ImageFont.ImageFont,
     ) -> None:
-        """Dibuja el título centrado y la leyenda de colores."""
-        title = "Optimización de Cortes"
-        title_w, _ = _text_size(title, title_font)
-        draw.text(
-            ((width - title_w) // 2, 24), title, fill=COLOR_TITLE, font=title_font
-        )
-
+        """Dibuja la leyenda de colores (pieza vs retazo)."""
         legend = [
             (COLOR_PIECE_FILL, COLOR_PIECE_OUTLINE, "Pieza"),
             (COLOR_WASTE_FILL, COLOR_WASTE_OUTLINE, "Retazo / Desperdicio"),
         ]
-        x = 60
-        box = 26
-        y = 92
+        box = 32
         for fill, outline, text in legend:
             draw.rectangle(
                 [x, y, x + box, y + box], fill=fill, outline=outline, width=2
             )
-            draw.text((x + box + 10, y), text, fill="black", font=legend_font)
+            th = _text_size(text, legend_font)[1]
+            draw.text(
+                (x + box + 12, y + (box - th) // 2),
+                text,
+                fill="black",
+                font=legend_font,
+            )
             tw, _ = _text_size(text, legend_font)
-            x += box + 10 + tw + 50
+            x += box + 12 + tw + 50
 
     @staticmethod
     def _draw_piece(
@@ -254,8 +228,9 @@ class VisualizationService:
         if alto.height <= ph - 2 * pad and alto.width <= pw - 2 * pad:
             img.paste(alto, (px + pad, py + (ph - alto.height) // 2), alto)
 
-        # Etiqueta de la pieza al centro (omitir las auto-generadas piece_N).
-        piece_id = str(piece.get("piece_id", ""))
+        # Etiqueta de la pieza al centro: usar la etiqueta base (sin sufijo de
+        # instancia) y omitir las auto-generadas piece_N.
+        piece_id = base_label(str(piece.get("piece_id", "")))
         if piece_id and not piece_id.startswith("piece_"):
             label = _fit_label(piece_id, label_font, pw - 2 * pad, ph - 2 * pad)
             if label:

--- a/tests/test_optimizations.py
+++ b/tests/test_optimizations.py
@@ -130,6 +130,46 @@ def test_service_get_or_404(db_session):
         OptimizationService(db_session).get_or_404(123456)
 
 
+def test_optimize_deduplicates_identical_patterns(client):
+    """Varias hojas con el mismo patrón se colapsan en un grupo con su conteo."""
+    created_client = _create_client(client)
+    created_board = _create_board(client)
+
+    # Una pieza grande (1700×670) entra una sola vez por tablero → 5 hojas idénticas.
+    payload = {
+        "clientId": created_client["id"],
+        "requirements": [
+            {
+                "priority": 0,
+                "height": 1700,
+                "width": 670,
+                "quantity": 5,
+                "boardId": created_board["id"],
+                "label": "",
+                "canRotate": True,
+            }
+        ],
+    }
+    resp = client.post("/api/v1/optimize/", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+
+    # El conteo físico se mantiene en 5 (layouts, totales y resumen de materiales).
+    assert data["totalBoardsUsed"] == 5
+    assert len(data["layouts"]) == 5
+    assert data["materialsSummary"][0]["count"] == 5
+
+    # Pero los patrones se deduplican en un único grupo con count == 5.
+    groups = data["layoutGroups"]
+    assert len(groups) == 1
+    group = groups[0]
+    assert group["patternId"] == 1
+    assert group["count"] == 5
+    assert len(group["sheetNumbers"]) == 5
+    assert group["boardId"] == created_board["id"]
+    assert group["layout"]["material"]["boardId"] == created_board["id"]
+
+
 def test_optimize_includes_materials_summary(client):
     """materials_summary agrupa por tipo de tablero con código, cantidad y costo."""
     created_client = _create_client(client)

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -1,0 +1,93 @@
+"""Tests de la agrupación de layouts por patrón de corte (lógica pura)."""
+
+from src.modules.optimizations.patterns import (
+    base_label,
+    group_layouts,
+    layout_signature,
+)
+
+
+def _layout(sheet_number, pieces, board_id=18):
+    """Construye un layout mínimo con la forma de ``CuttingLayout.to_dict``."""
+    return {
+        "material": {"board_id": board_id, "sheet_number": sheet_number},
+        "placed_pieces": [
+            {
+                "piece_id": pid,
+                "x": x,
+                "y": y,
+                "width": w,
+                "height": h,
+                "rotated": rot,
+            }
+            for (pid, x, y, w, h, rot) in pieces
+        ],
+        "remainders": [],
+    }
+
+
+def test_base_label_strips_single_instance_suffix():
+    assert base_label("piece_1_5") == "piece_1"
+    assert base_label("Puerta_2") == "Puerta"
+    assert base_label("Puerta") == "Puerta"
+    assert base_label("") == ""
+
+
+def test_signature_ignores_instance_suffix_and_sheet_number():
+    a = _layout(1, [("Puerta_1", 0, 0, 670, 1700, False)])
+    b = _layout(7, [("Puerta_9", 0, 0, 670, 1700, False)])
+    assert layout_signature(a) == layout_signature(b)
+
+
+def test_signature_ignores_piece_order():
+    a = _layout(1, [("A", 0, 0, 100, 200, False), ("B", 300, 0, 100, 200, False)])
+    b = _layout(1, [("B", 300, 0, 100, 200, False), ("A", 0, 0, 100, 200, False)])
+    assert layout_signature(a) == layout_signature(b)
+
+
+def test_group_collapses_identical_patterns():
+    layouts = [
+        _layout(1, [("piece_1_1", 0, 0, 670, 1700, False)]),
+        _layout(2, [("piece_1_2", 0, 0, 670, 1700, False)]),
+        _layout(3, [("piece_1_3", 0, 0, 670, 1700, False)]),
+    ]
+    groups = group_layouts(layouts)
+    assert len(groups) == 1
+    group = groups[0]
+    assert group["pattern_id"] == 1
+    assert group["count"] == 3
+    assert group["sheet_numbers"] == [1, 2, 3]
+    assert group["board_id"] == 18
+    assert group["layout"] is layouts[0]
+
+
+def test_group_keeps_different_labels_separate():
+    layouts = [
+        _layout(1, [("Puerta", 0, 0, 670, 1700, False)]),
+        _layout(2, [("Cajon", 0, 0, 670, 1700, False)]),
+    ]
+    groups = group_layouts(layouts)
+    assert len(groups) == 2
+    assert [g["pattern_id"] for g in groups] == [1, 2]
+    assert all(g["count"] == 1 for g in groups)
+
+
+def test_group_keeps_different_geometry_separate():
+    layouts = [
+        _layout(1, [("A", 0, 0, 670, 1700, False)]),
+        _layout(2, [("A", 0, 0, 800, 1700, False)]),
+    ]
+    groups = group_layouts(layouts)
+    assert len(groups) == 2
+
+
+def test_group_preserves_first_appearance_order():
+    layouts = [
+        _layout(1, [("A", 0, 0, 100, 100, False)]),
+        _layout(2, [("B", 0, 0, 200, 200, False)]),
+        _layout(3, [("A", 0, 0, 100, 100, False)]),
+    ]
+    groups = group_layouts(layouts)
+    assert len(groups) == 2
+    assert groups[0]["count"] == 2 and groups[0]["sheet_numbers"] == [1, 3]
+    assert groups[1]["count"] == 1 and groups[1]["sheet_numbers"] == [2]


### PR DESCRIPTION
  - Group layouts sharing the same pattern (geometry + label) and render each unique pattern once on its own full-page diagram with a ×N badge.
  - Persist the grouping as layout_groups and expose it in the optimize response (+ Alembic migration).
  - Install DejaVu font in the Docker image and enlarge legend/labels so accents and the × symbol render correctly.