### PR TITLE
feat: add orders module backed by an optimization cache

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,10 @@ REDIS_URL=redis://redis:6379/0
 OPT_RESULT_TTL_SECONDS=259200
 CORS_ORIGINS=http://localhost:3000,http://localhost:3001
 
+# Órdenes (antiabuso)
+ORDER_VALIDITY_DAYS=15
+MAX_PENDING_ORDERS_PER_CLIENT=3
+
 # Base de datos
 # Para SQLite local:
 DATABASE_URL=sqlite:///./cutter_local.db

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -11,6 +11,7 @@ from alembic import context
 from src.modules.boards.model import BoardModel  # noqa: F401
 from src.modules.clients.model import ClientModel  # noqa: F401
 from src.modules.optimizations.model import OptimizationModel  # noqa: F401
+from src.modules.orders import model as orders_model  # noqa: F401
 from src.shared.config import config as app_config
 from src.shared.database import Base
 

--- a/alembic/versions/e5f6a7b8c9d0_add_orders_tables.py
+++ b/alembic/versions/e5f6a7b8c9d0_add_orders_tables.py
@@ -1,0 +1,97 @@
+"""add orders tables
+
+Revision ID: e5f6a7b8c9d0
+Revises: b2c3d4e5f6a7
+Create Date: 2026-06-02 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "e5f6a7b8c9d0"
+down_revision: Union[str, None] = "b2c3d4e5f6a7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "orders",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("code", sa.String(length=32), nullable=True),
+        sa.Column("client_id", sa.Integer(), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("optimization_snapshot", sa.JSON(), nullable=False),
+        sa.Column("optimization_hash", sa.String(length=64), nullable=False),
+        sa.Column("currency", sa.String(length=8), nullable=False),
+        sa.Column("subtotal", sa.Float(), nullable=False),
+        sa.Column("total", sa.Float(), nullable=False),
+        sa.Column("total_boards_used", sa.Integer(), nullable=False),
+        sa.Column("external_invoice_id", sa.String(length=64), nullable=True),
+        sa.Column("source", sa.String(length=32), nullable=True),
+        sa.Column("notes", sa.String(length=512), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("confirmed_at", sa.DateTime(), nullable=True),
+        sa.Column("expires_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["client_id"], ["clients.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("code"),
+    )
+    op.create_table(
+        "order_lines",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("order_id", sa.Integer(), nullable=False),
+        sa.Column("board_id", sa.Integer(), nullable=False),
+        sa.Column("board_code", sa.String(length=32), nullable=True),
+        sa.Column("board_name", sa.String(length=128), nullable=True),
+        sa.Column("quantity", sa.Integer(), nullable=False),
+        sa.Column("unit_price_snapshot", sa.Float(), nullable=False),
+        sa.Column("line_total", sa.Float(), nullable=False),
+        sa.Column("avg_efficiency", sa.Float(), nullable=True),
+        sa.Column("total_area_m2", sa.Float(), nullable=True),
+        sa.ForeignKeyConstraint(["order_id"], ["orders.id"]),
+        sa.ForeignKeyConstraint(["board_id"], ["boards.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_table(
+        "order_pieces",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("order_id", sa.Integer(), nullable=False),
+        sa.Column("board_id", sa.Integer(), nullable=False),
+        sa.Column("label", sa.String(length=128), nullable=True),
+        sa.Column("height", sa.Integer(), nullable=False),
+        sa.Column("width", sa.Integer(), nullable=False),
+        sa.Column("quantity", sa.Integer(), nullable=False),
+        sa.Column("priority", sa.Integer(), nullable=False),
+        sa.Column("can_rotate", sa.Boolean(), nullable=False),
+        sa.ForeignKeyConstraint(["order_id"], ["orders.id"]),
+        sa.ForeignKeyConstraint(["board_id"], ["boards.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_table(
+        "order_status_history",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("order_id", sa.Integer(), nullable=False),
+        sa.Column("from_status", sa.String(length=32), nullable=True),
+        sa.Column("to_status", sa.String(length=32), nullable=False),
+        sa.Column("actor", sa.String(length=32), nullable=True),
+        sa.Column("note", sa.String(length=512), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["order_id"], ["orders.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.add_column(
+        "optimizations",
+        sa.Column("optimization_hash", sa.String(length=64), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("optimizations", "optimization_hash")
+    op.drop_table("order_status_history")
+    op.drop_table("order_pieces")
+    op.drop_table("order_lines")
+    op.drop_table("orders")

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ from fastapi.responses import RedirectResponse
 from src.modules.boards.router import router as boards_router
 from src.modules.clients.router import router as clients_router
 from src.modules.optimizations.router import router as optimizations_router
+from src.modules.orders.router import router as orders_router
 from src.modules.system.router import router as system_router
 from src.shared.config import config
 from src.shared.errors import register_exception_handlers
@@ -55,6 +56,7 @@ app.include_router(system_router, prefix="/api/v1")
 app.include_router(boards_router, prefix="/api/v1")
 app.include_router(clients_router, prefix="/api/v1")
 app.include_router(optimizations_router, prefix="/api/v1")
+app.include_router(orders_router, prefix="/api/v1")
 
 
 @app.get("/")

--- a/src/modules/optimizations/model.py
+++ b/src/modules/optimizations/model.py
@@ -1,6 +1,7 @@
 from datetime import datetime
+from typing import Optional
 
-from sqlalchemy import JSON, DateTime, Float, ForeignKey, Integer
+from sqlalchemy import JSON, DateTime, Float, ForeignKey, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.shared.database import Base
@@ -18,6 +19,7 @@ class OptimizationModel(Base):
     layouts: Mapped[dict] = mapped_column(JSON)
     materials_summary: Mapped[dict] = mapped_column(JSON, nullable=True)
     layout_groups: Mapped[dict] = mapped_column(JSON, nullable=True)
+    optimization_hash: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     client_id: Mapped[int] = mapped_column(ForeignKey("clients.id"))

--- a/src/modules/optimizations/schemas.py
+++ b/src/modules/optimizations/schemas.py
@@ -119,6 +119,9 @@ class LayoutGroup(CamelModel):
 class OptimizeResponse(CamelModel):
     id: int
     client: ClientResponse = Field(..., description="Client information")
+    optimization_hash: Optional[str] = Field(
+        default=None, description="Deterministic hash of the optimization inputs"
+    )
     total_boards_used: int = Field(..., description="Total number of boards used")
     total_boards_cost: float = Field(..., description="Total cost of boards used")
     layouts: List[Layout] = Field(

--- a/src/modules/optimizations/service.py
+++ b/src/modules/optimizations/service.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 from collections import defaultdict
 from typing import Dict, List, Tuple
 
@@ -17,13 +19,14 @@ from src.modules.boards.service import BoardService
 from src.modules.optimizations.model import OptimizationModel
 from src.modules.optimizations.patterns import group_layouts
 from src.modules.optimizations.schemas import OptimizeRequest, Requirement
+from src.shared.cache import cache
 from src.shared.config import config
 from src.shared.database import get_db
 from src.shared.exceptions import EntityNotFoundError, ValidationError
 
 
 class OptimizationService:
-    """Orquesta el dominio de corte (``cutting``) y persiste optimizaciones."""
+    """Orquesta el dominio de corte (``cutting``), cachea por hash y persiste."""
 
     def __init__(self, db: Session):
         self.db = db
@@ -37,7 +40,18 @@ class OptimizationService:
         return optimization
 
     def execute(self, request: OptimizeRequest) -> OptimizationModel:
-        """Ejecuta la optimización: agrupa por tablero, corta y persiste."""
+        """Ejecuta la optimización (cache-first) y la persiste (dual-write)."""
+        payload, optimization_hash = self.compute(request)
+        return self._save_optimization_from_payload(payload, optimization_hash)
+
+    def compute(self, request: OptimizeRequest) -> Tuple[dict, str]:
+        """Calcula (o recupera de caché) el resultado de la optimización.
+
+        Cache-first por un hash determinista de entradas (requerimientos +
+        parámetros de corte + precios de tableros). No escribe en BD: lo reutiliza
+        el módulo de órdenes para congelar el snapshot sin depender de la caché.
+        Devuelve ``(payload, optimization_hash)``.
+        """
         if not request.requirements:
             raise ValidationError("La lista de piezas no puede estar vacía")
 
@@ -51,25 +65,60 @@ class OptimizationService:
             right_trim=config.RIGHT_TRIM,
         )
 
-        board_results = []
-        board_codes: Dict[int, str] = {}
-        board_names: Dict[int, str] = {}
-        for board_id, board_requirements in requirements_by_board.items():
+        boards: Dict[int, BoardModel] = {}
+        for board_id in requirements_by_board:
             board = self.board_service.get(board_id)
             if board is None:
                 raise EntityNotFoundError("Board", board_id)
+            boards[board_id] = board
 
-            board_codes[board_id] = board.code
-            board_names[board_id] = board.name
-            board_results.append(
-                self._optimize(
-                    pieces=board_requirements,
-                    board=board,
-                    cutting_params=cutting_params,
-                )
+        optimization_hash = self._compute_hash(request, cutting_params, boards)
+
+        cached = cache.get_json(optimization_hash)
+        if cached is not None:
+            return cached, optimization_hash
+
+        board_codes = {bid: board.code for bid, board in boards.items()}
+        board_names = {bid: board.name for bid, board in boards.items()}
+        board_results = [
+            self._optimize(
+                pieces=requirements_by_board[bid],
+                board=boards[bid],
+                cutting_params=cutting_params,
             )
+            for bid in requirements_by_board
+        ]
 
-        return self._save_optimization(request, board_results, board_codes, board_names)
+        payload = self._build_result_payload(
+            request, board_results, board_codes, board_names
+        )
+        cache.set_json(optimization_hash, payload)
+        return payload, optimization_hash
+
+    def _compute_hash(
+        self,
+        request: OptimizeRequest,
+        cutting_params: CuttingParameters,
+        boards: Dict[int, BoardModel],
+    ) -> str:
+        """Hash sha256 determinista de las entradas que afectan el resultado.
+
+        No incluye ``client_id`` (el cómputo no depende del cliente); la dedupe de
+        órdenes sí combina ``client_id`` con este hash.
+        """
+        digest_input = {
+            "requirements": [r.model_dump() for r in request.requirements],
+            "params": {
+                "kerf": cutting_params.kerf,
+                "top_trim": cutting_params.top_trim,
+                "bottom_trim": cutting_params.bottom_trim,
+                "left_trim": cutting_params.left_trim,
+                "right_trim": cutting_params.right_trim,
+            },
+            "prices": {str(bid): board.price for bid, board in boards.items()},
+        }
+        canonical = json.dumps(digest_input, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
     def _group_requirements_by_board(
         self, requirements: List[Requirement]
@@ -165,38 +214,55 @@ class OptimizationService:
             result.append(entry)
         return result
 
-    def _save_optimization(
+    def _build_result_payload(
         self,
         request: OptimizeRequest,
         board_results: List[Tuple[List[CuttingLayout], List[Piece]]],
         board_codes: Dict[int, str],
         board_names: Dict[int, str],
-    ) -> OptimizationModel:
-        """Guarda los resultados de la optimización en la base de datos."""
+    ) -> dict:
+        """Arma el payload cacheable/serializable del resultado de optimización.
+
+        Mismas claves que persiste ``optimizations`` y que consumen ``proforma`` y
+        el snapshot de las órdenes.
+        """
         total_boards_used = sum(len(layouts) for layouts, _ in board_results)
         total_boards_cost = sum(
             layout.material.cost_per_unit
             for layouts, _ in board_results
             for layout in layouts
         )
-
         layout_dicts = [
             layout.to_dict() for layouts, _ in board_results for layout in layouts
         ]
-
-        optimization = OptimizationModel(
-            total_boards_used=total_boards_used,
-            total_boards_cost=total_boards_cost,
-            requirements=[
+        return {
+            "total_boards_used": total_boards_used,
+            "total_boards_cost": total_boards_cost,
+            "requirements": [
                 {**r.model_dump(), "board_code": board_codes.get(r.board_id, "N/A")}
                 for r in request.requirements
             ],
-            layouts=layout_dicts,
-            materials_summary=self._build_materials_summary(
+            "layouts": layout_dicts,
+            "materials_summary": self._build_materials_summary(
                 board_results, board_codes, board_names
             ),
-            layout_groups=group_layouts(layout_dicts),
-            client_id=request.client_id,
+            "layout_groups": group_layouts(layout_dicts),
+            "client_id": request.client_id,
+        }
+
+    def _save_optimization_from_payload(
+        self, payload: dict, optimization_hash: str
+    ) -> OptimizationModel:
+        """Persiste una fila de ``optimizations`` desde un payload (dual-write)."""
+        optimization = OptimizationModel(
+            total_boards_used=payload["total_boards_used"],
+            total_boards_cost=payload["total_boards_cost"],
+            requirements=payload["requirements"],
+            layouts=payload["layouts"],
+            materials_summary=payload["materials_summary"],
+            layout_groups=payload["layout_groups"],
+            client_id=payload["client_id"],
+            optimization_hash=optimization_hash,
         )
         self.db.add(optimization)
         self.db.commit()

--- a/src/modules/orders/model.py
+++ b/src/modules/orders/model.py
@@ -1,0 +1,142 @@
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from sqlalchemy import JSON, Boolean, DateTime, Float, ForeignKey, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.shared.database import Base
+
+
+class OrderStatus(str, Enum):
+    """Estados del proceso comercial de una orden."""
+
+    draft = "draft"
+    quoted = "quoted"
+    confirmed = "confirmed"
+    approved = "approved"
+    in_production = "in_production"
+    cut = "cut"
+    completed = "completed"
+    cancelled = "cancelled"
+    expired = "expired"
+
+
+# Estados sin salida: la orden ya no se transforma.
+TERMINAL_STATUSES = {OrderStatus.completed, OrderStatus.cancelled, OrderStatus.expired}
+
+# Pendientes (abiertas, pre-producción): cuentan para el tope antiabuso por cliente.
+PENDING_STATUSES = {OrderStatus.confirmed, OrderStatus.approved}
+
+# Mapa de transiciones válidas de la máquina de estados (ver diseño §7.2).
+TRANSITIONS: dict[OrderStatus, set[OrderStatus]] = {
+    OrderStatus.draft: {OrderStatus.quoted, OrderStatus.cancelled},
+    OrderStatus.quoted: {
+        OrderStatus.confirmed,
+        OrderStatus.expired,
+        OrderStatus.cancelled,
+    },
+    OrderStatus.confirmed: {OrderStatus.approved, OrderStatus.cancelled},
+    OrderStatus.approved: {OrderStatus.in_production, OrderStatus.cancelled},
+    OrderStatus.in_production: {OrderStatus.cut},
+    OrderStatus.cut: {OrderStatus.completed},
+    OrderStatus.completed: set(),
+    OrderStatus.cancelled: set(),
+    OrderStatus.expired: set(),
+}
+
+
+class OrderModel(Base):
+    """Raíz de agregado: pedido con snapshot inmutable y máquina de estados."""
+
+    __tablename__ = "orders"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    code: Mapped[Optional[str]] = mapped_column(String(32), unique=True, nullable=True)
+    client_id: Mapped[int] = mapped_column(ForeignKey("clients.id"))
+    status: Mapped[str] = mapped_column(String(32), default=OrderStatus.confirmed.value)
+
+    optimization_snapshot: Mapped[dict] = mapped_column(JSON)
+    optimization_hash: Mapped[str] = mapped_column(String(64))
+
+    currency: Mapped[str] = mapped_column(String(8), default="USD")
+    subtotal: Mapped[float] = mapped_column(Float)
+    total: Mapped[float] = mapped_column(Float)
+    total_boards_used: Mapped[int] = mapped_column(Integer)
+
+    external_invoice_id: Mapped[Optional[str]] = mapped_column(
+        String(64), nullable=True
+    )
+    source: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
+    notes: Mapped[Optional[str]] = mapped_column(String(512), nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    confirmed_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    expires_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+
+    client: Mapped["ClientModel"] = relationship("ClientModel")  # noqa: F821
+    lines: Mapped[list["OrderLineModel"]] = relationship(
+        "OrderLineModel", back_populates="order", cascade="all, delete-orphan"
+    )
+    pieces: Mapped[list["OrderPieceModel"]] = relationship(
+        "OrderPieceModel", back_populates="order", cascade="all, delete-orphan"
+    )
+    history: Mapped[list["OrderStatusHistoryModel"]] = relationship(
+        "OrderStatusHistoryModel",
+        back_populates="order",
+        cascade="all, delete-orphan",
+        order_by="OrderStatusHistoryModel.id",
+    )
+
+
+class OrderLineModel(Base):
+    """Línea de COBRO: un tipo de tablero usado (cantidad × precio congelado)."""
+
+    __tablename__ = "order_lines"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    order_id: Mapped[int] = mapped_column(ForeignKey("orders.id"))
+    board_id: Mapped[int] = mapped_column(ForeignKey("boards.id"))
+    board_code: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
+    board_name: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
+    quantity: Mapped[int] = mapped_column(Integer)
+    unit_price_snapshot: Mapped[float] = mapped_column(Float)
+    line_total: Mapped[float] = mapped_column(Float)
+    avg_efficiency: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    total_area_m2: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+
+    order: Mapped["OrderModel"] = relationship("OrderModel", back_populates="lines")
+
+
+class OrderPieceModel(Base):
+    """Pieza de la LISTA DE CORTE (insumo de producción; no se cobra)."""
+
+    __tablename__ = "order_pieces"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    order_id: Mapped[int] = mapped_column(ForeignKey("orders.id"))
+    board_id: Mapped[int] = mapped_column(ForeignKey("boards.id"))
+    label: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
+    height: Mapped[int] = mapped_column(Integer)
+    width: Mapped[int] = mapped_column(Integer)
+    quantity: Mapped[int] = mapped_column(Integer)
+    priority: Mapped[int] = mapped_column(Integer, default=0)
+    can_rotate: Mapped[bool] = mapped_column(Boolean, default=True)
+
+    order: Mapped["OrderModel"] = relationship("OrderModel", back_populates="pieces")
+
+
+class OrderStatusHistoryModel(Base):
+    """Auditoría de transiciones de estado de una orden."""
+
+    __tablename__ = "order_status_history"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    order_id: Mapped[int] = mapped_column(ForeignKey("orders.id"))
+    from_status: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
+    to_status: Mapped[str] = mapped_column(String(32))
+    actor: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
+    note: Mapped[Optional[str]] = mapped_column(String(512), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    order: Mapped["OrderModel"] = relationship("OrderModel", back_populates="history")

--- a/src/modules/orders/router.py
+++ b/src/modules/orders/router.py
@@ -1,0 +1,46 @@
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, Query
+
+from src.modules.orders.model import OrderStatus
+from src.modules.orders.schemas import OrderCreate, OrderResponse, OrderStatusUpdate
+from src.modules.orders.service import OrderService, order_service
+
+router = APIRouter(prefix="/orders", tags=["orders"])
+
+
+@router.post("/", response_model=OrderResponse, status_code=201)
+def create_order(data: OrderCreate, svc: OrderService = Depends(order_service)):
+    """Crea (o recupera, por idempotencia) una orden congelando el snapshot."""
+    return svc.create(data)
+
+
+@router.get("/", response_model=List[OrderResponse])
+def list_orders(
+    status: Optional[OrderStatus] = Query(
+        default=None, description="Filter orders by status"
+    ),
+    skip: int = Query(0, ge=0, description="Number of records to skip"),
+    limit: int = Query(
+        100, ge=1, le=1000, description="Maximum number of records to return"
+    ),
+    svc: OrderService = Depends(order_service),
+):
+    """Lista órdenes con filtro por estado y paginación opcionales."""
+    return svc.list_orders(status=status, skip=skip, limit=limit)
+
+
+@router.get("/{order_id}", response_model=OrderResponse)
+def get_order(order_id: int, svc: OrderService = Depends(order_service)):
+    """Obtiene una orden por ID."""
+    return svc.get_or_404(order_id)
+
+
+@router.patch("/{order_id}/status", response_model=OrderResponse)
+def update_order_status(
+    order_id: int,
+    data: OrderStatusUpdate,
+    svc: OrderService = Depends(order_service),
+):
+    """Transiciona el estado de una orden validando la máquina de estados."""
+    return svc.transition(order_id, data.status, actor="sales", note=data.note)

--- a/src/modules/orders/schemas.py
+++ b/src/modules/orders/schemas.py
@@ -1,0 +1,80 @@
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import Field
+
+from src.modules.clients.schemas import ClientResponse
+from src.modules.optimizations.schemas import Requirement
+from src.modules.orders.model import OrderStatus
+from src.shared.schemas import CamelModel
+
+
+class OrderCreate(CamelModel):
+    """Crear una orden: misma forma que ``OptimizeRequest`` + metadatos."""
+
+    requirements: List[Requirement] = Field(
+        ..., min_length=1, description="Cut list to optimize and freeze into the order"
+    )
+    client_id: int = Field(..., description="Client ID placing the order")
+    notes: Optional[str] = Field(default=None, max_length=512)
+    source: Optional[str] = Field(default="telegram", max_length=32)
+
+
+class OrderStatusUpdate(CamelModel):
+    """Transición de estado solicitada."""
+
+    status: OrderStatus = Field(..., description="Target status to transition to")
+    note: Optional[str] = Field(default=None, max_length=512)
+
+
+class OrderLineResponse(CamelModel):
+    id: int
+    board_id: int
+    board_code: Optional[str] = None
+    board_name: Optional[str] = None
+    quantity: int = Field(..., description="Number of boards charged (cobro=tableros)")
+    unit_price_snapshot: float
+    line_total: float
+    avg_efficiency: Optional[float] = None
+    total_area_m2: Optional[float] = None
+
+
+class OrderPieceResponse(CamelModel):
+    id: int
+    board_id: int
+    label: Optional[str] = None
+    height: int
+    width: int
+    quantity: int
+    priority: int
+    can_rotate: bool
+
+
+class OrderStatusHistoryResponse(CamelModel):
+    id: int
+    from_status: Optional[OrderStatus] = None
+    to_status: OrderStatus
+    actor: Optional[str] = None
+    note: Optional[str] = None
+    created_at: datetime
+
+
+class OrderResponse(CamelModel):
+    id: int
+    code: Optional[str] = None
+    client: ClientResponse = Field(..., description="Client information")
+    status: OrderStatus
+    currency: str
+    subtotal: float
+    total: float
+    total_boards_used: int
+    optimization_hash: str
+    external_invoice_id: Optional[str] = None
+    source: Optional[str] = None
+    notes: Optional[str] = None
+    created_at: datetime
+    confirmed_at: Optional[datetime] = None
+    expires_at: Optional[datetime] = None
+    lines: List[OrderLineResponse] = Field(default_factory=list)
+    pieces: List[OrderPieceResponse] = Field(default_factory=list)
+    history: List[OrderStatusHistoryResponse] = Field(default_factory=list)

--- a/src/modules/orders/service.py
+++ b/src/modules/orders/service.py
@@ -1,0 +1,187 @@
+from datetime import datetime, timedelta
+from typing import List, Optional
+
+from fastapi import Depends
+from sqlalchemy.orm import Session
+
+from src.modules.optimizations.schemas import OptimizeRequest
+from src.modules.optimizations.service import OptimizationService
+from src.modules.orders.model import (
+    PENDING_STATUSES,
+    TERMINAL_STATUSES,
+    TRANSITIONS,
+    OrderLineModel,
+    OrderModel,
+    OrderPieceModel,
+    OrderStatus,
+    OrderStatusHistoryModel,
+)
+from src.modules.orders.schemas import OrderCreate
+from src.shared.config import config
+from src.shared.database import get_db
+from src.shared.exceptions import BusinessRuleError, EntityNotFoundError
+
+
+class OrderService:
+    """Crea órdenes (snapshot inmutable), gestiona estados y antiabuso."""
+
+    def __init__(self, db: Session):
+        self.db = db
+        self.optimization_service = OptimizationService(db)
+
+    def get_or_404(self, order_id: int) -> OrderModel:
+        order = self.db.get(OrderModel, order_id)
+        if order is None:
+            raise EntityNotFoundError("Order", order_id)
+        return order
+
+    def list_orders(
+        self,
+        status: Optional[OrderStatus] = None,
+        skip: int = 0,
+        limit: int = 100,
+    ) -> List[OrderModel]:
+        """Lista órdenes (más recientes primero), opcionalmente por estado."""
+        query = self.db.query(OrderModel)
+        if status is not None:
+            query = query.filter(OrderModel.status == status.value)
+        return query.order_by(OrderModel.id.desc()).offset(skip).limit(limit).all()
+
+    def create(self, data: OrderCreate) -> OrderModel:
+        """Recalcula (cache-first), congela el snapshot y crea la orden.
+
+        Idempotente: un re-POST idéntico devuelve la orden activa existente.
+        """
+        opt_request = OptimizeRequest(
+            requirements=data.requirements, client_id=data.client_id
+        )
+        payload, optimization_hash = self.optimization_service.compute(opt_request)
+
+        existing = self._find_active_duplicate(data.client_id, optimization_hash)
+        if existing is not None:
+            return existing
+
+        self._enforce_pending_cap(data.client_id)
+
+        now = datetime.utcnow()
+        order = OrderModel(
+            client_id=data.client_id,
+            status=OrderStatus.confirmed.value,
+            optimization_snapshot=payload,
+            optimization_hash=optimization_hash,
+            currency="USD",
+            subtotal=payload["total_boards_cost"],
+            total=payload["total_boards_cost"],
+            total_boards_used=payload["total_boards_used"],
+            source=data.source,
+            notes=data.notes,
+            created_at=now,
+            confirmed_at=now,
+            expires_at=now + timedelta(days=config.ORDER_VALIDITY_DAYS),
+        )
+        # Líneas de cobro = tableros usados (desde materials_summary).
+        order.lines = [
+            OrderLineModel(
+                board_id=m["board_id"],
+                board_code=m.get("board_code"),
+                board_name=m.get("board_name"),
+                quantity=m["count"],
+                unit_price_snapshot=m["cost_per_unit"],
+                line_total=m["total_cost"],
+                avg_efficiency=m.get("avg_efficiency"),
+                total_area_m2=m.get("total_area_m2"),
+            )
+            for m in payload["materials_summary"]
+        ]
+        # Lista de corte = piezas (insumo de producción; no se cobra).
+        order.pieces = [
+            OrderPieceModel(
+                board_id=r["board_id"],
+                label=r.get("label"),
+                height=r["height"],
+                width=r["width"],
+                quantity=r["quantity"],
+                priority=r.get("priority", 0),
+                can_rotate=r.get("can_rotate", True),
+            )
+            for r in payload["requirements"]
+        ]
+        order.history = [
+            OrderStatusHistoryModel(
+                from_status=None,
+                to_status=OrderStatus.confirmed.value,
+                actor="system",
+                note="Orden creada",
+            )
+        ]
+
+        self.db.add(order)
+        self.db.flush()  # asigna id para componer el code legible
+        order.code = f"ORD-{now.year}-{order.id:04d}"
+        self.db.commit()
+        self.db.refresh(order)
+        return order
+
+    def transition(
+        self,
+        order_id: int,
+        to_status: OrderStatus,
+        actor: str = "system",
+        note: Optional[str] = None,
+    ) -> OrderModel:
+        """Valida y aplica una transición de estado, registrando el historial."""
+        order = self.get_or_404(order_id)
+        current = OrderStatus(order.status)
+        if to_status not in TRANSITIONS.get(current, set()):
+            raise BusinessRuleError(
+                f"Transición inválida de '{current.value}' a '{to_status.value}'"
+            )
+        order.history.append(
+            OrderStatusHistoryModel(
+                from_status=current.value,
+                to_status=to_status.value,
+                actor=actor,
+                note=note,
+            )
+        )
+        order.status = to_status.value
+        self.db.commit()
+        self.db.refresh(order)
+        return order
+
+    def _find_active_duplicate(
+        self, client_id: int, optimization_hash: str
+    ) -> Optional[OrderModel]:
+        """Orden no terminal del cliente con el mismo hash (idempotencia)."""
+        terminal = [s.value for s in TERMINAL_STATUSES]
+        return (
+            self.db.query(OrderModel)
+            .filter(
+                OrderModel.client_id == client_id,
+                OrderModel.optimization_hash == optimization_hash,
+                OrderModel.status.not_in(terminal),
+            )
+            .first()
+        )
+
+    def _enforce_pending_cap(self, client_id: int) -> None:
+        """Bloquea si el cliente excede el tope de órdenes pendientes."""
+        pending = [s.value for s in PENDING_STATUSES]
+        count = (
+            self.db.query(OrderModel)
+            .filter(
+                OrderModel.client_id == client_id,
+                OrderModel.status.in_(pending),
+            )
+            .count()
+        )
+        if count >= config.MAX_PENDING_ORDERS_PER_CLIENT:
+            raise BusinessRuleError(
+                f"El cliente ya tiene {count} pedido(s) pendiente(s); "
+                "resuélvalos o espere a que expiren antes de crear otro."
+            )
+
+
+def order_service(db: Session = Depends(get_db)) -> OrderService:
+    """Provider de ``OrderService`` para inyección en rutas."""
+    return OrderService(db)

--- a/src/shared/cache.py
+++ b/src/shared/cache.py
@@ -1,0 +1,74 @@
+"""Caché compartida sobre Redis con (de)serialización JSON y degradación elegante.
+
+La caché es un *acelerador*, no la fuente de verdad: si Redis no responde,
+``get_json`` devuelve ``None`` y ``set_json`` es un no-op, de modo que el llamador
+simplemente recalcula. El cliente se crea de forma perezosa y puede inyectarse en
+tests (``CacheService(client=...)``).
+"""
+
+import json
+import logging
+from typing import Any, Optional
+
+import redis
+
+from src.shared.config import config
+
+logger = logging.getLogger(__name__)
+
+
+class CacheService:
+    """Envoltorio JSON sobre un cliente Redis tolerante a fallos."""
+
+    def __init__(self, client: Optional["redis.Redis"] = None):
+        self._client = client
+        self._initialized = client is not None
+
+    @property
+    def client(self) -> Optional["redis.Redis"]:
+        """Cliente Redis perezoso; ``None`` si no se pudo inicializar."""
+        if not self._initialized:
+            try:
+                self._client = redis.Redis.from_url(
+                    config.REDIS_URL,
+                    socket_connect_timeout=0.5,
+                    socket_timeout=0.5,
+                    decode_responses=True,
+                )
+            except (redis.RedisError, ValueError) as exc:  # pragma: no cover
+                logger.warning("No se pudo inicializar Redis: %s", exc)
+                self._client = None
+            self._initialized = True
+        return self._client
+
+    def get_json(self, key: str) -> Optional[Any]:
+        """Devuelve el valor deserializado, o ``None`` si no existe o Redis falla."""
+        client = self.client
+        if client is None:
+            return None
+        try:
+            raw = client.get(key)
+        except redis.RedisError as exc:
+            logger.warning("Cache get falló (%s): %s", key, exc)
+            return None
+        if raw is None:
+            return None
+        try:
+            return json.loads(raw)
+        except (TypeError, ValueError):
+            return None
+
+    def set_json(self, key: str, value: Any, ttl: Optional[int] = None) -> None:
+        """Serializa y guarda ``value`` con expiración; no-op si Redis falla."""
+        client = self.client
+        if client is None:
+            return
+        ttl = ttl if ttl is not None else config.OPT_RESULT_TTL_SECONDS
+        try:
+            client.set(key, json.dumps(value), ex=ttl)
+        except redis.RedisError as exc:
+            logger.warning("Cache set falló (%s): %s", key, exc)
+
+
+# Instancia compartida; los servicios importan ``cache`` y lo usan directamente.
+cache = CacheService()

--- a/src/shared/config.py
+++ b/src/shared/config.py
@@ -70,6 +70,10 @@ class Config:
 
     OPT_RESULT_TTL_SECONDS = env.int("OPT_RESULT_TTL_SECONDS", 259200)
 
+    # Órdenes: vigencia de la cotización y tope de pendientes por cliente (antiabuso)
+    ORDER_VALIDITY_DAYS = env.int("ORDER_VALIDITY_DAYS", 15)
+    MAX_PENDING_ORDERS_PER_CLIENT = env.int("MAX_PENDING_ORDERS_PER_CLIENT", 3)
+
     # Datos de la empresa para la proforma PDF
     COMPANY_NAME = env("COMPANY_NAME", "EMPRESA MADERABLE S.A.")
     COMPANY_RUC = env("COMPANY_RUC", "1234567890001")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,8 +10,36 @@ from sqlalchemy.pool import StaticPool
 import src.modules.boards.model  # noqa: F401,E402
 import src.modules.clients.model  # noqa: F401,E402
 import src.modules.optimizations.model  # noqa: F401,E402
+import src.modules.orders.model  # noqa: F401,E402
 from main import app
+from src.shared.cache import cache
 from src.shared.database import Base, get_db
+
+
+class _InMemoryRedis:
+    """Doble en memoria de Redis: parea ``get``/``set`` sobre strings JSON."""
+
+    def __init__(self):
+        self._store: dict = {}
+
+    def get(self, key):
+        return self._store.get(key)
+
+    def set(self, key, value, ex=None):
+        self._store[key] = value
+        return True
+
+
+@pytest.fixture(autouse=True)
+def isolated_cache():
+    """Aísla la caché de Redis real: cada test usa un doble en memoria limpio."""
+    original_client, original_initialized = cache._client, cache._initialized
+    cache._client = _InMemoryRedis()
+    cache._initialized = True
+    try:
+        yield
+    finally:
+        cache._client, cache._initialized = original_client, original_initialized
 
 
 @pytest.fixture

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,52 @@
+"""Tests del helper de caché: round-trip JSON y degradación elegante."""
+
+import redis
+
+from src.shared.cache import CacheService
+
+
+class _FakeRedis:
+    """Doble en memoria que parea ``get``/``set`` (como ``decode_responses=True``)."""
+
+    def __init__(self):
+        self._store = {}
+
+    def get(self, key):
+        return self._store.get(key)
+
+    def set(self, key, value, ex=None):
+        self._store[key] = value
+        return True
+
+
+class _BrokenRedis:
+    """Doble que simula Redis caído: toda operación lanza ``ConnectionError``."""
+
+    def get(self, key):
+        raise redis.ConnectionError("redis down")
+
+    def set(self, key, value, ex=None):
+        raise redis.ConnectionError("redis down")
+
+
+def test_set_and_get_json_round_trip():
+    svc = CacheService(client=_FakeRedis())
+    value = {"a": 1, "nested": [1, 2, {"b": True}], "s": "x"}
+    svc.set_json("k", value, ttl=60)
+    assert svc.get_json("k") == value
+
+
+def test_get_json_missing_key_returns_none():
+    svc = CacheService(client=_FakeRedis())
+    assert svc.get_json("missing") is None
+
+
+def test_get_json_degrades_on_redis_error():
+    svc = CacheService(client=_BrokenRedis())
+    assert svc.get_json("k") is None
+
+
+def test_set_json_degrades_on_redis_error():
+    svc = CacheService(client=_BrokenRedis())
+    # No debe propagar la excepción: la caché es acelerador, no fuente de verdad.
+    svc.set_json("k", {"x": 1})

--- a/tests/test_optimizations.py
+++ b/tests/test_optimizations.py
@@ -66,6 +66,20 @@ def test_optimize_returns_layouts(client):
     assert layout["placedPieces"][0]["originalWidth"] == 600
 
 
+def test_optimize_returns_optimization_hash(client):
+    """La respuesta expone el hash determinista de las entradas."""
+    created_client = _create_client(client)
+    created_board = _create_board(client)
+
+    resp = client.post(
+        "/api/v1/optimize/",
+        json=_optimize_payload(created_client["id"], created_board["id"]),
+    )
+    assert resp.status_code == 200
+    optimization_hash = resp.json()["optimizationHash"]
+    assert isinstance(optimization_hash, str) and len(optimization_hash) == 64
+
+
 def test_optimize_computes_total_boards_cost(client):
     """El costo total debe ser nº de tableros usados * precio del tablero."""
     created_client = _create_client(client)

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -1,0 +1,174 @@
+"""Tests del módulo orders: creación (snapshot), idempotencia, tope, estados."""
+
+from datetime import datetime
+
+from src.shared.config import config
+
+
+def _create_client(client, identifier="0991112233"):
+    return client.post(
+        "/api/v1/clients/",
+        json={"identifier": identifier, "firstName": "Ada", "lastName": "Lovelace"},
+    ).json()
+
+
+def _create_board(client, code="MEL18"):
+    return client.post(
+        "/api/v1/boards/",
+        json={
+            "code": code,
+            "name": f"Melamina {code}",
+            "height": 2440,
+            "width": 1220,
+            "thickness": 18,
+            "price": 45.5,
+        },
+    ).json()
+
+
+def _order_payload(client_id, board_id, height=400, width=600, quantity=2):
+    return {
+        "clientId": client_id,
+        "requirements": [
+            {
+                "priority": 0,
+                "height": height,
+                "width": width,
+                "quantity": quantity,
+                "boardId": board_id,
+                "label": "Puerta",
+                "canRotate": True,
+            }
+        ],
+    }
+
+
+def test_create_order_freezes_snapshot_and_charges_boards(client):
+    c = _create_client(client)
+    b = _create_board(client)
+
+    resp = client.post("/api/v1/orders/", json=_order_payload(c["id"], b["id"]))
+    assert resp.status_code == 201
+    data = resp.json()
+
+    assert data["status"] == "confirmed"
+    assert data["code"] == f"ORD-{datetime.utcnow().year}-{data['id']:04d}"
+    assert data["client"]["id"] == c["id"]
+    assert len(data["optimizationHash"]) == 64
+
+    # Cobro = tableros: una línea por tipo de tablero (desde materials_summary).
+    assert len(data["lines"]) == 1
+    line = data["lines"][0]
+    assert line["boardCode"] == "MEL18"
+    assert line["quantity"] == data["totalBoardsUsed"]
+    assert line["lineTotal"] == line["quantity"] * 45.5
+
+    # Totales inmutables = suma por tableros.
+    assert data["total"] == data["subtotal"] == line["lineTotal"]
+
+    # Lista de corte = piezas (insumo de producción, no se cobra).
+    assert len(data["pieces"]) == 1
+    piece = data["pieces"][0]
+    assert piece["height"] == 400 and piece["width"] == 600
+    assert piece["quantity"] == 2
+
+    # Historial inicial registra la creación.
+    assert data["history"][0]["toStatus"] == "confirmed"
+    assert data["history"][0]["fromStatus"] is None
+
+
+def test_create_order_is_idempotent(client):
+    c = _create_client(client)
+    b = _create_board(client)
+    payload = _order_payload(c["id"], b["id"])
+
+    first = client.post("/api/v1/orders/", json=payload).json()
+    second = client.post("/api/v1/orders/", json=payload).json()
+
+    assert first["id"] == second["id"]
+    assert first["code"] == second["code"]
+    # No se crean dos órdenes para el mismo (cliente, hash).
+    assert len(client.get("/api/v1/orders/").json()) == 1
+
+
+def test_pending_cap_blocks_excess_orders(client, monkeypatch):
+    monkeypatch.setattr(config, "MAX_PENDING_ORDERS_PER_CLIENT", 2)
+    c = _create_client(client)
+    b = _create_board(client)
+
+    # Dos órdenes distintas (distinto hash) → ambas quedan pendientes.
+    assert (
+        client.post(
+            "/api/v1/orders/", json=_order_payload(c["id"], b["id"], width=600)
+        ).status_code
+        == 201
+    )
+    assert (
+        client.post(
+            "/api/v1/orders/", json=_order_payload(c["id"], b["id"], width=500)
+        ).status_code
+        == 201
+    )
+
+    # La tercera excede el tope de pendientes.
+    third = client.post(
+        "/api/v1/orders/", json=_order_payload(c["id"], b["id"], width=450)
+    )
+    assert third.status_code == 422
+    assert "pendiente" in third.json()["detail"]
+
+
+def test_status_transitions_valid_and_invalid(client):
+    c = _create_client(client)
+    b = _create_board(client)
+    order = client.post("/api/v1/orders/", json=_order_payload(c["id"], b["id"])).json()
+    oid = order["id"]
+
+    ok = client.patch(f"/api/v1/orders/{oid}/status", json={"status": "approved"})
+    assert ok.status_code == 200
+    assert ok.json()["status"] == "approved"
+
+    ok2 = client.patch(f"/api/v1/orders/{oid}/status", json={"status": "in_production"})
+    assert ok2.status_code == 200
+    assert ok2.json()["status"] == "in_production"
+    # Historial acumulado: creación + 2 transiciones.
+    assert len(ok2.json()["history"]) == 3
+
+    # in_production → completed no es una transición válida.
+    bad = client.patch(f"/api/v1/orders/{oid}/status", json={"status": "completed"})
+    assert bad.status_code == 422
+    assert "inválida" in bad.json()["detail"]
+
+
+def test_invalid_transition_from_confirmed(client):
+    c = _create_client(client)
+    b = _create_board(client)
+    order = client.post("/api/v1/orders/", json=_order_payload(c["id"], b["id"])).json()
+    # confirmed → completed (salta estados) no es válido.
+    bad = client.patch(
+        f"/api/v1/orders/{order['id']}/status", json={"status": "completed"}
+    )
+    assert bad.status_code == 422
+
+
+def test_list_orders_filter_by_status(client):
+    c = _create_client(client)
+    b = _create_board(client)
+    o1 = client.post(
+        "/api/v1/orders/", json=_order_payload(c["id"], b["id"], width=600)
+    ).json()
+    client.post("/api/v1/orders/", json=_order_payload(c["id"], b["id"], width=500))
+
+    # Aprobar solo la primera.
+    client.patch(f"/api/v1/orders/{o1['id']}/status", json={"status": "approved"})
+
+    approved = client.get("/api/v1/orders/", params={"status": "approved"}).json()
+    assert [o["id"] for o in approved] == [o1["id"]]
+
+    confirmed = client.get("/api/v1/orders/", params={"status": "confirmed"}).json()
+    assert o1["id"] not in [o["id"] for o in confirmed]
+    assert len(confirmed) == 1
+
+
+def test_get_order_404(client):
+    assert client.get("/api/v1/orders/999999").status_code == 404


### PR DESCRIPTION
    - Add Redis cache layer with graceful degradation and a deterministic optimization hash; expose optimizationHash on the optimize response.
    - Add orders module: immutable snapshot, charge-by-board lines, cut-list pieces, status machine, idempotency and a per-client pending cap.
    - Keep persisting optimizations (dual-write) so the current flow is intact.
    - Alembic migration for the order tables plus the optimization_hash column.