### PR TITLE
feat: render order documents and make optimize cache-only

### DIFF
--- a/src/modules/optimizations/carrier.py
+++ b/src/modules/optimizations/carrier.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class ProformaCarrier:
+    """Portador duck-typed que la proforma y la hoja de producción saben renderizar.
+
+    Unifica las dos fuentes de un mismo cálculo —una optimización efímera
+    (cacheada por hash) o el snapshot inmutable de una orden— exponiendo los
+    mismos atributos que ``ProformaService`` lee, sin acoplar el render a un
+    modelo ORM concreto. El render solo depende de esta forma, no de su origen.
+    """
+
+    reference: str
+    client: object
+    requirements: List[dict] = field(default_factory=list)
+    materials_summary: List[dict] = field(default_factory=list)
+    layouts: List[dict] = field(default_factory=list)
+    layout_groups: List[dict] = field(default_factory=list)
+    total_boards_used: int = 0
+    total_boards_cost: float = 0.0
+
+    @classmethod
+    def from_payload(cls, payload: dict, client, reference: str) -> "ProformaCarrier":
+        """Construye el portador desde un payload de optimización + el cliente."""
+        return cls(
+            reference=reference,
+            client=client,
+            requirements=payload.get("requirements") or [],
+            materials_summary=payload.get("materials_summary") or [],
+            layouts=payload.get("layouts") or [],
+            layout_groups=payload.get("layout_groups") or [],
+            total_boards_used=payload.get("total_boards_used", 0),
+            total_boards_cost=payload.get("total_boards_cost", 0.0),
+        )
+
+    @classmethod
+    def from_order(cls, order) -> "ProformaCarrier":
+        """Construye el portador desde una orden (snapshot + precios congelados)."""
+        snapshot = order.optimization_snapshot or {}
+        reference = order.code or f"ORD-{order.id:06d}"
+        carrier = cls.from_payload(snapshot, order.client, reference=reference)
+        # La orden congela totales al confirmar: prevalecen sobre el snapshot.
+        carrier.total_boards_used = order.total_boards_used
+        carrier.total_boards_cost = order.total
+        return carrier

--- a/src/modules/optimizations/proforma.py
+++ b/src/modules/optimizations/proforma.py
@@ -1,7 +1,9 @@
+import base64
 import io
 from datetime import datetime
-from typing import List
+from typing import List, Union
 
+from fastapi.responses import StreamingResponse
 from reportlab.lib import colors
 from reportlab.lib.enums import TA_LEFT, TA_RIGHT
 from reportlab.lib.pagesizes import A4
@@ -18,7 +20,7 @@ from reportlab.platypus import (
     TableStyle,
 )
 
-from src.modules.optimizations.model import OptimizationModel
+from src.modules.optimizations.carrier import ProformaCarrier
 from src.modules.optimizations.patterns import group_layouts
 from src.modules.optimizations.visualization import VisualizationService
 from src.shared.config import config
@@ -53,66 +55,56 @@ def _draw_page_footer(canvas, doc) -> None:
     canvas.restoreState()
 
 
+def _new_doc(buffer: io.BytesIO) -> SimpleDocTemplate:
+    """Documento A4 con los márgenes estándar de los PDFs de Cutter."""
+    return SimpleDocTemplate(
+        buffer,
+        pagesize=A4,
+        topMargin=0.5 * inch,
+        bottomMargin=0.6 * inch,
+        leftMargin=LEFT_MARGIN,
+        rightMargin=RIGHT_MARGIN,
+    )
+
+
 class ProformaService:
     @staticmethod
-    def generate_proforma_pdf(optimization: OptimizationModel) -> io.BytesIO:
+    def generate_proforma_pdf(carrier: ProformaCarrier) -> io.BytesIO:
+        """Proforma comercial: requerimientos, materiales con precios y disposición."""
         buffer = io.BytesIO()
-        doc = SimpleDocTemplate(
-            buffer,
-            pagesize=A4,
-            topMargin=0.5 * inch,
-            bottomMargin=0.6 * inch,
-            leftMargin=LEFT_MARGIN,
-            rightMargin=RIGHT_MARGIN,
-        )
+        doc = _new_doc(buffer)
 
         styles = getSampleStyleSheet()
-        heading_style = ParagraphStyle(
-            "SectionHeading",
-            parent=styles["Heading2"],
-            fontSize=13,
-            textColor=DARK_BLUE,
-            spaceAfter=2,
-            spaceBefore=4,
-            fontName="Helvetica-Bold",
-        )
-        cell_style = ParagraphStyle(
-            "Cell",
-            parent=styles["Normal"],
-            fontSize=9,
-            leading=11,
-            textColor=TEXT_GREY,
-            alignment=TA_LEFT,
-        )
+        heading_style = _heading_style(styles)
+        cell_style = _cell_style(styles)
 
         story = []
-        story.extend(ProformaService._build_header(optimization, styles))
+        story.extend(ProformaService._build_header(carrier, styles, "PROFORMA"))
         story.append(Spacer(1, 0.25 * inch))
 
         story.extend(_section("INFORMACIÓN DEL CLIENTE", heading_style))
-        story.append(ProformaService._build_client_table(optimization))
+        story.append(ProformaService._build_client_table(carrier))
         story.append(Spacer(1, 0.25 * inch))
 
         story.extend(_section("DETALLE DE REQUERIMIENTOS", heading_style))
-        story.append(
-            ProformaService._build_requirements_table(optimization, cell_style)
-        )
+        story.append(ProformaService._build_requirements_table(carrier, cell_style))
         story.append(Spacer(1, 0.25 * inch))
 
         story.extend(_section("RESUMEN DE MATERIALES", heading_style))
-        story.append(ProformaService._build_materials_table(optimization, cell_style))
+        story.append(ProformaService._build_materials_table(carrier, cell_style))
         story.append(Spacer(1, 0.2 * inch))
-        story.append(ProformaService._build_totals_table(optimization))
+        story.append(ProformaService._build_totals_table(carrier))
 
         story.append(PageBreak())
         story.extend(_section("DISPOSICIÓN DE CORTES", heading_style))
         story.append(Spacer(1, 0.08 * inch))
-        story.extend(ProformaService._build_layout_pages(optimization))
+        story.extend(ProformaService._build_layout_pages(carrier))
 
         story.append(Spacer(1, 0.3 * inch))
         story.append(
             Paragraph(
-                "Esta proforma es válida por 15 días. Los precios no incluyen IVA.",
+                f"Esta proforma es válida por {config.ORDER_VALIDITY_DAYS} días. "
+                "Los precios no incluyen IVA.",
                 ParagraphStyle(
                     "Note",
                     parent=styles["Normal"],
@@ -128,8 +120,46 @@ class ProformaService:
         return buffer
 
     @staticmethod
-    def _build_header(optimization: OptimizationModel, styles) -> List:
-        """Encabezado tipo factura: datos de empresa + bloque PROFORMA."""
+    def generate_production_sheet_pdf(carrier: ProformaCarrier) -> io.BytesIO:
+        """Hoja de producción para el taller: lista de corte y disposición, SIN precios."""
+        buffer = io.BytesIO()
+        doc = _new_doc(buffer)
+
+        styles = getSampleStyleSheet()
+        heading_style = _heading_style(styles)
+        cell_style = _cell_style(styles)
+
+        story = []
+        story.extend(
+            ProformaService._build_header(carrier, styles, "HOJA DE PRODUCCIÓN")
+        )
+        story.append(Spacer(1, 0.25 * inch))
+
+        story.extend(_section("CLIENTE", heading_style))
+        story.append(ProformaService._build_client_table(carrier))
+        story.append(Spacer(1, 0.25 * inch))
+
+        story.extend(_section("LISTA DE CORTE", heading_style))
+        story.append(ProformaService._build_requirements_table(carrier, cell_style))
+        story.append(Spacer(1, 0.25 * inch))
+
+        story.extend(_section("TABLEROS A UTILIZAR", heading_style))
+        story.append(ProformaService._build_materials_plain_table(carrier, cell_style))
+        story.append(Spacer(1, 0.2 * inch))
+        story.append(ProformaService._build_boards_total_table(carrier))
+
+        story.append(PageBreak())
+        story.extend(_section("DISPOSICIÓN DE CORTES", heading_style))
+        story.append(Spacer(1, 0.08 * inch))
+        story.extend(ProformaService._build_layout_pages(carrier))
+
+        doc.build(story, onFirstPage=_draw_page_footer, onLaterPages=_draw_page_footer)
+        buffer.seek(0)
+        return buffer
+
+    @staticmethod
+    def _build_header(carrier: ProformaCarrier, styles, title: str) -> List:
+        """Encabezado tipo factura: datos de empresa + bloque de documento."""
         name_style = ParagraphStyle(
             "CompanyName",
             parent=styles["Normal"],
@@ -145,8 +175,8 @@ class ProformaService:
             leading=13,
             textColor=colors.white,
         )
-        proforma_title_style = ParagraphStyle(
-            "ProformaTitle",
+        doc_title_style = ParagraphStyle(
+            "DocTitle",
             parent=styles["Normal"],
             fontSize=16,
             leading=20,
@@ -154,8 +184,8 @@ class ProformaService:
             fontName="Helvetica-Bold",
             alignment=TA_RIGHT,
         )
-        proforma_detail_style = ParagraphStyle(
-            "ProformaDetail",
+        doc_detail_style = ParagraphStyle(
+            "DocDetail",
             parent=styles["Normal"],
             fontSize=10,
             leading=15,
@@ -175,11 +205,11 @@ class ProformaService:
             ),
         ]
         right_cell = [
-            Paragraph("PROFORMA", proforma_title_style),
+            Paragraph(title, doc_title_style),
             Paragraph(
-                f"N° {optimization.id:06d}<br/>"
+                f"N° {carrier.reference}<br/>"
                 f"Fecha: {datetime.now().strftime('%d/%m/%Y')}",
-                proforma_detail_style,
+                doc_detail_style,
             ),
         ]
 
@@ -202,8 +232,8 @@ class ProformaService:
         return [header_table]
 
     @staticmethod
-    def _build_client_table(optimization: OptimizationModel) -> Table:
-        client = optimization.client
+    def _build_client_table(carrier: ProformaCarrier) -> Table:
+        client = carrier.client
         client_name = (
             f"{client.first_name or ''} {client.last_name or ''}".strip() or "N/A"
         )
@@ -232,8 +262,8 @@ class ProformaService:
         return client_table
 
     @staticmethod
-    def _build_requirements_table(optimization: OptimizationModel, cell_style) -> Table:
-        requirements = optimization.requirements
+    def _build_requirements_table(carrier: ProformaCarrier, cell_style) -> Table:
+        requirements = carrier.requirements
         req_data = [["#", "Alto", "Ancho", "Cantidad", "Tablero", "Etiqueta"]]
         if isinstance(requirements, list):
             for idx, req in enumerate(requirements, 1):
@@ -264,8 +294,8 @@ class ProformaService:
         return req_table
 
     @staticmethod
-    def _build_materials_table(optimization: OptimizationModel, cell_style) -> Table:
-        materials_summary = optimization.materials_summary
+    def _build_materials_table(carrier: ProformaCarrier, cell_style) -> Table:
+        materials_summary = carrier.materials_summary
         mat_data = [
             [
                 "Código",
@@ -313,44 +343,67 @@ class ProformaService:
         return mat_table
 
     @staticmethod
-    def _build_totals_table(optimization: OptimizationModel) -> Table:
-        summary_data = [
-            ["Total de tableros utilizados:", str(optimization.total_boards_used)],
-            ["Costo total estimado:", f"${optimization.total_boards_cost:.2f}"],
+    def _build_materials_plain_table(carrier: ProformaCarrier, cell_style) -> Table:
+        """Tableros a usar SIN precios (hoja de producción): código, dimensiones, cant."""
+        materials_summary = carrier.materials_summary
+        mat_data = [
+            ["Código", "Nombre", "Dimensiones", "Espesor", "Cantidad", "Efic. Prom."]
         ]
-        summary_table = Table(
-            summary_data, colWidths=[CONTENT_WIDTH - 2.0 * inch, 2.0 * inch]
+        if isinstance(materials_summary, list) and materials_summary:
+            for entry in materials_summary:
+                mat_data.append(
+                    [
+                        entry.get("board_code", "N/A"),
+                        Paragraph(entry.get("board_name", "N/A"), cell_style),
+                        f"{entry.get('height', 0):.0f}×{entry.get('width', 0):.0f} mm",
+                        f"{entry.get('thickness', 0):.0f} mm",
+                        str(entry.get("count", 0)),
+                        f"{entry.get('avg_efficiency', 0):.1f}%",
+                    ]
+                )
+        else:
+            mat_data.append(["Sin datos de materiales", "", "", "", "", ""])
+
+        mat_table = Table(
+            mat_data,
+            colWidths=[
+                0.9 * inch,
+                CONTENT_WIDTH - 4.5 * inch,
+                1.3 * inch,
+                0.9 * inch,
+                0.9 * inch,
+                0.9 * inch,
+            ],
+            repeatRows=1,
         )
-        summary_table.setStyle(
-            TableStyle(
-                [
-                    ("BACKGROUND", (0, 0), (-1, -1), LIGHT_BLUE),
-                    ("BOX", (0, 0), (-1, -1), 1, BRAND_BLUE),
-                    ("LINEBELOW", (0, 0), (-1, 0), 0.5, colors.HexColor("#BBDEFB")),
-                    ("FONTNAME", (0, 0), (-1, -1), "Helvetica-Bold"),
-                    ("FONTSIZE", (0, 0), (-1, -1), 11),
-                    ("TEXTCOLOR", (0, 0), (-1, -1), DARK_BLUE),
-                    ("ALIGN", (0, 0), (0, -1), "LEFT"),
-                    ("ALIGN", (1, 0), (1, -1), "RIGHT"),
-                    ("TOPPADDING", (0, 0), (-1, -1), 8),
-                    ("BOTTOMPADDING", (0, 0), (-1, -1), 8),
-                    ("LEFTPADDING", (0, 0), (-1, -1), 12),
-                    ("RIGHTPADDING", (0, 0), (-1, -1), 12),
-                ]
-            )
-        )
-        return summary_table
+        mat_table.setStyle(_data_table_style(header_size=10, body_size=9))
+        return mat_table
 
     @staticmethod
-    def _build_layout_pages(optimization: OptimizationModel) -> List:
+    def _build_totals_table(carrier: ProformaCarrier) -> Table:
+        summary_data = [
+            ["Total de tableros utilizados:", str(carrier.total_boards_used)],
+            ["Costo total estimado:", f"${carrier.total_boards_cost:.2f}"],
+        ]
+        return _totals_table(summary_data)
+
+    @staticmethod
+    def _build_boards_total_table(carrier: ProformaCarrier) -> Table:
+        """Total de tableros a cortar, sin costos (hoja de producción)."""
+        return _totals_table(
+            [["Total de tableros a cortar:", str(carrier.total_boards_used)]]
+        )
+
+    @staticmethod
+    def _build_layout_pages(carrier: ProformaCarrier) -> List:
         """Una imagen por patrón, cada una a página completa ocupando el máximo."""
-        layouts = optimization.layouts
+        layouts = carrier.layouts
         if not (isinstance(layouts, list) and layouts):
             return []
 
         # Usa los grupos persistidos; recompútalos para optimizaciones antiguas que
         # se guardaron antes de existir el campo ``layout_groups``.
-        groups = optimization.layout_groups
+        groups = carrier.layout_groups
         if not (isinstance(groups, list) and groups):
             groups = group_layouts(layouts)
 
@@ -378,6 +431,48 @@ class ProformaService:
         return flowables
 
 
+def pdf_response(
+    buffer: io.BytesIO, filename: str, fmt: str = "pdf"
+) -> Union[StreamingResponse, dict]:
+    """Devuelve el PDF como descarga (``pdf``) o envuelto en JSON base64 (``base64``)."""
+    if fmt.lower() == "base64":
+        content = base64.b64encode(buffer.getvalue()).decode("utf-8")
+        return {
+            "format": "base64",
+            "content": content,
+            "filename": filename,
+            "mimeType": "application/pdf",
+        }
+    return StreamingResponse(
+        buffer,
+        media_type="application/pdf",
+        headers={"Content-Disposition": f"attachment; filename={filename}"},
+    )
+
+
+def _heading_style(styles) -> ParagraphStyle:
+    return ParagraphStyle(
+        "SectionHeading",
+        parent=styles["Heading2"],
+        fontSize=13,
+        textColor=DARK_BLUE,
+        spaceAfter=2,
+        spaceBefore=4,
+        fontName="Helvetica-Bold",
+    )
+
+
+def _cell_style(styles) -> ParagraphStyle:
+    return ParagraphStyle(
+        "Cell",
+        parent=styles["Normal"],
+        fontSize=9,
+        leading=11,
+        textColor=TEXT_GREY,
+        alignment=TA_LEFT,
+    )
+
+
 def _section(title: str, heading_style) -> List:
     """Título de sección con regla de color debajo."""
     return [
@@ -386,6 +481,30 @@ def _section(title: str, heading_style) -> List:
             width="100%", thickness=1.2, color=BRAND_BLUE, spaceBefore=2, spaceAfter=8
         ),
     ]
+
+
+def _totals_table(rows: List[List[str]]) -> Table:
+    """Caja resaltada de totales (clave a la izquierda, valor a la derecha)."""
+    table = Table(rows, colWidths=[CONTENT_WIDTH - 2.0 * inch, 2.0 * inch])
+    table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, -1), LIGHT_BLUE),
+                ("BOX", (0, 0), (-1, -1), 1, BRAND_BLUE),
+                ("LINEBELOW", (0, 0), (-1, 0), 0.5, colors.HexColor("#BBDEFB")),
+                ("FONTNAME", (0, 0), (-1, -1), "Helvetica-Bold"),
+                ("FONTSIZE", (0, 0), (-1, -1), 11),
+                ("TEXTCOLOR", (0, 0), (-1, -1), DARK_BLUE),
+                ("ALIGN", (0, 0), (0, -1), "LEFT"),
+                ("ALIGN", (1, 0), (1, -1), "RIGHT"),
+                ("TOPPADDING", (0, 0), (-1, -1), 8),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 8),
+                ("LEFTPADDING", (0, 0), (-1, -1), 12),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 12),
+            ]
+        )
+    )
+    return table
 
 
 def _data_table_style(header_size: int, body_size: int) -> TableStyle:

--- a/src/modules/optimizations/router.py
+++ b/src/modules/optimizations/router.py
@@ -1,9 +1,6 @@
-import base64
-
 from fastapi import APIRouter, Depends, Query
-from fastapi.responses import StreamingResponse
 
-from src.modules.optimizations.proforma import ProformaService
+from src.modules.optimizations.proforma import ProformaService, pdf_response
 from src.modules.optimizations.schemas import OptimizeRequest, OptimizeResponse
 from src.modules.optimizations.service import OptimizationService, optimization_service
 
@@ -15,13 +12,13 @@ def optimize(
     request: OptimizeRequest,
     svc: OptimizationService = Depends(optimization_service),
 ):
-    """Ejecuta una optimización de cortes y devuelve la solución."""
-    return svc.execute(request)
+    """Ejecuta una optimización de cortes (cache-first) y devuelve la solución."""
+    return svc.optimize_response(request)
 
 
-@router.get("/{optimization_id}/proforma")
+@router.get("/{optimization_hash}/proforma")
 def get_proforma(
-    optimization_id: int,
+    optimization_hash: str,
     format: str = Query(
         default="pdf",
         description="Formato de salida: 'pdf' (archivo) o 'base64' (JSON)",
@@ -29,24 +26,7 @@ def get_proforma(
     ),
     svc: OptimizationService = Depends(optimization_service),
 ):
-    """Genera la proforma en PDF de una optimización."""
-    optimization = svc.get_or_404(optimization_id)
-    pdf_buffer = ProformaService.generate_proforma_pdf(optimization)
-
-    if format.lower() == "base64":
-        pdf_base64 = base64.b64encode(pdf_buffer.getvalue()).decode("utf-8")
-        return {
-            "optimizationId": optimization_id,
-            "format": "base64",
-            "content": pdf_base64,
-            "filename": f"proforma_{optimization_id}.pdf",
-            "mimeType": "application/pdf",
-        }
-
-    return StreamingResponse(
-        pdf_buffer,
-        media_type="application/pdf",
-        headers={
-            "Content-Disposition": f"attachment; filename=proforma_{optimization_id}.pdf"
-        },
-    )
+    """Genera la proforma PDF de una optimización cacheada (por hash)."""
+    carrier = svc.build_carrier_from_hash(optimization_hash)
+    pdf_buffer = ProformaService.generate_proforma_pdf(carrier)
+    return pdf_response(pdf_buffer, f"proforma_{optimization_hash[:8]}.pdf", format)

--- a/src/modules/optimizations/schemas.py
+++ b/src/modules/optimizations/schemas.py
@@ -117,7 +117,10 @@ class LayoutGroup(CamelModel):
 
 
 class OptimizeResponse(CamelModel):
-    id: int
+    id: Optional[int] = Field(
+        default=None,
+        description="Deprecated: optimizations are no longer persisted; use the hash",
+    )
     client: ClientResponse = Field(..., description="Client information")
     optimization_hash: Optional[str] = Field(
         default=None, description="Deterministic hash of the optimization inputs"

--- a/src/modules/optimizations/service.py
+++ b/src/modules/optimizations/service.py
@@ -16,9 +16,14 @@ from src.cutting import (
 )
 from src.modules.boards.model import BoardModel
 from src.modules.boards.service import BoardService
-from src.modules.optimizations.model import OptimizationModel
+from src.modules.clients.model import ClientModel
+from src.modules.optimizations.carrier import ProformaCarrier
 from src.modules.optimizations.patterns import group_layouts
-from src.modules.optimizations.schemas import OptimizeRequest, Requirement
+from src.modules.optimizations.schemas import (
+    OptimizeRequest,
+    OptimizeResponse,
+    Requirement,
+)
 from src.shared.cache import cache
 from src.shared.config import config
 from src.shared.database import get_db
@@ -26,23 +31,50 @@ from src.shared.exceptions import EntityNotFoundError, ValidationError
 
 
 class OptimizationService:
-    """Orquesta el dominio de corte (``cutting``), cachea por hash y persiste."""
+    """Orquesta el dominio de corte (``cutting``) y cachea el resultado por hash.
+
+    El cómputo es determinista y efímero: se cachea por un hash de las entradas y
+    **no** se persiste en BD (la orden es la fuente de verdad durable). El hash es
+    el identificador con el que se recupera la proforma.
+    """
 
     def __init__(self, db: Session):
         self.db = db
         self.board_service = BoardService(db)
 
-    def get_or_404(self, optimization_id: int) -> OptimizationModel:
-        """Obtiene una optimización por ID o lanza 404."""
-        optimization = self.db.get(OptimizationModel, optimization_id)
-        if optimization is None:
-            raise EntityNotFoundError("Optimization", optimization_id)
-        return optimization
-
-    def execute(self, request: OptimizeRequest) -> OptimizationModel:
-        """Ejecuta la optimización (cache-first) y la persiste (dual-write)."""
+    def optimize_response(self, request: OptimizeRequest) -> OptimizeResponse:
+        """Calcula (cache-first) y arma la respuesta del endpoint ``POST /optimize``."""
         payload, optimization_hash = self.compute(request)
-        return self._save_optimization_from_payload(payload, optimization_hash)
+        client = self.db.get(ClientModel, payload["client_id"])
+        if client is None:
+            raise EntityNotFoundError("Client", payload["client_id"])
+        return OptimizeResponse(
+            id=None,
+            client=client,
+            optimization_hash=optimization_hash,
+            total_boards_used=payload["total_boards_used"],
+            total_boards_cost=payload["total_boards_cost"],
+            layouts=payload["layouts"],
+            materials_summary=payload["materials_summary"],
+            layout_groups=payload["layout_groups"],
+        )
+
+    def get_cached_payload(self, optimization_hash: str) -> dict:
+        """Recupera el payload cacheado por hash o lanza 404 si expiró/no existe."""
+        payload = cache.get_json(optimization_hash)
+        if payload is None:
+            raise EntityNotFoundError("Optimization", optimization_hash)
+        return payload
+
+    def build_carrier_from_hash(self, optimization_hash: str) -> ProformaCarrier:
+        """Portador de proforma para una optimización cacheada (por hash)."""
+        payload = self.get_cached_payload(optimization_hash)
+        client = self.db.get(ClientModel, payload["client_id"])
+        if client is None:
+            raise EntityNotFoundError("Client", payload["client_id"])
+        return ProformaCarrier.from_payload(
+            payload, client, reference=f"OPT-{optimization_hash[:8]}"
+        )
 
     def compute(self, request: OptimizeRequest) -> Tuple[dict, str]:
         """Calcula (o recupera de caché) el resultado de la optimización.
@@ -249,25 +281,6 @@ class OptimizationService:
             "layout_groups": group_layouts(layout_dicts),
             "client_id": request.client_id,
         }
-
-    def _save_optimization_from_payload(
-        self, payload: dict, optimization_hash: str
-    ) -> OptimizationModel:
-        """Persiste una fila de ``optimizations`` desde un payload (dual-write)."""
-        optimization = OptimizationModel(
-            total_boards_used=payload["total_boards_used"],
-            total_boards_cost=payload["total_boards_cost"],
-            requirements=payload["requirements"],
-            layouts=payload["layouts"],
-            materials_summary=payload["materials_summary"],
-            layout_groups=payload["layout_groups"],
-            client_id=payload["client_id"],
-            optimization_hash=optimization_hash,
-        )
-        self.db.add(optimization)
-        self.db.commit()
-        self.db.refresh(optimization)
-        return optimization
 
 
 def optimization_service(db: Session = Depends(get_db)) -> OptimizationService:

--- a/src/modules/orders/router.py
+++ b/src/modules/orders/router.py
@@ -2,11 +2,19 @@ from typing import List, Optional
 
 from fastapi import APIRouter, Depends, Query
 
+from src.modules.optimizations.carrier import ProformaCarrier
+from src.modules.optimizations.proforma import ProformaService, pdf_response
 from src.modules.orders.model import OrderStatus
 from src.modules.orders.schemas import OrderCreate, OrderResponse, OrderStatusUpdate
 from src.modules.orders.service import OrderService, order_service
 
 router = APIRouter(prefix="/orders", tags=["orders"])
+
+_FORMAT_QUERY = Query(
+    default="pdf",
+    description="Formato de salida: 'pdf' (archivo) o 'base64' (JSON)",
+    pattern="^(pdf|base64)$",
+)
 
 
 @router.post("/", response_model=OrderResponse, status_code=201)
@@ -44,3 +52,29 @@ def update_order_status(
 ):
     """Transiciona el estado de una orden validando la máquina de estados."""
     return svc.transition(order_id, data.status, actor="sales", note=data.note)
+
+
+@router.get("/{order_id}/proforma")
+def get_order_proforma(
+    order_id: int,
+    format: str = _FORMAT_QUERY,
+    svc: OrderService = Depends(order_service),
+):
+    """Proforma comercial (con precios congelados) renderizada desde el snapshot."""
+    order = svc.get_or_404(order_id)
+    carrier = ProformaCarrier.from_order(order)
+    pdf_buffer = ProformaService.generate_proforma_pdf(carrier)
+    return pdf_response(pdf_buffer, f"proforma_{order.code or order.id}.pdf", format)
+
+
+@router.get("/{order_id}/production-sheet")
+def get_order_production_sheet(
+    order_id: int,
+    format: str = _FORMAT_QUERY,
+    svc: OrderService = Depends(order_service),
+):
+    """Hoja de producción (lista de corte y disposición, SIN precios) para el taller."""
+    order = svc.get_or_404(order_id)
+    carrier = ProformaCarrier.from_order(order)
+    pdf_buffer = ProformaService.generate_production_sheet_pdf(carrier)
+    return pdf_response(pdf_buffer, f"produccion_{order.code or order.id}.pdf", format)

--- a/src/modules/orders/service.py
+++ b/src/modules/orders/service.py
@@ -33,6 +33,9 @@ class OrderService:
         order = self.db.get(OrderModel, order_id)
         if order is None:
             raise EntityNotFoundError("Order", order_id)
+        if self._expire_if_stale(order):
+            self.db.commit()
+            self.db.refresh(order)
         return order
 
     def list_orders(
@@ -45,7 +48,13 @@ class OrderService:
         query = self.db.query(OrderModel)
         if status is not None:
             query = query.filter(OrderModel.status == status.value)
-        return query.order_by(OrderModel.id.desc()).offset(skip).limit(limit).all()
+        orders = query.order_by(OrderModel.id.desc()).offset(skip).limit(limit).all()
+        if any([self._expire_if_stale(o) for o in orders]):
+            self.db.commit()
+        if status is not None:
+            # Una orden recién expirada deja de pertenecer al estado consultado.
+            orders = [o for o in orders if o.status == status.value]
+        return orders
 
     def create(self, data: OrderCreate) -> OrderModel:
         """Recalcula (cache-first), congela el snapshot y crea la orden.
@@ -149,12 +158,37 @@ class OrderService:
         self.db.refresh(order)
         return order
 
+    def _expire_if_stale(self, order: OrderModel) -> bool:
+        """Marca como ``expired`` una orden pendiente cuya vigencia ya venció.
+
+        Expiración perezosa: se dispara al leer (get/list) o al evaluar el tope de
+        pendientes. Solo afecta a estados pendientes (confirmed/approved). No hace
+        commit: el llamador decide cuándo persistir el barrido. Devuelve ``True``
+        si transicionó la orden.
+        """
+        if (
+            order.expires_at is not None
+            and order.status in {s.value for s in PENDING_STATUSES}
+            and order.expires_at < datetime.utcnow()
+        ):
+            order.history.append(
+                OrderStatusHistoryModel(
+                    from_status=order.status,
+                    to_status=OrderStatus.expired.value,
+                    actor="system",
+                    note="Vigencia vencida",
+                )
+            )
+            order.status = OrderStatus.expired.value
+            return True
+        return False
+
     def _find_active_duplicate(
         self, client_id: int, optimization_hash: str
     ) -> Optional[OrderModel]:
         """Orden no terminal del cliente con el mismo hash (idempotencia)."""
         terminal = [s.value for s in TERMINAL_STATUSES]
-        return (
+        candidate = (
             self.db.query(OrderModel)
             .filter(
                 OrderModel.client_id == client_id,
@@ -163,21 +197,32 @@ class OrderService:
             )
             .first()
         )
+        if candidate is not None and self._expire_if_stale(candidate):
+            # La duplicada estaba vencida: ya no cuenta, se crea una nueva orden.
+            self.db.commit()
+            return None
+        return candidate
 
     def _enforce_pending_cap(self, client_id: int) -> None:
-        """Bloquea si el cliente excede el tope de órdenes pendientes."""
+        """Bloquea si el cliente excede el tope de órdenes pendientes.
+
+        Primero expira las pendientes vencidas (no cuentan para el tope).
+        """
         pending = [s.value for s in PENDING_STATUSES]
-        count = (
+        candidates = (
             self.db.query(OrderModel)
             .filter(
                 OrderModel.client_id == client_id,
                 OrderModel.status.in_(pending),
             )
-            .count()
+            .all()
         )
-        if count >= config.MAX_PENDING_ORDERS_PER_CLIENT:
+        if any([self._expire_if_stale(o) for o in candidates]):
+            self.db.commit()
+        active = sum(1 for o in candidates if o.status in pending)
+        if active >= config.MAX_PENDING_ORDERS_PER_CLIENT:
             raise BusinessRuleError(
-                f"El cliente ya tiene {count} pedido(s) pendiente(s); "
+                f"El cliente ya tiene {active} pedido(s) pendiente(s); "
                 "resuélvalos o espere a que expiren antes de crear otro."
             )
 

--- a/tests/test_optimizations.py
+++ b/tests/test_optimizations.py
@@ -113,14 +113,16 @@ def test_proforma_pdf_and_base64(client):
         "/api/v1/optimize/",
         json=_optimize_payload(created_client["id"], created_board["id"]),
     ).json()
-    opt_id = optimization["id"]
+    opt_hash = optimization["optimizationHash"]
 
-    pdf = client.get(f"/api/v1/optimize/{opt_id}/proforma")
+    pdf = client.get(f"/api/v1/optimize/{opt_hash}/proforma")
     assert pdf.status_code == 200
     assert pdf.headers["content-type"] == "application/pdf"
     assert len(pdf.content) > 1000
 
-    b64 = client.get(f"/api/v1/optimize/{opt_id}/proforma", params={"format": "base64"})
+    b64 = client.get(
+        f"/api/v1/optimize/{opt_hash}/proforma", params={"format": "base64"}
+    )
     assert b64.status_code == 200
     body = b64.json()
     assert body["format"] == "base64"
@@ -129,19 +131,35 @@ def test_proforma_pdf_and_base64(client):
 
 
 def test_proforma_missing_optimization_returns_404(client):
-    assert client.get("/api/v1/optimize/999999/proforma").status_code == 404
+    """Un hash que no está en caché (expiró o nunca existió) responde 404."""
+    assert client.get(f"/api/v1/optimize/{'0' * 64}/proforma").status_code == 404
+
+
+def test_optimize_does_not_persist(client, db_session):
+    """El dual-write se retiró: ``POST /optimize`` no escribe en BD."""
+    from src.modules.optimizations.model import OptimizationModel
+
+    created_client = _create_client(client)
+    created_board = _create_board(client)
+    resp = client.post(
+        "/api/v1/optimize/",
+        json=_optimize_payload(created_client["id"], created_board["id"]),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["id"] is None
+    assert db_session.query(OptimizationModel).count() == 0
 
 
 def test_service_rejects_empty_requirements(db_session):
-    """La guarda defensiva de ``execute`` lanza ValidationError (422)."""
+    """La guarda defensiva de ``compute`` lanza ValidationError (422)."""
     request = OptimizeRequest.model_construct(requirements=[], client_id=1)
     with pytest.raises(ValidationError):
-        OptimizationService(db_session).execute(request)
+        OptimizationService(db_session).compute(request)
 
 
-def test_service_get_or_404(db_session):
+def test_service_cached_payload_404(db_session):
     with pytest.raises(EntityNotFoundError):
-        OptimizationService(db_session).get_or_404(123456)
+        OptimizationService(db_session).get_cached_payload("nope")
 
 
 def test_optimize_deduplicates_identical_patterns(client):

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -172,3 +172,71 @@ def test_list_orders_filter_by_status(client):
 
 def test_get_order_404(client):
     assert client.get("/api/v1/orders/999999").status_code == 404
+
+
+def test_order_proforma_pdf_and_base64(client):
+    c = _create_client(client)
+    b = _create_board(client)
+    order = client.post("/api/v1/orders/", json=_order_payload(c["id"], b["id"])).json()
+    oid = order["id"]
+
+    pdf = client.get(f"/api/v1/orders/{oid}/proforma")
+    assert pdf.status_code == 200
+    assert pdf.headers["content-type"] == "application/pdf"
+    assert len(pdf.content) > 1000
+
+    b64 = client.get(f"/api/v1/orders/{oid}/proforma", params={"format": "base64"})
+    assert b64.status_code == 200
+    body = b64.json()
+    assert body["format"] == "base64"
+    assert body["mimeType"] == "application/pdf"
+    assert order["code"] in body["filename"]
+
+
+def test_order_production_sheet_pdf(client):
+    c = _create_client(client)
+    b = _create_board(client)
+    order = client.post("/api/v1/orders/", json=_order_payload(c["id"], b["id"])).json()
+
+    sheet = client.get(f"/api/v1/orders/{order['id']}/production-sheet")
+    assert sheet.status_code == 200
+    assert sheet.headers["content-type"] == "application/pdf"
+    assert len(sheet.content) > 1000
+
+
+def test_order_documents_404(client):
+    assert client.get("/api/v1/orders/999999/proforma").status_code == 404
+    assert client.get("/api/v1/orders/999999/production-sheet").status_code == 404
+
+
+def test_order_expires_lazily_on_read(client, monkeypatch):
+    """Una orden vencida se transiciona a ``expired`` al leerla (barrido perezoso)."""
+    monkeypatch.setattr(config, "ORDER_VALIDITY_DAYS", -1)
+    c = _create_client(client)
+    b = _create_board(client)
+    order = client.post("/api/v1/orders/", json=_order_payload(c["id"], b["id"])).json()
+    # Nace confirmed, pero su vigencia ya está vencida (expiresAt en el pasado).
+    assert order["status"] == "confirmed"
+
+    fetched = client.get(f"/api/v1/orders/{order['id']}").json()
+    assert fetched["status"] == "expired"
+    assert fetched["history"][-1]["toStatus"] == "expired"
+    assert fetched["history"][-1]["fromStatus"] == "confirmed"
+
+
+def test_expired_order_frees_pending_cap(client, monkeypatch):
+    """Las pendientes vencidas no cuentan para el tope: se expiran al evaluarlo."""
+    monkeypatch.setattr(config, "MAX_PENDING_ORDERS_PER_CLIENT", 1)
+    monkeypatch.setattr(config, "ORDER_VALIDITY_DAYS", -1)
+    c = _create_client(client)
+    b = _create_board(client)
+
+    first = client.post(
+        "/api/v1/orders/", json=_order_payload(c["id"], b["id"], width=600)
+    )
+    assert first.status_code == 201
+    # La primera está vencida; la segunda (distinto hash) no choca con el tope.
+    second = client.post(
+        "/api/v1/orders/", json=_order_payload(c["id"], b["id"], width=500)
+    )
+    assert second.status_code == 201


### PR DESCRIPTION
    Add a duck-typed ProformaCarrier to render the proforma and a new
    price-free production sheet from an order snapshot or a cached
    optimization, exposed via GET /orders/{id}/proforma, /production-sheet
    and GET /optimize/{hash}/proforma. Retire the optimizations dual-write
    (the hash is now the identifier) and expire orders lazily on read.