### PR TITLE
feat: order billing seam (invoice + export)

### DIFF
--- a/src/modules/clients/model.py
+++ b/src/modules/clients/model.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from sqlalchemy import String
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column
 
 from src.shared.database import Base
 
@@ -16,7 +16,3 @@ class ClientModel(Base):
     first_name: Mapped[Optional[str]] = mapped_column(String(64))
     last_name: Mapped[Optional[str]] = mapped_column(String(64))
     source: Mapped[Optional[str]] = mapped_column(String(64))
-
-    optimizations: Mapped[list["OptimizationModel"]] = relationship(  # noqa: F821
-        "OptimizationModel", back_populates="client"
-    )

--- a/src/modules/optimizations/model.py
+++ b/src/modules/optimizations/model.py
@@ -2,13 +2,15 @@ from datetime import datetime
 from typing import Optional
 
 from sqlalchemy import JSON, DateTime, Float, ForeignKey, Integer, String
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column
 
 from src.shared.database import Base
 
 
 class OptimizationModel(Base):
-    """Modelo ORM para optimizaciones"""
+    """Modelo ORM de la tabla ``optimizations`` (conservada, pero ya sin escrituras:
+    las optimizaciones son cache-only desde S2). Sin relación ORM hacia ``clients``:
+    el cómputo es efímero y la orden es la raíz durable."""
 
     __tablename__ = "optimizations"
 
@@ -23,7 +25,3 @@ class OptimizationModel(Base):
 
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     client_id: Mapped[int] = mapped_column(ForeignKey("clients.id"))
-
-    client: Mapped["ClientModel"] = relationship(  # noqa: F821
-        "ClientModel", back_populates="optimizations"
-    )

--- a/src/modules/orders/router.py
+++ b/src/modules/orders/router.py
@@ -5,7 +5,13 @@ from fastapi import APIRouter, Depends, Query
 from src.modules.optimizations.carrier import ProformaCarrier
 from src.modules.optimizations.proforma import ProformaService, pdf_response
 from src.modules.orders.model import OrderStatus
-from src.modules.orders.schemas import OrderCreate, OrderResponse, OrderStatusUpdate
+from src.modules.orders.schemas import (
+    OrderCreate,
+    OrderExportResponse,
+    OrderInvoiceUpdate,
+    OrderResponse,
+    OrderStatusUpdate,
+)
 from src.modules.orders.service import OrderService, order_service
 
 router = APIRouter(prefix="/orders", tags=["orders"])
@@ -52,6 +58,22 @@ def update_order_status(
 ):
     """Transiciona el estado de una orden validando la máquina de estados."""
     return svc.transition(order_id, data.status, actor="sales", note=data.note)
+
+
+@router.post("/{order_id}/invoice", response_model=OrderResponse)
+def set_order_invoice(
+    order_id: int,
+    data: OrderInvoiceUpdate,
+    svc: OrderService = Depends(order_service),
+):
+    """Asocia el ID de la factura externa (costura con el proveedor de facturación)."""
+    return svc.set_external_invoice_id(order_id, data.external_invoice_id)
+
+
+@router.get("/{order_id}/export", response_model=OrderExportResponse)
+def export_order(order_id: int, svc: OrderService = Depends(order_service)):
+    """Documento de facturación neutral para el proveedor externo (cobro=tableros)."""
+    return svc.build_export(order_id)
 
 
 @router.get("/{order_id}/proforma")

--- a/src/modules/orders/schemas.py
+++ b/src/modules/orders/schemas.py
@@ -27,6 +27,41 @@ class OrderStatusUpdate(CamelModel):
     note: Optional[str] = Field(default=None, max_length=512)
 
 
+class OrderInvoiceUpdate(CamelModel):
+    """Asocia el ID de la factura emitida por el proveedor externo de facturación."""
+
+    external_invoice_id: str = Field(
+        ...,
+        min_length=1,
+        max_length=64,
+        description="Invoice ID assigned by the external billing provider",
+    )
+
+
+class OrderExportLine(CamelModel):
+    """Línea de factura para el proveedor externo (cobro por tablero)."""
+
+    description: str = Field(..., description="Human-readable line description")
+    board_code: Optional[str] = None
+    quantity: int = Field(..., description="Number of boards charged")
+    unit_price: float
+    line_total: float
+
+
+class OrderExportResponse(CamelModel):
+    """Documento de facturación neutral: lo consume el proveedor de facturación."""
+
+    order_code: Optional[str] = None
+    status: OrderStatus
+    issued_at: datetime = Field(..., description="When the order was frozen/confirmed")
+    currency: str
+    client: ClientResponse
+    lines: List[OrderExportLine]
+    subtotal: float
+    total: float
+    external_invoice_id: Optional[str] = None
+
+
 class OrderLineResponse(CamelModel):
     id: int
     board_id: int

--- a/src/modules/orders/service.py
+++ b/src/modules/orders/service.py
@@ -16,10 +16,10 @@ from src.modules.orders.model import (
     OrderStatus,
     OrderStatusHistoryModel,
 )
-from src.modules.orders.schemas import OrderCreate
+from src.modules.orders.schemas import OrderCreate, OrderExportLine, OrderExportResponse
 from src.shared.config import config
 from src.shared.database import get_db
-from src.shared.exceptions import BusinessRuleError, EntityNotFoundError
+from src.shared.exceptions import BusinessRuleError, ConflictError, EntityNotFoundError
 
 
 class OrderService:
@@ -158,6 +158,53 @@ class OrderService:
         self.db.refresh(order)
         return order
 
+    def set_external_invoice_id(
+        self, order_id: int, external_invoice_id: str
+    ) -> OrderModel:
+        """Asocia (costura de facturación) el ID de la factura externa a la orden.
+
+        Idempotente con el mismo ID; si ya hay otro asociado lanza ``ConflictError``
+        para no pisar una factura ya emitida.
+        """
+        order = self.get_or_404(order_id)
+        if (
+            order.external_invoice_id is not None
+            and order.external_invoice_id != external_invoice_id
+        ):
+            raise ConflictError(
+                "La orden ya tiene una factura externa asociada "
+                f"({order.external_invoice_id})"
+            )
+        order.external_invoice_id = external_invoice_id
+        self.db.commit()
+        self.db.refresh(order)
+        return order
+
+    def build_export(self, order_id: int) -> OrderExportResponse:
+        """Proyecta la orden como documento de facturación neutral (cobro=tableros)."""
+        order = self.get_or_404(order_id)
+        lines = [
+            OrderExportLine(
+                description=_line_description(line),
+                board_code=line.board_code,
+                quantity=line.quantity,
+                unit_price=line.unit_price_snapshot,
+                line_total=line.line_total,
+            )
+            for line in order.lines
+        ]
+        return OrderExportResponse(
+            order_code=order.code,
+            status=OrderStatus(order.status),
+            issued_at=order.confirmed_at or order.created_at,
+            currency=order.currency,
+            client=order.client,
+            lines=lines,
+            subtotal=order.subtotal,
+            total=order.total,
+            external_invoice_id=order.external_invoice_id,
+        )
+
     def _expire_if_stale(self, order: OrderModel) -> bool:
         """Marca como ``expired`` una orden pendiente cuya vigencia ya venció.
 
@@ -225,6 +272,13 @@ class OrderService:
                 f"El cliente ya tiene {active} pedido(s) pendiente(s); "
                 "resuélvalos o espere a que expiren antes de crear otro."
             )
+
+
+def _line_description(line: OrderLineModel) -> str:
+    """Descripción legible de una línea de cobro para la factura externa."""
+    if line.board_code and line.board_name:
+        return f"{line.board_name} ({line.board_code})"
+    return line.board_name or line.board_code or f"Tablero {line.board_id}"
 
 
 def order_service(db: Session = Depends(get_db)) -> OrderService:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,8 +1,36 @@
+import os
+import subprocess
+import sys
+
 from fastapi.testclient import TestClient
 
 from main import app
 
 client = TestClient(app)
+
+
+def test_app_mappers_configure_without_extra_model_imports():
+    """Regresión: la app debe configurar los mappers de SQLAlchemy solo con los
+    modelos que importa ``main`` (vía routers). No debe depender de que algo más
+    importe ``optimizations.model``.
+
+    Se corre en un subproceso aislado porque ``conftest`` importa TODOS los modelos
+    y enmascararía el problema: el 500 ``failed to locate 'OptimizationModel'`` solo
+    aparecía en el runtime real de la app (p. ej. ``GET /clients/identifier/...``).
+    """
+    code = (
+        "import main; "
+        "from sqlalchemy.orm import configure_mappers; "
+        "configure_mappers()"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        env={**os.environ, "ENVIRONMENT": "local"},
+    )
+    assert result.returncode == 0, result.stderr
 
 
 def test_root_redirect():

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -209,6 +209,82 @@ def test_order_documents_404(client):
     assert client.get("/api/v1/orders/999999/production-sheet").status_code == 404
 
 
+def test_order_export_document(client):
+    c = _create_client(client)
+    b = _create_board(client)
+    order = client.post("/api/v1/orders/", json=_order_payload(c["id"], b["id"])).json()
+
+    resp = client.get(f"/api/v1/orders/{order['id']}/export")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert data["orderCode"] == order["code"]
+    assert data["status"] == "confirmed"
+    assert data["client"]["id"] == c["id"]
+    assert data["currency"] == "USD"
+    assert data["issuedAt"] is not None
+    assert data["externalInvoiceId"] is None
+
+    # Cobro por tablero: una línea con descripción legible y el código.
+    assert len(data["lines"]) == 1
+    line = data["lines"][0]
+    assert line["boardCode"] == "MEL18"
+    assert "MEL18" in line["description"]
+    assert line["quantity"] == order["totalBoardsUsed"]
+    assert line["unitPrice"] == 45.5
+    assert line["lineTotal"] == line["quantity"] * 45.5
+    assert data["subtotal"] == data["total"] == line["lineTotal"]
+
+
+def test_set_external_invoice_id_and_reflect_in_export(client):
+    c = _create_client(client)
+    b = _create_board(client)
+    order = client.post("/api/v1/orders/", json=_order_payload(c["id"], b["id"])).json()
+    oid = order["id"]
+
+    resp = client.post(
+        f"/api/v1/orders/{oid}/invoice", json={"externalInvoiceId": "FAC-001-42"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["externalInvoiceId"] == "FAC-001-42"
+
+    # Idempotente con el mismo ID.
+    again = client.post(
+        f"/api/v1/orders/{oid}/invoice", json={"externalInvoiceId": "FAC-001-42"}
+    )
+    assert again.status_code == 200
+
+    # El export refleja la factura asociada.
+    exported = client.get(f"/api/v1/orders/{oid}/export").json()
+    assert exported["externalInvoiceId"] == "FAC-001-42"
+
+
+def test_set_external_invoice_id_conflict_on_different_id(client):
+    c = _create_client(client)
+    b = _create_board(client)
+    order = client.post("/api/v1/orders/", json=_order_payload(c["id"], b["id"])).json()
+    oid = order["id"]
+
+    client.post(
+        f"/api/v1/orders/{oid}/invoice", json={"externalInvoiceId": "FAC-001-42"}
+    )
+    # Otro ID sobre una orden ya facturada → 409 (no pisa la factura emitida).
+    conflict = client.post(
+        f"/api/v1/orders/{oid}/invoice", json={"externalInvoiceId": "FAC-999-00"}
+    )
+    assert conflict.status_code == 409
+
+
+def test_billing_seam_404(client):
+    assert client.get("/api/v1/orders/999999/export").status_code == 404
+    assert (
+        client.post(
+            "/api/v1/orders/999999/invoice", json={"externalInvoiceId": "X"}
+        ).status_code
+        == 404
+    )
+
+
 def test_order_expires_lazily_on_read(client, monkeypatch):
     """Una orden vencida se transiciona a ``expired`` al leerla (barrido perezoso)."""
     monkeypatch.setattr(config, "ORDER_VALIDITY_DAYS", -1)


### PR DESCRIPTION
    - POST /orders/{id}/invoice records external_invoice_id (409 on conflict)
    - GET /orders/{id}/export emits a provider-neutral invoice document
    - fix: drop dead ClientModel<->OptimizationModel relationship that 500'd client queries now that optimizations are cache-only