### PR TITLE
feat: make optimize client-agnostic for lazy client resolution

### DIFF
--- a/src/modules/clients/router.py
+++ b/src/modules/clients/router.py
@@ -15,6 +15,16 @@ def create_client(data: ClientCreate, svc: ClientService = Depends(client_servic
     return svc.create(data)
 
 
+@router.post("/resolve", response_model=ClientResponse)
+def resolve_client(data: ClientCreate, svc: ClientService = Depends(client_service)):
+    """Obtiene el cliente por identificador o lo crea (idempotente).
+
+    Pensado para el bot: resuelve al cliente justo antes de una acción comercial
+    (proforma u orden) en una sola llamada, sin GET + POST condicional.
+    """
+    return svc.resolve(data)
+
+
 @router.get("/", response_model=List[ClientResponse])
 def list_clients(
     skip: int = Query(0, ge=0, description="Number of records to skip"),

--- a/src/modules/clients/service.py
+++ b/src/modules/clients/service.py
@@ -7,6 +7,7 @@ from src.modules.clients.model import ClientModel
 from src.modules.clients.schemas import ClientCreate, ClientUpdate
 from src.shared.crud import CRUDService
 from src.shared.database import get_db
+from src.shared.exceptions import ConflictError
 
 
 class ClientService(CRUDService[ClientModel, ClientCreate, ClientUpdate]):
@@ -22,6 +23,25 @@ class ClientService(CRUDService[ClientModel, ClientCreate, ClientUpdate]):
             .filter(ClientModel.identifier == identifier)
             .first()
         )
+
+    def resolve(self, data: ClientCreate) -> ClientModel:
+        """Obtiene el cliente por ``identifier`` o lo crea (idempotente).
+
+        Resolución perezosa para el bot: el cliente solo se materializa cuando hay
+        una acción comercial. Seguro ante carreras —dos mensajes casi simultáneos
+        del mismo usuario— porque el unique de ``identifier`` hace fallar la segunda
+        creación; se captura el conflicto y se re-lee el cliente ya creado.
+        """
+        existing = self.get_by_identifier(data.identifier)
+        if existing is not None:
+            return existing
+        try:
+            return self.create(data)
+        except ConflictError:
+            client = self.get_by_identifier(data.identifier)
+            if client is None:
+                raise
+            return client
 
     def search(self, search: str, skip: int = 0, limit: int = 100) -> List[ClientModel]:
         """Busca clientes por identificador, nombre o apellido."""

--- a/src/modules/optimizations/router.py
+++ b/src/modules/optimizations/router.py
@@ -19,6 +19,9 @@ def optimize(
 @router.get("/{optimization_hash}/proforma")
 def get_proforma(
     optimization_hash: str,
+    client_id: int = Query(
+        ..., alias="clientId", description="Cliente para el encabezado de la proforma"
+    ),
     format: str = Query(
         default="pdf",
         description="Formato de salida: 'pdf' (archivo) o 'base64' (JSON)",
@@ -27,6 +30,6 @@ def get_proforma(
     svc: OptimizationService = Depends(optimization_service),
 ):
     """Genera la proforma PDF de una optimización cacheada (por hash)."""
-    carrier = svc.build_carrier_from_hash(optimization_hash)
+    carrier = svc.build_carrier_from_hash(optimization_hash, client_id)
     pdf_buffer = ProformaService.generate_proforma_pdf(carrier)
     return pdf_response(pdf_buffer, f"proforma_{optimization_hash[:8]}.pdf", format)

--- a/src/modules/optimizations/schemas.py
+++ b/src/modules/optimizations/schemas.py
@@ -46,7 +46,14 @@ class OptimizeRequest(CamelModel):
     requirements: List[Requirement] = Field(
         ..., min_length=1, description="List of cuts to optimize"
     )
-    client_id: int = Field(..., description="Client ID for the optimization")
+    client_id: Optional[int] = Field(
+        default=None,
+        description=(
+            "Optional client ID. The optimization is client-agnostic (the result "
+            "and its hash do not depend on the client); only proformas and orders "
+            "require a client, resolved at that point."
+        ),
+    )
 
 
 class Material(CamelModel):
@@ -121,7 +128,9 @@ class OptimizeResponse(CamelModel):
         default=None,
         description="Deprecated: optimizations are no longer persisted; use the hash",
     )
-    client: ClientResponse = Field(..., description="Client information")
+    client: Optional[ClientResponse] = Field(
+        default=None, description="Client information (only when a client_id is sent)"
+    )
     optimization_hash: Optional[str] = Field(
         default=None, description="Deterministic hash of the optimization inputs"
     )

--- a/src/modules/optimizations/service.py
+++ b/src/modules/optimizations/service.py
@@ -43,11 +43,17 @@ class OptimizationService:
         self.board_service = BoardService(db)
 
     def optimize_response(self, request: OptimizeRequest) -> OptimizeResponse:
-        """Calcula (cache-first) y arma la respuesta del endpoint ``POST /optimize``."""
+        """Calcula (cache-first) y arma la respuesta del endpoint ``POST /optimize``.
+
+        El cómputo es agnóstico del cliente: solo se resuelve (y valida) el cliente
+        cuando la petición trae ``client_id``. Sin él, la respuesta es anónima.
+        """
         payload, optimization_hash = self.compute(request)
-        client = self.db.get(ClientModel, payload["client_id"])
-        if client is None:
-            raise EntityNotFoundError("Client", payload["client_id"])
+        client = None
+        if request.client_id is not None:
+            client = self.db.get(ClientModel, request.client_id)
+            if client is None:
+                raise EntityNotFoundError("Client", request.client_id)
         return OptimizeResponse(
             id=None,
             client=client,
@@ -66,12 +72,18 @@ class OptimizationService:
             raise EntityNotFoundError("Optimization", optimization_hash)
         return payload
 
-    def build_carrier_from_hash(self, optimization_hash: str) -> ProformaCarrier:
-        """Portador de proforma para una optimización cacheada (por hash)."""
+    def build_carrier_from_hash(
+        self, optimization_hash: str, client_id: int
+    ) -> ProformaCarrier:
+        """Portador de proforma para una optimización cacheada (por hash).
+
+        La optimización es anónima; el cliente se aporta al renderizar (la proforma
+        necesita sus datos para el encabezado del documento).
+        """
         payload = self.get_cached_payload(optimization_hash)
-        client = self.db.get(ClientModel, payload["client_id"])
+        client = self.db.get(ClientModel, client_id)
         if client is None:
-            raise EntityNotFoundError("Client", payload["client_id"])
+            raise EntityNotFoundError("Client", client_id)
         return ProformaCarrier.from_payload(
             payload, client, reference=f"OPT-{optimization_hash[:8]}"
         )
@@ -279,7 +291,6 @@ class OptimizationService:
                 board_results, board_codes, board_names
             ),
             "layout_groups": group_layouts(layout_dicts),
-            "client_id": request.client_id,
         }
 
 

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -31,6 +31,29 @@ def test_get_missing_client_returns_404(client):
     assert "no encontrado" in resp.json()["detail"]
 
 
+def test_resolve_creates_then_is_idempotent(client):
+    """``POST /clients/resolve`` crea la primera vez y luego devuelve el mismo id."""
+    first = client.post("/api/v1/clients/resolve", json=_payload())
+    assert first.status_code == 200
+    created = first.json()
+    assert created["identifier"] == "0991112233"
+
+    second = client.post("/api/v1/clients/resolve", json=_payload(first="Ignored"))
+    assert second.status_code == 200
+    assert second.json()["id"] == created["id"]
+    # No se duplica ni se sobrescribe el cliente existente.
+    assert second.json()["firstName"] == "Ada"
+    assert len(client.get("/api/v1/clients/").json()) == 1
+
+
+def test_resolve_returns_existing_created_client(client):
+    """Si el cliente ya existe (creado por POST /clients), resolve lo reutiliza."""
+    created = client.post("/api/v1/clients/", json=_payload()).json()
+    resolved = client.post("/api/v1/clients/resolve", json=_payload())
+    assert resolved.status_code == 200
+    assert resolved.json()["id"] == created["id"]
+
+
 def test_list_and_search_clients(client):
     client.post(
         "/api/v1/clients/", json=_payload(identifier="0990000001", first="Grace")

--- a/tests/test_optimizations.py
+++ b/tests/test_optimizations.py
@@ -115,13 +115,17 @@ def test_proforma_pdf_and_base64(client):
     ).json()
     opt_hash = optimization["optimizationHash"]
 
-    pdf = client.get(f"/api/v1/optimize/{opt_hash}/proforma")
+    pdf = client.get(
+        f"/api/v1/optimize/{opt_hash}/proforma",
+        params={"clientId": created_client["id"]},
+    )
     assert pdf.status_code == 200
     assert pdf.headers["content-type"] == "application/pdf"
     assert len(pdf.content) > 1000
 
     b64 = client.get(
-        f"/api/v1/optimize/{opt_hash}/proforma", params={"format": "base64"}
+        f"/api/v1/optimize/{opt_hash}/proforma",
+        params={"clientId": created_client["id"], "format": "base64"},
     )
     assert b64.status_code == 200
     body = b64.json()
@@ -132,7 +136,45 @@ def test_proforma_pdf_and_base64(client):
 
 def test_proforma_missing_optimization_returns_404(client):
     """Un hash que no está en caché (expiró o nunca existió) responde 404."""
-    assert client.get(f"/api/v1/optimize/{'0' * 64}/proforma").status_code == 404
+    resp = client.get(f"/api/v1/optimize/{'0' * 64}/proforma", params={"clientId": 1})
+    assert resp.status_code == 404
+
+
+def test_proforma_requires_client_id(client):
+    """La proforma exige ``clientId`` (la optimización es anónima)."""
+    assert client.get(f"/api/v1/optimize/{'0' * 64}/proforma").status_code == 422
+
+
+def test_optimize_without_client_is_anonymous(client):
+    """``POST /optimize`` sin ``clientId`` responde 200 con ``client`` nulo y el
+    mismo hash que con cliente (el cómputo es agnóstico del cliente)."""
+    created_client = _create_client(client)
+    created_board = _create_board(client)
+
+    with_client = client.post(
+        "/api/v1/optimize/",
+        json=_optimize_payload(created_client["id"], created_board["id"]),
+    ).json()
+
+    anon_payload = _optimize_payload(created_client["id"], created_board["id"])
+    anon_payload.pop("clientId")
+    anon = client.post("/api/v1/optimize/", json=anon_payload)
+
+    assert anon.status_code == 200
+    data = anon.json()
+    assert data["client"] is None
+    assert data["optimizationHash"] == with_client["optimizationHash"]
+
+
+def test_optimize_unknown_client_returns_404(client):
+    """Si se envía un ``clientId`` inexistente, la respuesta es 404."""
+    created_board = _create_board(client)
+    resp = client.post(
+        "/api/v1/optimize/",
+        json=_optimize_payload(client_id=99999, board_id=created_board["id"]),
+    )
+    assert resp.status_code == 404
+    assert "Client 99999" in resp.json()["detail"]
 
 
 def test_optimize_does_not_persist(client, db_session):


### PR DESCRIPTION
    The cutting result and its hash never depended on the client, so drop
    the artificial client_id requirement from POST /optimize: it's now
    optional and the cached payload no longer stores it. Proformas take
    clientId at render time (GET /optimize/{hash}/proforma?clientId=...),
    and clients gain an idempotent POST /clients/resolve (get-or-create).

    This lets the Telegram bot keep the whole quoting phase anonymous and
    resolve the client only on a commercial action (proforma or order).