### PR TITLE
feat: require client phone before proforma/order

### DIFF
--- a/alembic/versions/f6a7b8c9d0e1_add_phone_email_to_clients.py
+++ b/alembic/versions/f6a7b8c9d0e1_add_phone_email_to_clients.py
@@ -1,0 +1,29 @@
+"""add phone and email to clients
+
+Revision ID: f6a7b8c9d0e1
+Revises: e5f6a7b8c9d0
+Create Date: 2026-06-03 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "f6a7b8c9d0e1"
+down_revision: Union[str, None] = "e5f6a7b8c9d0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Nullable: el cliente se crea perezosamente (resolve) antes de conocerse el
+    # celular; la obligatoriedad es regla de negocio al generar proforma/orden.
+    op.add_column("clients", sa.Column("phone", sa.String(length=32), nullable=True))
+    op.add_column("clients", sa.Column("email", sa.String(length=128), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("clients", "email")
+    op.drop_column("clients", "phone")

--- a/src/modules/clients/model.py
+++ b/src/modules/clients/model.py
@@ -16,3 +16,8 @@ class ClientModel(Base):
     first_name: Mapped[Optional[str]] = mapped_column(String(64))
     last_name: Mapped[Optional[str]] = mapped_column(String(64))
     source: Mapped[Optional[str]] = mapped_column(String(64))
+    # Celular y email: nullable porque el cliente se crea perezosamente (resolve) antes
+    # de conocerse. Exigir el celular es una regla de negocio al generar proforma/orden,
+    # no un constraint de creación.
+    phone: Mapped[Optional[str]] = mapped_column(String(32))
+    email: Mapped[Optional[str]] = mapped_column(String(128))

--- a/src/modules/clients/schemas.py
+++ b/src/modules/clients/schemas.py
@@ -18,6 +18,12 @@ class ClientBase(CamelModel):
     source: Optional[str] = Field(
         None, max_length=64, description="Client source (e.g. instagram, referral)"
     )
+    phone: Optional[str] = Field(
+        None, max_length=32, description="Client mobile phone (celular)"
+    )
+    email: Optional[str] = Field(
+        None, max_length=128, description="Client email (optional)"
+    )
 
 
 class ClientCreate(ClientBase):
@@ -38,6 +44,12 @@ class ClientUpdate(CamelModel):
     )
     source: Optional[str] = Field(
         None, max_length=64, description="Client source (e.g. instagram, referral)"
+    )
+    phone: Optional[str] = Field(
+        None, max_length=32, description="Client mobile phone (celular)"
+    )
+    email: Optional[str] = Field(
+        None, max_length=128, description="Client email (optional)"
     )
 
 

--- a/src/modules/clients/service.py
+++ b/src/modules/clients/service.py
@@ -7,7 +7,20 @@ from src.modules.clients.model import ClientModel
 from src.modules.clients.schemas import ClientCreate, ClientUpdate
 from src.shared.crud import CRUDService
 from src.shared.database import get_db
-from src.shared.exceptions import ConflictError
+from src.shared.exceptions import BusinessRuleError, ConflictError
+
+
+def require_phone(client: ClientModel) -> None:
+    """Exige un celular registrado antes de emitir documentos comerciales.
+
+    Regla de negocio dura: ni la proforma ni la orden pueden generarse sin un
+    número de celular válido. El email es opcional y nunca bloquea.
+    """
+    if not (client.phone and client.phone.strip()):
+        raise BusinessRuleError(
+            "El cliente no tiene un número de celular registrado. Solicita y "
+            "registra su celular antes de generar la proforma o el pedido."
+        )
 
 
 class ClientService(CRUDService[ClientModel, ClientCreate, ClientUpdate]):

--- a/src/modules/optimizations/proforma.py
+++ b/src/modules/optimizations/proforma.py
@@ -359,9 +359,11 @@ class ProformaService:
         )
         client_data = [
             ["Nombre:", client_name],
-            ["Identificador:", client.identifier or "N/A"],
-            ["ID Cliente:", str(client.id)],
+            ["Celular:", getattr(client, "phone", None) or "N/A"],
         ]
+        if getattr(client, "email", None):
+            client_data.append(["Email:", client.email])
+        client_data.append(["ID Cliente:", str(client.id)])
         client_table = Table(
             client_data, colWidths=[1.5 * inch, CONTENT_WIDTH - 1.5 * inch]
         )

--- a/src/modules/optimizations/service.py
+++ b/src/modules/optimizations/service.py
@@ -17,6 +17,7 @@ from src.cutting import (
 from src.modules.boards.model import BoardModel
 from src.modules.boards.service import BoardService
 from src.modules.clients.model import ClientModel
+from src.modules.clients.service import require_phone
 from src.modules.optimizations.carrier import ProformaCarrier
 from src.modules.optimizations.patterns import group_layouts
 from src.modules.optimizations.schemas import (
@@ -84,6 +85,7 @@ class OptimizationService:
         client = self.db.get(ClientModel, client_id)
         if client is None:
             raise EntityNotFoundError("Client", client_id)
+        require_phone(client)
         return ProformaCarrier.from_payload(
             payload, client, reference=f"OPT-{optimization_hash[:8]}"
         )

--- a/src/modules/orders/service.py
+++ b/src/modules/orders/service.py
@@ -4,6 +4,8 @@ from typing import List, Optional
 from fastapi import Depends
 from sqlalchemy.orm import Session
 
+from src.modules.clients.model import ClientModel
+from src.modules.clients.service import require_phone
 from src.modules.optimizations.schemas import OptimizeRequest
 from src.modules.optimizations.service import OptimizationService
 from src.modules.orders.model import (
@@ -61,6 +63,13 @@ class OrderService:
 
         Idempotente: un re-POST idéntico devuelve la orden activa existente.
         """
+        # Regla de negocio: el cliente debe existir y tener un celular registrado
+        # antes de congelar cualquier pedido (también bloquea re-POST sin celular).
+        client = self.db.get(ClientModel, data.client_id)
+        if client is None:
+            raise EntityNotFoundError("Client", data.client_id)
+        require_phone(client)
+
         opt_request = OptimizeRequest(
             requirements=data.requirements, client_id=data.client_id
         )

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -90,6 +90,31 @@ def test_update_client(client):
     assert resp.json()["lastName"] == "Lovelace"
 
 
+def test_create_client_stores_phone_and_email(client):
+    """``phone`` y ``email`` se almacenan y se devuelven (email opcional)."""
+    payload = {**_payload(), "phone": "0991112233", "email": "ada@example.com"}
+    created = client.post("/api/v1/clients/", json=payload).json()
+    assert created["phone"] == "0991112233"
+    assert created["email"] == "ada@example.com"
+
+
+def test_client_phone_and_email_are_optional_on_create(client):
+    """Sin ``phone``/``email`` el cliente se crea igual (regla se aplica al cotizar)."""
+    created = client.post("/api/v1/clients/", json=_payload()).json()
+    assert created["phone"] is None
+    assert created["email"] is None
+
+
+def test_update_client_phone(client):
+    """``PUT`` permite registrar el celular más tarde (lo usa el bot tras compartir)."""
+    created = client.post("/api/v1/clients/", json=_payload()).json()
+    resp = client.put(f"/api/v1/clients/{created['id']}", json={"phone": "0987654321"})
+    assert resp.status_code == 200
+    assert resp.json()["phone"] == "0987654321"
+    # No pisa el resto de campos.
+    assert resp.json()["firstName"] == "Ada"
+
+
 def test_update_missing_client_returns_404(client):
     resp = client.put("/api/v1/clients/999999", json={"firstName": "Nobody"})
     assert resp.status_code == 404

--- a/tests/test_optimizations.py
+++ b/tests/test_optimizations.py
@@ -10,7 +10,12 @@ from src.shared.exceptions import EntityNotFoundError, ValidationError
 def _create_client(client):
     return client.post(
         "/api/v1/clients/",
-        json={"identifier": "0991112233", "firstName": "Ada", "lastName": "Lovelace"},
+        json={
+            "identifier": "0991112233",
+            "firstName": "Ada",
+            "lastName": "Lovelace",
+            "phone": "0991112233",
+        },
     ).json()
 
 
@@ -143,6 +148,27 @@ def test_proforma_missing_optimization_returns_404(client):
 def test_proforma_requires_client_id(client):
     """La proforma exige ``clientId`` (la optimización es anónima)."""
     assert client.get(f"/api/v1/optimize/{'0' * 64}/proforma").status_code == 422
+
+
+def test_proforma_blocked_without_client_phone(client):
+    """Regla de negocio: sin celular registrado no se genera la proforma (422)."""
+    created_board = _create_board(client)
+    no_phone = client.post(
+        "/api/v1/clients/",
+        json={"identifier": "0990000000", "firstName": "Sin", "lastName": "Tel"},
+    ).json()
+    optimization = client.post(
+        "/api/v1/optimize/",
+        json=_optimize_payload(no_phone["id"], created_board["id"]),
+    ).json()
+    opt_hash = optimization["optimizationHash"]
+
+    resp = client.get(
+        f"/api/v1/optimize/{opt_hash}/proforma",
+        params={"clientId": no_phone["id"]},
+    )
+    assert resp.status_code == 422
+    assert "celular" in resp.json()["detail"].lower()
 
 
 def test_optimize_without_client_is_anonymous(client):

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -5,10 +5,15 @@ from datetime import datetime
 from src.shared.config import config
 
 
-def _create_client(client, identifier="0991112233"):
+def _create_client(client, identifier="0991112233", phone="0991112233"):
     return client.post(
         "/api/v1/clients/",
-        json={"identifier": identifier, "firstName": "Ada", "lastName": "Lovelace"},
+        json={
+            "identifier": identifier,
+            "firstName": "Ada",
+            "lastName": "Lovelace",
+            "phone": phone,
+        },
     ).json()
 
 
@@ -75,6 +80,29 @@ def test_create_order_freezes_snapshot_and_charges_boards(client):
     # Historial inicial registra la creación.
     assert data["history"][0]["toStatus"] == "confirmed"
     assert data["history"][0]["fromStatus"] is None
+
+
+def test_create_order_blocked_without_client_phone(client):
+    """Regla de negocio: sin celular registrado no se crea el pedido (422)."""
+    b = _create_board(client)
+    no_phone = client.post(
+        "/api/v1/clients/",
+        json={"identifier": "0990000000", "firstName": "Sin", "lastName": "Tel"},
+    ).json()
+
+    resp = client.post("/api/v1/orders/", json=_order_payload(no_phone["id"], b["id"]))
+    assert resp.status_code == 422
+    assert "celular" in resp.json()["detail"].lower()
+    # No se persistió ninguna orden.
+    assert client.get("/api/v1/orders/").json() == []
+
+
+def test_create_order_unknown_client_returns_404(client):
+    """Un ``clientId`` inexistente da 404 limpio antes de congelar nada."""
+    b = _create_board(client)
+    resp = client.post("/api/v1/orders/", json=_order_payload(99999, b["id"]))
+    assert resp.status_code == 404
+    assert "Client 99999" in resp.json()["detail"]
 
 
 def test_create_order_is_idempotent(client):


### PR DESCRIPTION
    Add nullable phone/email to Client (migration f6a7b8c9d0e1) and a
    require_phone rule (422) enforced when generating a proforma and when
    creating an order. Render Celular/Email on the proforma PDF instead of
    the Telegram identifier. Email stays optional and never blocks.