### PR TITLE
feat: standardize HTTP responses and centralize error handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ from src.modules.orders.router import router as orders_router
 from src.modules.system.router import router as system_router
 from src.shared.config import config
 from src.shared.errors import register_exception_handlers
+from src.shared.middleware import RequestIDMiddleware
 
 # Configurar logging
 logging.basicConfig(
@@ -47,6 +48,9 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+# Correlación por request (requestId + header X-Request-ID). Se añade de último
+# para envolver al resto del stack y estar disponible en éxito y en error.
+app.add_middleware(RequestIDMiddleware)
 
 # Manejo centralizado de errores de aplicación
 register_exception_handlers(app)

--- a/src/modules/boards/router.py
+++ b/src/modules/boards/router.py
@@ -1,58 +1,63 @@
-from typing import List, Optional
+from typing import Optional
 
 from fastapi import APIRouter, Depends, Query
 
 from src.modules.boards.schemas import BoardCreate, BoardResponse, BoardUpdate
 from src.modules.boards.service import BoardService, board_service
 from src.shared.exceptions import EntityNotFoundError
+from src.shared.pagination import PageParams
+from src.shared.responses import (
+    ERROR_RESPONSES,
+    DataResponse,
+    PaginatedResponse,
+    ok,
+    page,
+)
 
-router = APIRouter(prefix="/boards", tags=["boards"])
+router = APIRouter(prefix="/boards", tags=["boards"], responses=ERROR_RESPONSES)
 
 
-@router.post("/", response_model=BoardResponse, status_code=201)
+@router.post("/", response_model=DataResponse[BoardResponse], status_code=201)
 def create_board(data: BoardCreate, svc: BoardService = Depends(board_service)):
     """Crea un nuevo tablero."""
-    return svc.create(data)
+    return ok(svc.create(data))
 
 
-@router.get("/", response_model=List[BoardResponse])
+@router.get("/", response_model=PaginatedResponse[BoardResponse])
 def list_boards(
-    skip: int = Query(0, ge=0, description="Number of records to skip"),
-    limit: int = Query(
-        100, ge=1, le=1000, description="Maximum number of records to return"
-    ),
-    search: Optional[str] = Query(
-        None, description="Search query for name, code, or description"
-    ),
+    paging: PageParams = Depends(),
+    search: Optional[str] = Query(None, description="Búsqueda por nombre o código"),
     svc: BoardService = Depends(board_service),
 ):
     """Lista tableros con búsqueda y paginación opcionales."""
     if search:
-        return svc.search(search, skip, limit)
-    return svc.list(skip, limit)
+        items, total = svc.search_paginated(search, paging.limit, paging.offset)
+    else:
+        items, total = svc.list_paginated(paging.limit, paging.offset)
+    return page(items, total, paging.limit, paging.offset)
 
 
-@router.get("/{board_id}", response_model=BoardResponse)
+@router.get("/{board_id}", response_model=DataResponse[BoardResponse])
 def get_board(board_id: int, svc: BoardService = Depends(board_service)):
     """Obtiene un tablero por ID."""
-    return svc.get_or_404(board_id)
+    return ok(svc.get_or_404(board_id))
 
 
-@router.get("/code/{code}", response_model=BoardResponse)
+@router.get("/code/{code}", response_model=DataResponse[BoardResponse])
 def get_board_by_code(code: str, svc: BoardService = Depends(board_service)):
     """Obtiene un tablero por código."""
     board = svc.get_by_code(code)
     if board is None:
         raise EntityNotFoundError("Board", code)
-    return board
+    return ok(board)
 
 
-@router.put("/{board_id}", response_model=BoardResponse)
+@router.put("/{board_id}", response_model=DataResponse[BoardResponse])
 def update_board(
     board_id: int, data: BoardUpdate, svc: BoardService = Depends(board_service)
 ):
     """Actualiza un tablero."""
-    return svc.update(board_id, data)
+    return ok(svc.update(board_id, data))
 
 
 @router.delete("/{board_id}", status_code=204)

--- a/src/modules/boards/service.py
+++ b/src/modules/boards/service.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from fastapi import Depends
 from sqlalchemy.orm import Session
@@ -22,16 +22,15 @@ class BoardService(CRUDService[BoardModel, BoardCreate, BoardUpdate]):
         """Obtiene un tablero por código."""
         return self.db.query(BoardModel).filter(BoardModel.code == code).first()
 
-    def search(self, search: str, skip: int = 0, limit: int = 100) -> List[BoardModel]:
-        """Busca tableros por código o nombre."""
+    def search_paginated(
+        self, search: str, limit: int = 20, offset: int = 0
+    ) -> Tuple[List[BoardModel], int]:
+        """Busca tableros por código o nombre; devuelve ``(items, total)``."""
         pattern = f"%{search}%"
-        return (
-            self.db.query(BoardModel)
-            .filter(BoardModel.code.ilike(pattern) | BoardModel.name.ilike(pattern))
-            .offset(skip)
-            .limit(limit)
-            .all()
+        query = self.db.query(BoardModel).filter(
+            BoardModel.code.ilike(pattern) | BoardModel.name.ilike(pattern)
         )
+        return self._paginate(query, limit, offset)
 
 
 def board_service(db: Session = Depends(get_db)) -> BoardService:

--- a/src/modules/clients/router.py
+++ b/src/modules/clients/router.py
@@ -1,54 +1,61 @@
-from typing import List, Optional
+from typing import Optional
 
 from fastapi import APIRouter, Depends, Query
 
 from src.modules.clients.schemas import ClientCreate, ClientResponse, ClientUpdate
 from src.modules.clients.service import ClientService, client_service
 from src.shared.exceptions import EntityNotFoundError
+from src.shared.pagination import PageParams
+from src.shared.responses import (
+    ERROR_RESPONSES,
+    DataResponse,
+    PaginatedResponse,
+    ok,
+    page,
+)
 
-router = APIRouter(prefix="/clients", tags=["clients"])
+router = APIRouter(prefix="/clients", tags=["clients"], responses=ERROR_RESPONSES)
 
 
-@router.post("/", response_model=ClientResponse, status_code=201)
+@router.post("/", response_model=DataResponse[ClientResponse], status_code=201)
 def create_client(data: ClientCreate, svc: ClientService = Depends(client_service)):
     """Crea un nuevo cliente."""
-    return svc.create(data)
+    return ok(svc.create(data))
 
 
-@router.post("/resolve", response_model=ClientResponse)
+@router.post("/resolve", response_model=DataResponse[ClientResponse])
 def resolve_client(data: ClientCreate, svc: ClientService = Depends(client_service)):
     """Obtiene el cliente por identificador o lo crea (idempotente).
 
     Pensado para el bot: resuelve al cliente justo antes de una acción comercial
     (proforma u orden) en una sola llamada, sin GET + POST condicional.
     """
-    return svc.resolve(data)
+    return ok(svc.resolve(data))
 
 
-@router.get("/", response_model=List[ClientResponse])
+@router.get("/", response_model=PaginatedResponse[ClientResponse])
 def list_clients(
-    skip: int = Query(0, ge=0, description="Number of records to skip"),
-    limit: int = Query(
-        100, ge=1, le=1000, description="Maximum number of records to return"
-    ),
+    paging: PageParams = Depends(),
     search: Optional[str] = Query(
-        None, description="Search query for identifier, first name, or last name"
+        None, description="Búsqueda por identificador, nombre o apellido"
     ),
     svc: ClientService = Depends(client_service),
 ):
     """Lista clientes con búsqueda y paginación opcionales."""
     if search:
-        return svc.search(search, skip, limit)
-    return svc.list(skip, limit)
+        items, total = svc.search_paginated(search, paging.limit, paging.offset)
+    else:
+        items, total = svc.list_paginated(paging.limit, paging.offset)
+    return page(items, total, paging.limit, paging.offset)
 
 
-@router.get("/{client_id}", response_model=ClientResponse)
+@router.get("/{client_id}", response_model=DataResponse[ClientResponse])
 def get_client(client_id: int, svc: ClientService = Depends(client_service)):
     """Obtiene un cliente por ID."""
-    return svc.get_or_404(client_id)
+    return ok(svc.get_or_404(client_id))
 
 
-@router.get("/identifier/{identifier}", response_model=ClientResponse)
+@router.get("/identifier/{identifier}", response_model=DataResponse[ClientResponse])
 def get_client_by_identifier(
     identifier: str, svc: ClientService = Depends(client_service)
 ):
@@ -56,15 +63,15 @@ def get_client_by_identifier(
     client = svc.get_by_identifier(identifier)
     if client is None:
         raise EntityNotFoundError("Client", identifier)
-    return client
+    return ok(client)
 
 
-@router.put("/{client_id}", response_model=ClientResponse)
+@router.put("/{client_id}", response_model=DataResponse[ClientResponse])
 def update_client(
     client_id: int, data: ClientUpdate, svc: ClientService = Depends(client_service)
 ):
     """Actualiza un cliente."""
-    return svc.update(client_id, data)
+    return ok(svc.update(client_id, data))
 
 
 @router.delete("/{client_id}", status_code=204)

--- a/src/modules/clients/service.py
+++ b/src/modules/clients/service.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from fastapi import Depends
 from sqlalchemy.orm import Session
@@ -56,20 +56,17 @@ class ClientService(CRUDService[ClientModel, ClientCreate, ClientUpdate]):
                 raise
             return client
 
-    def search(self, search: str, skip: int = 0, limit: int = 100) -> List[ClientModel]:
-        """Busca clientes por identificador, nombre o apellido."""
+    def search_paginated(
+        self, search: str, limit: int = 20, offset: int = 0
+    ) -> Tuple[List[ClientModel], int]:
+        """Busca clientes por identificador, nombre o apellido; ``(items, total)``."""
         pattern = f"%{search}%"
-        return (
-            self.db.query(ClientModel)
-            .filter(
-                ClientModel.identifier.ilike(pattern)
-                | ClientModel.first_name.ilike(pattern)
-                | ClientModel.last_name.ilike(pattern)
-            )
-            .offset(skip)
-            .limit(limit)
-            .all()
+        query = self.db.query(ClientModel).filter(
+            ClientModel.identifier.ilike(pattern)
+            | ClientModel.first_name.ilike(pattern)
+            | ClientModel.last_name.ilike(pattern)
         )
+        return self._paginate(query, limit, offset)
 
 
 def client_service(db: Session = Depends(get_db)) -> ClientService:

--- a/src/modules/optimizations/router.py
+++ b/src/modules/optimizations/router.py
@@ -3,19 +3,22 @@ from fastapi import APIRouter, Depends, Query
 from src.modules.optimizations.proforma import ProformaService, pdf_response
 from src.modules.optimizations.schemas import OptimizeRequest, OptimizeResponse
 from src.modules.optimizations.service import OptimizationService, optimization_service
+from src.shared.responses import ERROR_RESPONSES, DataResponse, ok
 
-router = APIRouter(prefix="/optimize", tags=["optimize"])
+router = APIRouter(prefix="/optimize", tags=["optimize"], responses=ERROR_RESPONSES)
 
 
-@router.post("/", response_model=OptimizeResponse)
+@router.post("/", response_model=DataResponse[OptimizeResponse])
 def optimize(
     request: OptimizeRequest,
     svc: OptimizationService = Depends(optimization_service),
 ):
     """Ejecuta una optimización de cortes (cache-first) y devuelve la solución."""
-    return svc.optimize_response(request)
+    return ok(svc.optimize_response(request))
 
 
+# Exento de la envoltura JSON: transporte de archivo PDF (StreamingResponse) y su
+# variante base64 son "el archivo, transportado", no un recurso JSON de dominio.
 @router.get("/{optimization_hash}/proforma")
 def get_proforma(
     optimization_hash: str,

--- a/src/modules/orders/router.py
+++ b/src/modules/orders/router.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Optional
 
 from fastapi import APIRouter, Depends, Query
 
@@ -13,8 +13,16 @@ from src.modules.orders.schemas import (
     OrderStatusUpdate,
 )
 from src.modules.orders.service import OrderService, order_service
+from src.shared.pagination import PageParams
+from src.shared.responses import (
+    ERROR_RESPONSES,
+    DataResponse,
+    PaginatedResponse,
+    ok,
+    page,
+)
 
-router = APIRouter(prefix="/orders", tags=["orders"])
+router = APIRouter(prefix="/orders", tags=["orders"], responses=ERROR_RESPONSES)
 
 _FORMAT_QUERY = Query(
     default="pdf",
@@ -23,59 +31,61 @@ _FORMAT_QUERY = Query(
 )
 
 
-@router.post("/", response_model=OrderResponse, status_code=201)
+@router.post("/", response_model=DataResponse[OrderResponse], status_code=201)
 def create_order(data: OrderCreate, svc: OrderService = Depends(order_service)):
     """Crea (o recupera, por idempotencia) una orden congelando el snapshot."""
-    return svc.create(data)
+    return ok(svc.create(data))
 
 
-@router.get("/", response_model=List[OrderResponse])
+@router.get("/", response_model=PaginatedResponse[OrderResponse])
 def list_orders(
     status: Optional[OrderStatus] = Query(
-        default=None, description="Filter orders by status"
+        default=None, description="Filtra órdenes por estado"
     ),
-    skip: int = Query(0, ge=0, description="Number of records to skip"),
-    limit: int = Query(
-        100, ge=1, le=1000, description="Maximum number of records to return"
-    ),
+    paging: PageParams = Depends(),
     svc: OrderService = Depends(order_service),
 ):
     """Lista órdenes con filtro por estado y paginación opcionales."""
-    return svc.list_orders(status=status, skip=skip, limit=limit)
+    items, total = svc.list_orders(
+        status=status, limit=paging.limit, offset=paging.offset
+    )
+    return page(items, total, paging.limit, paging.offset)
 
 
-@router.get("/{order_id}", response_model=OrderResponse)
+@router.get("/{order_id}", response_model=DataResponse[OrderResponse])
 def get_order(order_id: int, svc: OrderService = Depends(order_service)):
     """Obtiene una orden por ID."""
-    return svc.get_or_404(order_id)
+    return ok(svc.get_or_404(order_id))
 
 
-@router.patch("/{order_id}/status", response_model=OrderResponse)
+@router.patch("/{order_id}/status", response_model=DataResponse[OrderResponse])
 def update_order_status(
     order_id: int,
     data: OrderStatusUpdate,
     svc: OrderService = Depends(order_service),
 ):
     """Transiciona el estado de una orden validando la máquina de estados."""
-    return svc.transition(order_id, data.status, actor="sales", note=data.note)
+    return ok(svc.transition(order_id, data.status, actor="sales", note=data.note))
 
 
-@router.post("/{order_id}/invoice", response_model=OrderResponse)
+@router.post("/{order_id}/invoice", response_model=DataResponse[OrderResponse])
 def set_order_invoice(
     order_id: int,
     data: OrderInvoiceUpdate,
     svc: OrderService = Depends(order_service),
 ):
     """Asocia el ID de la factura externa (costura con el proveedor de facturación)."""
-    return svc.set_external_invoice_id(order_id, data.external_invoice_id)
+    return ok(svc.set_external_invoice_id(order_id, data.external_invoice_id))
 
 
-@router.get("/{order_id}/export", response_model=OrderExportResponse)
+@router.get("/{order_id}/export", response_model=DataResponse[OrderExportResponse])
 def export_order(order_id: int, svc: OrderService = Depends(order_service)):
     """Documento de facturación neutral para el proveedor externo (cobro=tableros)."""
-    return svc.build_export(order_id)
+    return ok(svc.build_export(order_id))
 
 
+# Exentos de la envoltura JSON: transporte de archivo PDF (StreamingResponse) y su
+# variante base64 son "el archivo, transportado", no recursos JSON de dominio.
 @router.get("/{order_id}/proforma")
 def get_order_proforma(
     order_id: int,

--- a/src/modules/orders/service.py
+++ b/src/modules/orders/service.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from fastapi import Depends
 from sqlalchemy.orm import Session
@@ -43,20 +43,22 @@ class OrderService:
     def list_orders(
         self,
         status: Optional[OrderStatus] = None,
-        skip: int = 0,
-        limit: int = 100,
-    ) -> List[OrderModel]:
-        """Lista órdenes (más recientes primero), opcionalmente por estado."""
+        limit: int = 20,
+        offset: int = 0,
+    ) -> Tuple[List[OrderModel], int]:
+        """Lista órdenes (más recientes primero) con conteo total: ``(items, total)``.
+
+        Barre primero las pendientes vencidas (las marca ``expired`` y persiste)
+        para que el filtro por estado, el total y la página reflejen el estado ya
+        expirado, sin que una expiración perezosa desbalancee el conteo.
+        """
+        self._sweep_expired()
         query = self.db.query(OrderModel)
         if status is not None:
             query = query.filter(OrderModel.status == status.value)
-        orders = query.order_by(OrderModel.id.desc()).offset(skip).limit(limit).all()
-        if any([self._expire_if_stale(o) for o in orders]):
-            self.db.commit()
-        if status is not None:
-            # Una orden recién expirada deja de pertenecer al estado consultado.
-            orders = [o for o in orders if o.status == status.value]
-        return orders
+        total = query.count()
+        orders = query.order_by(OrderModel.id.desc()).offset(offset).limit(limit).all()
+        return orders, total
 
     def create(self, data: OrderCreate) -> OrderModel:
         """Recalcula (cache-first), congela el snapshot y crea la orden.
@@ -213,6 +215,22 @@ class OrderService:
             total=order.total,
             external_invoice_id=order.external_invoice_id,
         )
+
+    def _sweep_expired(self) -> None:
+        """Expira (y persiste) las pendientes vencidas antes de contar/paginar.
+
+        Acotado a las pendientes con vigencia vencida, no a toda la tabla.
+        """
+        stale = (
+            self.db.query(OrderModel)
+            .filter(
+                OrderModel.status.in_([s.value for s in PENDING_STATUSES]),
+                OrderModel.expires_at < datetime.utcnow(),
+            )
+            .all()
+        )
+        if any([self._expire_if_stale(o) for o in stale]):
+            self.db.commit()
 
     def _expire_if_stale(self, order: OrderModel) -> bool:
         """Marca como ``expired`` una orden pendiente cuya vigencia ya venció.

--- a/src/shared/context.py
+++ b/src/shared/context.py
@@ -1,0 +1,16 @@
+"""Contexto por request: identificador de correlación (requestId).
+
+Lo fija ``RequestIDMiddleware`` (ASGI puro) al inicio de cada request y lo leen
+tanto la ``Meta`` de las respuestas como los handlers de error, sin tener que
+propagar el valor por la firma de cada endpoint.
+"""
+
+from contextvars import ContextVar
+from uuid import uuid4
+
+request_id_ctx: ContextVar[str] = ContextVar("request_id", default="")
+
+
+def get_request_id() -> str:
+    """requestId del request en curso, o uno nuevo como fallback defensivo."""
+    return request_id_ctx.get() or str(uuid4())

--- a/src/shared/crud.py
+++ b/src/shared/crud.py
@@ -1,8 +1,8 @@
-from typing import Generic, List, Optional, Type, TypeVar
+from typing import Generic, List, Optional, Tuple, Type, TypeVar
 
 from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Query, Session
 
 from src.shared.database import Base
 from src.shared.exceptions import ConflictError, EntityNotFoundError
@@ -36,8 +36,19 @@ class CRUDService(Generic[ModelT, CreateT, UpdateT]):
             raise EntityNotFoundError(self.model.__name__, id)
         return obj
 
-    def list(self, skip: int = 0, limit: int = 100) -> List[ModelT]:
-        return self.db.query(self.model).offset(skip).limit(limit).all()
+    def list_paginated(
+        self, limit: int = 20, offset: int = 0
+    ) -> Tuple[List[ModelT], int]:
+        """Página de registros más su conteo total: ``(items, total)``."""
+        return self._paginate(self.db.query(self.model), limit, offset)
+
+    def _paginate(
+        self, query: Query, limit: int, offset: int
+    ) -> Tuple[List[ModelT], int]:
+        """Cuenta el total y devuelve la página, reusable por búsquedas de slice."""
+        total = query.count()
+        items = query.offset(offset).limit(limit).all()
+        return items, total
 
     def create(self, data: CreateT) -> ModelT:
         return self._persist(self.model(**data.model_dump()))

--- a/src/shared/errors.py
+++ b/src/shared/errors.py
@@ -1,19 +1,75 @@
+import logging
+
 from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from src.shared.exceptions import AppError
+from src.shared.responses import ErrorDetail, ErrorResponse
+
+logger = logging.getLogger(__name__)
+
+# Nombres de código legibles para errores HTTP que no nacen de un ``AppError``
+# (rutas inexistentes, método no permitido, ``HTTPException`` manual).
+_HTTP_CODE_NAMES = {
+    400: "BAD_REQUEST",
+    401: "UNAUTHORIZED",
+    403: "FORBIDDEN",
+    404: "NOT_FOUND",
+    405: "METHOD_NOT_ALLOWED",
+    409: "CONFLICT",
+    422: "VALIDATION_ERROR",
+}
+
+
+def _error_response(status_code: int, details: list[ErrorDetail]) -> JSONResponse:
+    body = ErrorResponse(errors=details)
+    return JSONResponse(
+        status_code=status_code,
+        content=body.model_dump(by_alias=True, mode="json"),
+    )
 
 
 def register_exception_handlers(app: FastAPI) -> None:
-    """Registra el manejo centralizado de errores de aplicación.
+    """Registra el manejo centralizado de errores con la envoltura ``{errors, meta}``.
 
-    Permite que servicios y dominio lancen ``AppError`` (y subclases) sin
-    conocer FastAPI; aquí se traducen a respuestas HTTP con su ``status_code``.
+    Cubre los cuatro orígenes: errores de aplicación/dominio (``AppError``),
+    validación de request (``RequestValidationError``), ``HTTPException`` del
+    framework y cualquier excepción no controlada (catch-all 500).
     """
 
     @app.exception_handler(AppError)
     async def handle_app_error(request: Request, exc: AppError) -> JSONResponse:
-        return JSONResponse(
-            status_code=exc.status_code,
-            content={"detail": exc.detail},
+        detail = ErrorDetail(code=exc.code, message=exc.detail, field=exc.field)
+        return _error_response(exc.status_code, [detail])
+
+    @app.exception_handler(RequestValidationError)
+    async def handle_validation_error(
+        request: Request, exc: RequestValidationError
+    ) -> JSONResponse:
+        details = [
+            ErrorDetail(
+                code="VALIDATION_ERROR",
+                message=err["msg"],
+                field=".".join(str(part) for part in err["loc"]),  # p. ej. body.price
+            )
+            for err in exc.errors()
+        ]
+        return _error_response(422, details)
+
+    @app.exception_handler(StarletteHTTPException)
+    async def handle_http_error(
+        request: Request, exc: StarletteHTTPException
+    ) -> JSONResponse:
+        code = _HTTP_CODE_NAMES.get(exc.status_code, "HTTP_ERROR")
+        detail = ErrorDetail(code=code, message=str(exc.detail))
+        return _error_response(exc.status_code, [detail])
+
+    @app.exception_handler(Exception)
+    async def handle_unhandled_error(request: Request, exc: Exception) -> JSONResponse:
+        logger.exception("Excepción no controlada")
+        detail = ErrorDetail(
+            code="INTERNAL_SERVER_ERROR", message="Error interno del servidor"
         )
+        return _error_response(500, [detail])

--- a/src/shared/exceptions.py
+++ b/src/shared/exceptions.py
@@ -2,13 +2,18 @@ class AppError(Exception):
     """Error de aplicación traducible a una respuesta HTTP.
 
     Las capas de aplicación/dominio lanzan estas excepciones; el handler
-    registrado en ``shared.errors`` las traduce a JSON con su ``status_code``.
+    registrado en ``shared.errors`` las traduce a la envoltura ``{errors, meta}``
+    usando ``status_code`` (HTTP) y ``code`` (legible por máquina).
     """
 
     status_code = 400
+    code = "APPLICATION_ERROR"
+    field: str | None = None
 
-    def __init__(self, detail: str):
+    def __init__(self, detail: str, *, field: str | None = None):
         self.detail = detail
+        if field is not None:
+            self.field = field
         super().__init__(detail)
 
 
@@ -16,6 +21,7 @@ class EntityNotFoundError(AppError):
     """No se encontró la entidad solicitada."""
 
     status_code = 404
+    code = "NOT_FOUND"
 
     def __init__(self, entity: str, entity_id):
         super().__init__(f"{entity} {entity_id} no encontrado")
@@ -25,15 +31,18 @@ class ConflictError(AppError):
     """Violación de una restricción de unicidad/integridad."""
 
     status_code = 409
+    code = "CONFLICT"
 
 
 class BusinessRuleError(AppError):
     """Se violó una regla de negocio."""
 
     status_code = 422
+    code = "BUSINESS_RULE_ERROR"
 
 
 class ValidationError(AppError):
     """Error de validación de dominio."""
 
     status_code = 422
+    code = "VALIDATION_ERROR"

--- a/src/shared/middleware.py
+++ b/src/shared/middleware.py
@@ -1,0 +1,41 @@
+"""Middleware ASGI puro para correlación de requests.
+
+Se usa ASGI puro (no ``BaseHTTPMiddleware``): este último ejecuta el endpoint en
+otra task y el ``ContextVar`` fijado antes de ``call_next`` no siempre propaga.
+ASGI puro corre en la misma task, así que el requestId queda visible durante la
+serialización del ``response_model`` (donde ``Meta`` lo lee).
+"""
+
+from uuid import uuid4
+
+from src.shared.context import request_id_ctx
+
+
+class RequestIDMiddleware:
+    """Asigna un requestId por request y lo devuelve en el header ``X-Request-ID``.
+
+    Respeta un ``X-Request-ID`` entrante (continuidad de traza, p. ej. desde el
+    bot) o genera uno nuevo.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = dict(scope["headers"])
+        request_id = headers.get(b"x-request-id", b"").decode() or str(uuid4())
+        token = request_id_ctx.set(request_id)
+
+        async def send_with_request_id(message):
+            if message["type"] == "http.response.start":
+                message["headers"].append((b"x-request-id", request_id.encode()))
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_with_request_id)
+        finally:
+            request_id_ctx.reset(token)

--- a/src/shared/pagination.py
+++ b/src/shared/pagination.py
@@ -1,0 +1,19 @@
+"""Dependencia reusable de paginación (``limit``/``offset``).
+
+Alinea los listados con el contrato ``meta.pagination``. Reemplaza el par
+``skip``/``limit`` previo (``skip`` -> ``offset``).
+"""
+
+from fastapi import Query
+
+
+class PageParams:
+    """Parámetros de paginación inyectables vía ``Depends()``."""
+
+    def __init__(
+        self,
+        limit: int = Query(20, ge=1, le=100, description="Máximo de registros"),
+        offset: int = Query(0, ge=0, description="Registros a omitir"),
+    ):
+        self.limit = limit
+        self.offset = offset

--- a/src/shared/responses.py
+++ b/src/shared/responses.py
@@ -1,0 +1,87 @@
+"""Contratos de respuesta del API: envoltura uniforme de éxito y error.
+
+Toda respuesta JSON comparte ``meta`` (requestId + timestamp). El éxito viaja en
+``data`` (recurso o lista paginada) y el error en ``errors`` (lista, preparada
+para múltiples errores de validación). Los helpers ``ok``/``page`` reducen el
+endpoint a una sola línea; ``meta`` se autocompleta por ``default_factory``.
+
+Exentos de la envoltura (por diseño): el transporte de archivos PDF
+(``StreamingResponse``/base64) y los endpoints de diagnóstico (``system``).
+"""
+
+from datetime import datetime, timezone
+from typing import Any, Generic, List, Optional, Sequence, TypeVar
+
+from pydantic import Field
+
+from src.shared.context import get_request_id
+from src.shared.schemas import CamelModel
+
+T = TypeVar("T")
+
+
+class Meta(CamelModel):
+    """Metadatos comunes a toda respuesta (observabilidad/trazabilidad)."""
+
+    request_id: str = Field(default_factory=get_request_id)
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class Pagination(CamelModel):
+    total: int
+    limit: int
+    offset: int
+
+
+class PaginatedMeta(Meta):
+    pagination: Pagination
+
+
+class DataResponse(CamelModel, Generic[T]):
+    """Recurso único o estructura compuesta envuelta en ``data``."""
+
+    data: T
+    meta: Meta = Field(default_factory=Meta)
+
+
+class PaginatedResponse(CamelModel, Generic[T]):
+    """Listado con conteo total en ``meta.pagination``."""
+
+    data: List[T]
+    meta: PaginatedMeta
+
+
+class ErrorDetail(CamelModel):
+    code: str
+    message: str
+    field: Optional[str] = None
+
+
+class ErrorResponse(CamelModel):
+    errors: List[ErrorDetail]
+    meta: Meta = Field(default_factory=Meta)
+
+
+def ok(data: Any) -> dict:
+    """Envuelve un recurso. FastAPI lo valida contra ``DataResponse[T]``."""
+    return {"data": data}
+
+
+def page(items: Sequence, total: int, limit: int, offset: int) -> dict:
+    """Envuelve un listado paginado. Se valida contra ``PaginatedResponse[T]``."""
+    return {
+        "data": items,
+        "meta": {"pagination": {"total": total, "limit": limit, "offset": offset}},
+    }
+
+
+# Documentación OpenAPI: un único grupo de errores aplicado a nivel router
+# (``APIRouter(responses=ERROR_RESPONSES)``). La forma de éxito ya la documenta
+# el ``response_model`` genérico de cada ruta.
+ERROR_RESPONSES = {
+    400: {"model": ErrorResponse, "description": "Solicitud inválida"},
+    404: {"model": ErrorResponse, "description": "Recurso no encontrado"},
+    409: {"model": ErrorResponse, "description": "Conflicto de estado"},
+    422: {"model": ErrorResponse, "description": "Error de validación"},
+    500: {"model": ErrorResponse, "description": "Error interno"},
+}

--- a/tests/test_boards.py
+++ b/tests/test_boards.py
@@ -17,27 +17,29 @@ def _payload(code="MEL18", name="Melamina 18mm"):
 def test_create_and_get_board(client):
     resp = client.post("/api/v1/boards/", json=_payload())
     assert resp.status_code == 201
-    created = resp.json()
+    created = resp.json()["data"]
     assert created["code"] == "MEL18"
     assert created["price"] == 45.5
 
     got = client.get(f"/api/v1/boards/{created['id']}")
     assert got.status_code == 200
-    assert got.json()["name"] == "Melamina 18mm"
+    assert got.json()["data"]["name"] == "Melamina 18mm"
 
 
 def test_create_duplicate_code_returns_409(client):
     client.post("/api/v1/boards/", json=_payload())
     dup = client.post("/api/v1/boards/", json=_payload(name="Otro nombre"))
     assert dup.status_code == 409
-    assert dup.json()["detail"] == "El código del tablero ya existe"
+    error = dup.json()["errors"][0]
+    assert error["code"] == "CONFLICT"
+    assert error["message"] == "El código del tablero ya existe"
 
 
 def test_create_duplicate_name_returns_409(client):
     client.post("/api/v1/boards/", json=_payload())
     dup = client.post("/api/v1/boards/", json=_payload(code="MEL15"))
     assert dup.status_code == 409
-    assert dup.json()["detail"] == "El nombre del tablero ya existe"
+    assert dup.json()["errors"][0]["message"] == "El nombre del tablero ya existe"
 
 
 def test_get_missing_board_returns_404(client):
@@ -49,25 +51,28 @@ def test_list_and_search_boards(client):
     client.post("/api/v1/boards/", json=_payload(code="MDF15", name="Roble"))
 
     listed = client.get("/api/v1/boards/")
-    assert len(listed.json()) == 2
+    body = listed.json()
+    assert len(body["data"]) == 2
+    assert body["meta"]["pagination"]["total"] == 2
 
     found = client.get("/api/v1/boards/", params={"search": "Roble"})
-    assert [b["code"] for b in found.json()] == ["MDF15"]
+    assert [b["code"] for b in found.json()["data"]] == ["MDF15"]
+    assert found.json()["meta"]["pagination"]["total"] == 1
 
 
 def test_get_board_by_code(client):
     client.post("/api/v1/boards/", json=_payload(code="ABC123"))
     ok = client.get("/api/v1/boards/code/ABC123")
     assert ok.status_code == 200
-    assert ok.json()["code"] == "ABC123"
+    assert ok.json()["data"]["code"] == "ABC123"
     assert client.get("/api/v1/boards/code/NOPE").status_code == 404
 
 
 def test_update_and_delete_board(client):
-    created = client.post("/api/v1/boards/", json=_payload()).json()
+    created = client.post("/api/v1/boards/", json=_payload()).json()["data"]
     upd = client.put(f"/api/v1/boards/{created['id']}", json={"price": 60.0})
     assert upd.status_code == 200
-    assert upd.json()["price"] == 60.0
+    assert upd.json()["data"]["price"] == 60.0
 
     assert client.delete(f"/api/v1/boards/{created['id']}").status_code == 204
     assert client.get(f"/api/v1/boards/{created['id']}").status_code == 404

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -8,50 +8,52 @@ def _payload(identifier="0991112233", first="Ada", last="Lovelace"):
 def test_create_and_get_client(client):
     resp = client.post("/api/v1/clients/", json=_payload())
     assert resp.status_code == 201
-    created = resp.json()
+    created = resp.json()["data"]
     assert created["identifier"] == "0991112233"
     assert created["firstName"] == "Ada"
     assert "id" in created
 
     got = client.get(f"/api/v1/clients/{created['id']}")
     assert got.status_code == 200
-    assert got.json()["id"] == created["id"]
+    assert got.json()["data"]["id"] == created["id"]
 
 
 def test_create_duplicate_identifier_returns_409(client):
     client.post("/api/v1/clients/", json=_payload())
     dup = client.post("/api/v1/clients/", json=_payload(first="Other"))
     assert dup.status_code == 409
-    assert dup.json()["detail"] == "El identificador ya existe"
+    assert dup.json()["errors"][0]["message"] == "El identificador ya existe"
 
 
 def test_get_missing_client_returns_404(client):
     resp = client.get("/api/v1/clients/999999")
     assert resp.status_code == 404
-    assert "no encontrado" in resp.json()["detail"]
+    error = resp.json()["errors"][0]
+    assert error["code"] == "NOT_FOUND"
+    assert "no encontrado" in error["message"]
 
 
 def test_resolve_creates_then_is_idempotent(client):
     """``POST /clients/resolve`` crea la primera vez y luego devuelve el mismo id."""
     first = client.post("/api/v1/clients/resolve", json=_payload())
     assert first.status_code == 200
-    created = first.json()
+    created = first.json()["data"]
     assert created["identifier"] == "0991112233"
 
     second = client.post("/api/v1/clients/resolve", json=_payload(first="Ignored"))
     assert second.status_code == 200
-    assert second.json()["id"] == created["id"]
+    assert second.json()["data"]["id"] == created["id"]
     # No se duplica ni se sobrescribe el cliente existente.
-    assert second.json()["firstName"] == "Ada"
-    assert len(client.get("/api/v1/clients/").json()) == 1
+    assert second.json()["data"]["firstName"] == "Ada"
+    assert len(client.get("/api/v1/clients/").json()["data"]) == 1
 
 
 def test_resolve_returns_existing_created_client(client):
     """Si el cliente ya existe (creado por POST /clients), resolve lo reutiliza."""
-    created = client.post("/api/v1/clients/", json=_payload()).json()
+    created = client.post("/api/v1/clients/", json=_payload()).json()["data"]
     resolved = client.post("/api/v1/clients/resolve", json=_payload())
     assert resolved.status_code == 200
-    assert resolved.json()["id"] == created["id"]
+    assert resolved.json()["data"]["id"] == created["id"]
 
 
 def test_list_and_search_clients(client):
@@ -64,11 +66,13 @@ def test_list_and_search_clients(client):
 
     listed = client.get("/api/v1/clients/")
     assert listed.status_code == 200
-    assert len(listed.json()) == 2
+    body = listed.json()
+    assert len(body["data"]) == 2
+    assert body["meta"]["pagination"]["total"] == 2
 
     found = client.get("/api/v1/clients/", params={"search": "Grace"})
     assert found.status_code == 200
-    names = [c["firstName"] for c in found.json()]
+    names = [c["firstName"] for c in found.json()["data"]]
     assert names == ["Grace"]
 
 
@@ -76,43 +80,43 @@ def test_get_client_by_identifier(client):
     client.post("/api/v1/clients/", json=_payload(identifier="0995554433"))
     ok = client.get("/api/v1/clients/identifier/0995554433")
     assert ok.status_code == 200
-    assert ok.json()["identifier"] == "0995554433"
+    assert ok.json()["data"]["identifier"] == "0995554433"
 
     missing = client.get("/api/v1/clients/identifier/0000000000")
     assert missing.status_code == 404
 
 
 def test_update_client(client):
-    created = client.post("/api/v1/clients/", json=_payload()).json()
+    created = client.post("/api/v1/clients/", json=_payload()).json()["data"]
     resp = client.put(f"/api/v1/clients/{created['id']}", json={"firstName": "Augusta"})
     assert resp.status_code == 200
-    assert resp.json()["firstName"] == "Augusta"
-    assert resp.json()["lastName"] == "Lovelace"
+    assert resp.json()["data"]["firstName"] == "Augusta"
+    assert resp.json()["data"]["lastName"] == "Lovelace"
 
 
 def test_create_client_stores_phone_and_email(client):
     """``phone`` y ``email`` se almacenan y se devuelven (email opcional)."""
     payload = {**_payload(), "phone": "0991112233", "email": "ada@example.com"}
-    created = client.post("/api/v1/clients/", json=payload).json()
+    created = client.post("/api/v1/clients/", json=payload).json()["data"]
     assert created["phone"] == "0991112233"
     assert created["email"] == "ada@example.com"
 
 
 def test_client_phone_and_email_are_optional_on_create(client):
     """Sin ``phone``/``email`` el cliente se crea igual (regla se aplica al cotizar)."""
-    created = client.post("/api/v1/clients/", json=_payload()).json()
+    created = client.post("/api/v1/clients/", json=_payload()).json()["data"]
     assert created["phone"] is None
     assert created["email"] is None
 
 
 def test_update_client_phone(client):
     """``PUT`` permite registrar el celular más tarde (lo usa el bot tras compartir)."""
-    created = client.post("/api/v1/clients/", json=_payload()).json()
+    created = client.post("/api/v1/clients/", json=_payload()).json()["data"]
     resp = client.put(f"/api/v1/clients/{created['id']}", json={"phone": "0987654321"})
     assert resp.status_code == 200
-    assert resp.json()["phone"] == "0987654321"
+    assert resp.json()["data"]["phone"] == "0987654321"
     # No pisa el resto de campos.
-    assert resp.json()["firstName"] == "Ada"
+    assert resp.json()["data"]["firstName"] == "Ada"
 
 
 def test_update_missing_client_returns_404(client):
@@ -121,7 +125,7 @@ def test_update_missing_client_returns_404(client):
 
 
 def test_delete_client(client):
-    created = client.post("/api/v1/clients/", json=_payload()).json()
+    created = client.post("/api/v1/clients/", json=_payload()).json()["data"]
     deleted = client.delete(f"/api/v1/clients/{created['id']}")
     assert deleted.status_code == 204
     assert client.get(f"/api/v1/clients/{created['id']}").status_code == 404

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,8 +5,20 @@ import sys
 from fastapi.testclient import TestClient
 
 from main import app
+from src.shared.database import get_db
 
 client = TestClient(app)
+
+
+def _board_payload(code="MEL18"):
+    return {
+        "code": code,
+        "name": f"Melamina {code}",
+        "height": 2440,
+        "width": 1220,
+        "thickness": 18,
+        "price": 45.5,
+    }
 
 
 def test_app_mappers_configure_without_extra_model_imports():
@@ -88,3 +100,67 @@ def test_cutter_status():
     assert data["status"] == "operational"
     assert "active_processes" in data
     assert "last_update" in data
+
+
+def test_success_response_has_meta_and_request_id_header(client):
+    """Toda respuesta de éxito trae ``meta`` y ecoa el requestId en el header."""
+    resp = client.post("/api/v1/boards/", json=_board_payload())
+    assert resp.status_code == 201
+    body = resp.json()
+    assert "data" in body
+    meta = body["meta"]
+    assert meta["requestId"]
+    assert meta["timestamp"]
+    assert resp.headers["x-request-id"] == meta["requestId"]
+
+
+def test_incoming_request_id_is_propagated(client):
+    """Un ``X-Request-ID`` entrante se conserva (continuidad de traza) y va en meta."""
+    resp = client.get("/api/v1/boards/999999", headers={"X-Request-ID": "trace-123"})
+    assert resp.status_code == 404
+    assert resp.headers["x-request-id"] == "trace-123"
+    assert resp.json()["meta"]["requestId"] == "trace-123"
+
+
+def test_validation_error_includes_field_path(client):
+    """Validación de request → 422 con ``code`` y ``field`` tipo ``body.<campo>``."""
+    resp = client.post("/api/v1/boards/", json={})
+    assert resp.status_code == 422
+    errors = resp.json()["errors"]
+    assert errors[0]["code"] == "VALIDATION_ERROR"
+    assert any(e["field"] and e["field"].startswith("body.") for e in errors)
+
+
+def test_unknown_route_returns_404_envelope(client):
+    """Una ruta inexistente también responde con la envoltura ``{errors, meta}``."""
+    resp = client.get("/api/v1/nope")
+    assert resp.status_code == 404
+    body = resp.json()
+    assert body["errors"][0]["code"] == "NOT_FOUND"
+    assert body["meta"]["requestId"]
+
+
+def test_unhandled_exception_returns_500_envelope(db_session, monkeypatch):
+    """Una excepción no controlada se traduce a un 500 con envoltura, sin filtrar."""
+
+    def _boom(self, id):
+        raise RuntimeError("boom")
+
+    from src.modules.boards.service import BoardService
+
+    monkeypatch.setattr(BoardService, "get_or_404", _boom)
+
+    def override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        with TestClient(app, raise_server_exceptions=False) as test_client:
+            resp = test_client.get("/api/v1/boards/1")
+        assert resp.status_code == 500
+        body = resp.json()
+        assert body["errors"][0]["code"] == "INTERNAL_SERVER_ERROR"
+        assert body["errors"][0]["message"] == "Error interno del servidor"
+        assert body["meta"]["requestId"]
+    finally:
+        app.dependency_overrides.clear()

--- a/tests/test_optimizations.py
+++ b/tests/test_optimizations.py
@@ -16,7 +16,7 @@ def _create_client(client):
             "lastName": "Lovelace",
             "phone": "0991112233",
         },
-    ).json()
+    ).json()["data"]
 
 
 def _create_board(client, code="MEL18"):
@@ -30,7 +30,7 @@ def _create_board(client, code="MEL18"):
             "thickness": 18,
             "price": 45.5,
         },
-    ).json()
+    ).json()["data"]
 
 
 def _optimize_payload(client_id, board_id):
@@ -59,7 +59,7 @@ def test_optimize_returns_layouts(client):
         json=_optimize_payload(created_client["id"], created_board["id"]),
     )
     assert resp.status_code == 200
-    data = resp.json()
+    data = resp.json()["data"]
     assert data["client"]["id"] == created_client["id"]
     assert data["totalBoardsUsed"] >= 1
     assert len(data["layouts"]) >= 1
@@ -81,7 +81,7 @@ def test_optimize_returns_optimization_hash(client):
         json=_optimize_payload(created_client["id"], created_board["id"]),
     )
     assert resp.status_code == 200
-    optimization_hash = resp.json()["optimizationHash"]
+    optimization_hash = resp.json()["data"]["optimizationHash"]
     assert isinstance(optimization_hash, str) and len(optimization_hash) == 64
 
 
@@ -95,7 +95,7 @@ def test_optimize_computes_total_boards_cost(client):
         json=_optimize_payload(created_client["id"], created_board["id"]),
     )
     assert resp.status_code == 200
-    data = resp.json()
+    data = resp.json()["data"]
     assert data["totalBoardsUsed"] >= 1
     assert data["totalBoardsCost"] == pytest.approx(data["totalBoardsUsed"] * 45.5)
     assert data["totalBoardsCost"] > 0
@@ -108,7 +108,7 @@ def test_optimize_unknown_board_returns_404(client):
         json=_optimize_payload(created_client["id"], board_id=99999),
     )
     assert resp.status_code == 404
-    assert "Board 99999" in resp.json()["detail"]
+    assert "Board 99999" in resp.json()["errors"][0]["message"]
 
 
 def test_proforma_pdf_and_base64(client):
@@ -117,7 +117,7 @@ def test_proforma_pdf_and_base64(client):
     optimization = client.post(
         "/api/v1/optimize/",
         json=_optimize_payload(created_client["id"], created_board["id"]),
-    ).json()
+    ).json()["data"]
     opt_hash = optimization["optimizationHash"]
 
     pdf = client.get(
@@ -128,6 +128,7 @@ def test_proforma_pdf_and_base64(client):
     assert pdf.headers["content-type"] == "application/pdf"
     assert len(pdf.content) > 1000
 
+    # La proforma PDF/base64 queda exenta de la envoltura (transporte de archivo).
     b64 = client.get(
         f"/api/v1/optimize/{opt_hash}/proforma",
         params={"clientId": created_client["id"], "format": "base64"},
@@ -156,11 +157,11 @@ def test_proforma_blocked_without_client_phone(client):
     no_phone = client.post(
         "/api/v1/clients/",
         json={"identifier": "0990000000", "firstName": "Sin", "lastName": "Tel"},
-    ).json()
+    ).json()["data"]
     optimization = client.post(
         "/api/v1/optimize/",
         json=_optimize_payload(no_phone["id"], created_board["id"]),
-    ).json()
+    ).json()["data"]
     opt_hash = optimization["optimizationHash"]
 
     resp = client.get(
@@ -168,7 +169,7 @@ def test_proforma_blocked_without_client_phone(client):
         params={"clientId": no_phone["id"]},
     )
     assert resp.status_code == 422
-    assert "celular" in resp.json()["detail"].lower()
+    assert "celular" in resp.json()["errors"][0]["message"].lower()
 
 
 def test_optimize_without_client_is_anonymous(client):
@@ -180,14 +181,14 @@ def test_optimize_without_client_is_anonymous(client):
     with_client = client.post(
         "/api/v1/optimize/",
         json=_optimize_payload(created_client["id"], created_board["id"]),
-    ).json()
+    ).json()["data"]
 
     anon_payload = _optimize_payload(created_client["id"], created_board["id"])
     anon_payload.pop("clientId")
     anon = client.post("/api/v1/optimize/", json=anon_payload)
 
     assert anon.status_code == 200
-    data = anon.json()
+    data = anon.json()["data"]
     assert data["client"] is None
     assert data["optimizationHash"] == with_client["optimizationHash"]
 
@@ -200,7 +201,7 @@ def test_optimize_unknown_client_returns_404(client):
         json=_optimize_payload(client_id=99999, board_id=created_board["id"]),
     )
     assert resp.status_code == 404
-    assert "Client 99999" in resp.json()["detail"]
+    assert "Client 99999" in resp.json()["errors"][0]["message"]
 
 
 def test_optimize_does_not_persist(client, db_session):
@@ -214,7 +215,7 @@ def test_optimize_does_not_persist(client, db_session):
         json=_optimize_payload(created_client["id"], created_board["id"]),
     )
     assert resp.status_code == 200
-    assert resp.json()["id"] is None
+    assert resp.json()["data"]["id"] is None
     assert db_session.query(OptimizationModel).count() == 0
 
 
@@ -252,7 +253,7 @@ def test_optimize_deduplicates_identical_patterns(client):
     }
     resp = client.post("/api/v1/optimize/", json=payload)
     assert resp.status_code == 200
-    data = resp.json()
+    data = resp.json()["data"]
 
     # El conteo físico se mantiene en 5 (layouts, totales y resumen de materiales).
     assert data["totalBoardsUsed"] == 5
@@ -280,7 +281,7 @@ def test_optimize_includes_materials_summary(client):
         json=_optimize_payload(created_client["id"], created_board["id"]),
     )
     assert resp.status_code == 200
-    data = resp.json()
+    data = resp.json()["data"]
 
     summary = data.get("materialsSummary")
     assert summary is not None and len(summary) == 1

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -14,7 +14,7 @@ def _create_client(client, identifier="0991112233", phone="0991112233"):
             "lastName": "Lovelace",
             "phone": phone,
         },
-    ).json()
+    ).json()["data"]
 
 
 def _create_board(client, code="MEL18"):
@@ -28,7 +28,7 @@ def _create_board(client, code="MEL18"):
             "thickness": 18,
             "price": 45.5,
         },
-    ).json()
+    ).json()["data"]
 
 
 def _order_payload(client_id, board_id, height=400, width=600, quantity=2):
@@ -54,7 +54,7 @@ def test_create_order_freezes_snapshot_and_charges_boards(client):
 
     resp = client.post("/api/v1/orders/", json=_order_payload(c["id"], b["id"]))
     assert resp.status_code == 201
-    data = resp.json()
+    data = resp.json()["data"]
 
     assert data["status"] == "confirmed"
     assert data["code"] == f"ORD-{datetime.utcnow().year}-{data['id']:04d}"
@@ -88,13 +88,13 @@ def test_create_order_blocked_without_client_phone(client):
     no_phone = client.post(
         "/api/v1/clients/",
         json={"identifier": "0990000000", "firstName": "Sin", "lastName": "Tel"},
-    ).json()
+    ).json()["data"]
 
     resp = client.post("/api/v1/orders/", json=_order_payload(no_phone["id"], b["id"]))
     assert resp.status_code == 422
-    assert "celular" in resp.json()["detail"].lower()
+    assert "celular" in resp.json()["errors"][0]["message"].lower()
     # No se persistió ninguna orden.
-    assert client.get("/api/v1/orders/").json() == []
+    assert client.get("/api/v1/orders/").json()["data"] == []
 
 
 def test_create_order_unknown_client_returns_404(client):
@@ -102,7 +102,7 @@ def test_create_order_unknown_client_returns_404(client):
     b = _create_board(client)
     resp = client.post("/api/v1/orders/", json=_order_payload(99999, b["id"]))
     assert resp.status_code == 404
-    assert "Client 99999" in resp.json()["detail"]
+    assert "Client 99999" in resp.json()["errors"][0]["message"]
 
 
 def test_create_order_is_idempotent(client):
@@ -110,13 +110,13 @@ def test_create_order_is_idempotent(client):
     b = _create_board(client)
     payload = _order_payload(c["id"], b["id"])
 
-    first = client.post("/api/v1/orders/", json=payload).json()
-    second = client.post("/api/v1/orders/", json=payload).json()
+    first = client.post("/api/v1/orders/", json=payload).json()["data"]
+    second = client.post("/api/v1/orders/", json=payload).json()["data"]
 
     assert first["id"] == second["id"]
     assert first["code"] == second["code"]
     # No se crean dos órdenes para el mismo (cliente, hash).
-    assert len(client.get("/api/v1/orders/").json()) == 1
+    assert len(client.get("/api/v1/orders/").json()["data"]) == 1
 
 
 def test_pending_cap_blocks_excess_orders(client, monkeypatch):
@@ -143,35 +143,39 @@ def test_pending_cap_blocks_excess_orders(client, monkeypatch):
         "/api/v1/orders/", json=_order_payload(c["id"], b["id"], width=450)
     )
     assert third.status_code == 422
-    assert "pendiente" in third.json()["detail"]
+    assert "pendiente" in third.json()["errors"][0]["message"]
 
 
 def test_status_transitions_valid_and_invalid(client):
     c = _create_client(client)
     b = _create_board(client)
-    order = client.post("/api/v1/orders/", json=_order_payload(c["id"], b["id"])).json()
+    order = client.post(
+        "/api/v1/orders/", json=_order_payload(c["id"], b["id"])
+    ).json()["data"]
     oid = order["id"]
 
     ok = client.patch(f"/api/v1/orders/{oid}/status", json={"status": "approved"})
     assert ok.status_code == 200
-    assert ok.json()["status"] == "approved"
+    assert ok.json()["data"]["status"] == "approved"
 
     ok2 = client.patch(f"/api/v1/orders/{oid}/status", json={"status": "in_production"})
     assert ok2.status_code == 200
-    assert ok2.json()["status"] == "in_production"
+    assert ok2.json()["data"]["status"] == "in_production"
     # Historial acumulado: creación + 2 transiciones.
-    assert len(ok2.json()["history"]) == 3
+    assert len(ok2.json()["data"]["history"]) == 3
 
     # in_production → completed no es una transición válida.
     bad = client.patch(f"/api/v1/orders/{oid}/status", json={"status": "completed"})
     assert bad.status_code == 422
-    assert "inválida" in bad.json()["detail"]
+    assert "inválida" in bad.json()["errors"][0]["message"]
 
 
 def test_invalid_transition_from_confirmed(client):
     c = _create_client(client)
     b = _create_board(client)
-    order = client.post("/api/v1/orders/", json=_order_payload(c["id"], b["id"])).json()
+    order = client.post(
+        "/api/v1/orders/", json=_order_payload(c["id"], b["id"])
+    ).json()["data"]
     # confirmed → completed (salta estados) no es válido.
     bad = client.patch(
         f"/api/v1/orders/{order['id']}/status", json={"status": "completed"}
@@ -184,18 +188,19 @@ def test_list_orders_filter_by_status(client):
     b = _create_board(client)
     o1 = client.post(
         "/api/v1/orders/", json=_order_payload(c["id"], b["id"], width=600)
-    ).json()
+    ).json()["data"]
     client.post("/api/v1/orders/", json=_order_payload(c["id"], b["id"], width=500))
 
     # Aprobar solo la primera.
     client.patch(f"/api/v1/orders/{o1['id']}/status", json={"status": "approved"})
 
     approved = client.get("/api/v1/orders/", params={"status": "approved"}).json()
-    assert [o["id"] for o in approved] == [o1["id"]]
+    assert [o["id"] for o in approved["data"]] == [o1["id"]]
+    assert approved["meta"]["pagination"]["total"] == 1
 
     confirmed = client.get("/api/v1/orders/", params={"status": "confirmed"}).json()
-    assert o1["id"] not in [o["id"] for o in confirmed]
-    assert len(confirmed) == 1
+    assert o1["id"] not in [o["id"] for o in confirmed["data"]]
+    assert len(confirmed["data"]) == 1
 
 
 def test_get_order_404(client):
@@ -205,7 +210,9 @@ def test_get_order_404(client):
 def test_order_proforma_pdf_and_base64(client):
     c = _create_client(client)
     b = _create_board(client)
-    order = client.post("/api/v1/orders/", json=_order_payload(c["id"], b["id"])).json()
+    order = client.post(
+        "/api/v1/orders/", json=_order_payload(c["id"], b["id"])
+    ).json()["data"]
     oid = order["id"]
 
     pdf = client.get(f"/api/v1/orders/{oid}/proforma")
@@ -213,6 +220,7 @@ def test_order_proforma_pdf_and_base64(client):
     assert pdf.headers["content-type"] == "application/pdf"
     assert len(pdf.content) > 1000
 
+    # PDF/base64 exentos de la envoltura (transporte de archivo).
     b64 = client.get(f"/api/v1/orders/{oid}/proforma", params={"format": "base64"})
     assert b64.status_code == 200
     body = b64.json()
@@ -224,7 +232,9 @@ def test_order_proforma_pdf_and_base64(client):
 def test_order_production_sheet_pdf(client):
     c = _create_client(client)
     b = _create_board(client)
-    order = client.post("/api/v1/orders/", json=_order_payload(c["id"], b["id"])).json()
+    order = client.post(
+        "/api/v1/orders/", json=_order_payload(c["id"], b["id"])
+    ).json()["data"]
 
     sheet = client.get(f"/api/v1/orders/{order['id']}/production-sheet")
     assert sheet.status_code == 200
@@ -240,11 +250,13 @@ def test_order_documents_404(client):
 def test_order_export_document(client):
     c = _create_client(client)
     b = _create_board(client)
-    order = client.post("/api/v1/orders/", json=_order_payload(c["id"], b["id"])).json()
+    order = client.post(
+        "/api/v1/orders/", json=_order_payload(c["id"], b["id"])
+    ).json()["data"]
 
     resp = client.get(f"/api/v1/orders/{order['id']}/export")
     assert resp.status_code == 200
-    data = resp.json()
+    data = resp.json()["data"]
 
     assert data["orderCode"] == order["code"]
     assert data["status"] == "confirmed"
@@ -267,14 +279,16 @@ def test_order_export_document(client):
 def test_set_external_invoice_id_and_reflect_in_export(client):
     c = _create_client(client)
     b = _create_board(client)
-    order = client.post("/api/v1/orders/", json=_order_payload(c["id"], b["id"])).json()
+    order = client.post(
+        "/api/v1/orders/", json=_order_payload(c["id"], b["id"])
+    ).json()["data"]
     oid = order["id"]
 
     resp = client.post(
         f"/api/v1/orders/{oid}/invoice", json={"externalInvoiceId": "FAC-001-42"}
     )
     assert resp.status_code == 200
-    assert resp.json()["externalInvoiceId"] == "FAC-001-42"
+    assert resp.json()["data"]["externalInvoiceId"] == "FAC-001-42"
 
     # Idempotente con el mismo ID.
     again = client.post(
@@ -283,14 +297,16 @@ def test_set_external_invoice_id_and_reflect_in_export(client):
     assert again.status_code == 200
 
     # El export refleja la factura asociada.
-    exported = client.get(f"/api/v1/orders/{oid}/export").json()
+    exported = client.get(f"/api/v1/orders/{oid}/export").json()["data"]
     assert exported["externalInvoiceId"] == "FAC-001-42"
 
 
 def test_set_external_invoice_id_conflict_on_different_id(client):
     c = _create_client(client)
     b = _create_board(client)
-    order = client.post("/api/v1/orders/", json=_order_payload(c["id"], b["id"])).json()
+    order = client.post(
+        "/api/v1/orders/", json=_order_payload(c["id"], b["id"])
+    ).json()["data"]
     oid = order["id"]
 
     client.post(
@@ -318,11 +334,13 @@ def test_order_expires_lazily_on_read(client, monkeypatch):
     monkeypatch.setattr(config, "ORDER_VALIDITY_DAYS", -1)
     c = _create_client(client)
     b = _create_board(client)
-    order = client.post("/api/v1/orders/", json=_order_payload(c["id"], b["id"])).json()
+    order = client.post(
+        "/api/v1/orders/", json=_order_payload(c["id"], b["id"])
+    ).json()["data"]
     # Nace confirmed, pero su vigencia ya está vencida (expiresAt en el pasado).
     assert order["status"] == "confirmed"
 
-    fetched = client.get(f"/api/v1/orders/{order['id']}").json()
+    fetched = client.get(f"/api/v1/orders/{order['id']}").json()["data"]
     assert fetched["status"] == "expired"
     assert fetched["history"][-1]["toStatus"] == "expired"
     assert fetched["history"][-1]["fromStatus"] == "confirmed"


### PR DESCRIPTION
    Wrap all JSON responses in a uniform envelope: success bodies in
    {data, meta} (DataResponse[T] / PaginatedResponse[T]) and errors in
    {errors, meta} (ErrorResponse). Every response carries a requestId
    (echoed via X-Request-ID) and timestamp via a pure-ASGI middleware.

    - Add shared responses/context/middleware/pagination modules
    - Centralize errors: AppError, request validation (field paths), HTTPException and an unhandled 500 catch-all
    - Add error codes to the AppError hierarchy
    - Paginate listings with total via CRUDService.list_paginated
    - Document shared error responses per router for OpenAPI
    - PDF and system/health endpoints exempt from the envelope

    BREAKING CHANGE: /api/v1 contract now wraps data/errors; listings use
    offset (was skip) with a default page size of 20.