### PR TITLE
feat: seed PVC edge bandings and support fractional thickness

### DIFF
--- a/scripts/seed_boards.py
+++ b/scripts/seed_boards.py
@@ -1,4 +1,4 @@
-"""Seed script: borra los tableros existentes e inserta la colección Trend 2026."""
+"""Seed script: borra tableros y tapacantos existentes e inserta la colección Trend 2026."""
 
 import os
 import sys
@@ -123,20 +123,90 @@ def build_boards():
     return boards
 
 
+# --- Tapacantos -----------------------------------------------------------
+#
+# Cada diseño de tablero tiene su tapacanto de PVC coordinado (mapeo 1:1 con
+# DESIGNS). Salvo el Blanco, todos vienen en las 3 medidas estándar:
+#   (tipo, espesor_mm, ancho_mm)
+EDGE_BAND_VARIANTS = [
+    ("Suave", 0.45, 19),
+    ("Duro", 1.00, 40),
+    ("Duro", 1.50, 19),
+]
+
+# TODO: precios PLACEHOLDER (no provistos). Reemplazar con los reales.
+EDGE_PRICES = {
+    (0.45, 19): 12.00,
+    (1.00, 40): 22.00,
+    (1.50, 19): 15.00,
+}
+
+
+def edge_label(abbr, name, cat):
+    """Etiqueta comercial del tapacanto según la categoría del diseño."""
+    if abbr == "BNV":  # el tapacanto se llama "Blanco", no "Blanco Nieve"
+        name = "Blanco"
+    if cat == "RO":
+        return f"Roble {name}"
+    if cat == "CR":
+        return f"{name} Cremona"
+    return name
+
+
+def make_edge_banding(abbr, name, cat, band_type, thickness, width):
+    label = edge_label(abbr, name, cat)
+    thick_txt = f"{thickness:g}"  # 0.45, 1, 1.5 (sin ceros sobrantes)
+    description = (
+        f"Tapacanto PVC {label}, tipo {band_type}, {thick_txt}mm x {width}mm, "
+        f"coordinado con tablero MDP {label}"
+    )
+    return {
+        "type": ProductType.EDGE_BANDING.value,
+        "code": f"TAP-{cat}-{abbr}-{int(round(thickness * 100)):03d}",
+        "name": f"Tapacanto PVC {label} {band_type} {thick_txt}x{width}mm",
+        "description": description[:256],
+        "price": EDGE_PRICES[(thickness, width)],
+        "is_active": True,
+        # Atributos en la forma canónica camelCase del catálogo de productos.
+        "attributes": {
+            "bandType": band_type,
+            "thickness": thickness,
+            "width": width,
+            "color": label,
+        },
+    }
+
+
+def build_edge_bandings():
+    bands = []
+    for abbr, name, cat, _grain, _texture in DESIGNS:
+        # El Blanco no se ofrece en las 3 medidas coordinadas; solo el Suave estándar.
+        variants = [EDGE_BAND_VARIANTS[0]] if abbr == "BNV" else EDGE_BAND_VARIANTS
+        for band_type, thickness, width in variants:
+            bands.append(
+                make_edge_banding(abbr, name, cat, band_type, thickness, width)
+            )
+    return bands
+
+
 def main():
     db = SessionLocal()
     try:
-        deleted = (
-            db.query(ProductModel)
-            .filter(ProductModel.type == ProductType.BOARD.value)
-            .delete()
-        )
-        print(f"Eliminados {deleted} tableros existentes.")
+        for product_type, builder, label in (
+            (ProductType.BOARD, build_boards, "tableros"),
+            (ProductType.EDGE_BANDING, build_edge_bandings, "tapacantos"),
+        ):
+            deleted = (
+                db.query(ProductModel)
+                .filter(ProductModel.type == product_type.value)
+                .delete()
+            )
+            print(f"Eliminados {deleted} {label} existentes.")
 
-        boards = [ProductModel(**data) for data in build_boards()]
-        db.add_all(boards)
+            items = [ProductModel(**data) for data in builder()]
+            db.add_all(items)
+            print(f"Insertados {len(items)} {label} nuevos.")
         db.commit()
-        print(f"Insertados {len(boards)} tableros nuevos.")
     except Exception as e:
         db.rollback()
         print(f"Error: {e}")

--- a/src/modules/products/types/edge_banding.py
+++ b/src/modules/products/types/edge_banding.py
@@ -1,18 +1,28 @@
 from typing import Optional
 
-from pydantic import Field, PositiveInt
+from pydantic import Field, PositiveFloat, PositiveInt
 
 from src.shared.schemas import CamelModel
 
 
 class EdgeBandingAttributes(CamelModel):
-    """Atributos de un tapacanto.
+    """Atributos de un tapacanto de PVC.
 
-    Placeholder para dejar lista la base multi-producto; la lógica de negocio del
-    tapacanto (cálculo de metraje, etc.) se implementará en una fase posterior.
+    Se identifica por su grosor y ancho, y se clasifica por tipo (Suave/Duro). El
+    grosor real es fraccionario (p. ej. 0.45 mm), de ahí el float. La lógica de
+    negocio (cálculo de metraje, etc.) se implementará en una fase posterior.
     """
 
-    length: PositiveInt = Field(..., description="Largo del rollo en mm")
-    width: PositiveInt = Field(..., description="Ancho en mm")
-    thickness: PositiveInt = Field(..., description="Grosor en mm")
-    color: Optional[str] = Field(None, max_length=64, description="Color/acabado")
+    thickness: PositiveFloat = Field(
+        ..., description="Grosor en mm (p. ej. 0.45, 1.0, 1.5)"
+    )
+    width: PositiveInt = Field(..., description="Ancho en mm (p. ej. 19, 40)")
+    band_type: Optional[str] = Field(
+        None, max_length=16, description="Tipo de tapacanto: Suave o Duro"
+    )
+    color: Optional[str] = Field(
+        None, max_length=64, description="Color/diseño coordinado"
+    )
+    length: Optional[PositiveInt] = Field(
+        None, description="Largo del rollo en mm (si aplica)"
+    )


### PR DESCRIPTION
    Extend the catalog seed to cover the Trend 2026 PVC edge bandings, which
    map 1:1 to the existing board designs. Each design gets the 3 standard
    variants (Suave 0.45x19, Duro 1.00x40, Duro 1.50x19); Blanco is limited to
    the Suave variant. Prices are placeholders pending real values.

    Update EdgeBandingAttributes accordingly:
    - thickness: PositiveInt -> PositiveFloat (real values are 0.45, 1.0, 1.5)
    - add optional bandType (Suave/Duro) to disambiguate the two 19mm widths
    - make length optional (no roll-length data; module is still a placeholder)