### PR TITLE
feat: edge banding support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,9 @@ CORS_ORIGINS=http://localhost:3000,http://localhost:3001
 ORDER_VALIDITY_DAYS=15
 MAX_PENDING_ORDERS_PER_CLIENT=3
 
+# Tapacantos: merma sobre el metraje neto antes de redondear al metro cobrado
+EDGE_BANDING_WASTE_FACTOR=0.10
+
 # Base de datos
 # Para SQLite local:
 DATABASE_URL=sqlite:///./cutter_local.db

--- a/alembic/versions/c1d2e3f4a5b6_add_edge_banding_to_orders.py
+++ b/alembic/versions/c1d2e3f4a5b6_add_edge_banding_to_orders.py
@@ -1,0 +1,28 @@
+"""add edge banding to order lines and pieces
+
+Revision ID: c1d2e3f4a5b6
+Revises: a7b8c9d0e1f2
+Create Date: 2026-06-04 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "c1d2e3f4a5b6"
+down_revision: Union[str, None] = "a7b8c9d0e1f2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Tapacanto: metros exactos (con merma) en la línea de cobro y spec por pieza.
+    op.add_column("order_lines", sa.Column("linear_m", sa.Float(), nullable=True))
+    op.add_column("order_pieces", sa.Column("edges", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("order_pieces", "edges")
+    op.drop_column("order_lines", "linear_m")

--- a/src/modules/optimizations/carrier.py
+++ b/src/modules/optimizations/carrier.py
@@ -16,10 +16,17 @@ class ProformaCarrier:
     client: object
     requirements: List[dict] = field(default_factory=list)
     materials_summary: List[dict] = field(default_factory=list)
+    edge_bandings_summary: List[dict] = field(default_factory=list)
     layouts: List[dict] = field(default_factory=list)
     layout_groups: List[dict] = field(default_factory=list)
     total_boards_used: int = 0
     total_boards_cost: float = 0.0
+    total_edge_banding_cost: float = 0.0
+
+    @property
+    def total_cost(self) -> float:
+        """Costo total: tableros + tapacantos."""
+        return round(self.total_boards_cost + self.total_edge_banding_cost, 2)
 
     @classmethod
     def from_payload(cls, payload: dict, client, reference: str) -> "ProformaCarrier":
@@ -29,19 +36,24 @@ class ProformaCarrier:
             client=client,
             requirements=payload.get("requirements") or [],
             materials_summary=payload.get("materials_summary") or [],
+            edge_bandings_summary=payload.get("edge_bandings_summary") or [],
             layouts=payload.get("layouts") or [],
             layout_groups=payload.get("layout_groups") or [],
             total_boards_used=payload.get("total_boards_used", 0),
             total_boards_cost=payload.get("total_boards_cost", 0.0),
+            total_edge_banding_cost=payload.get("total_edge_banding_cost", 0.0),
         )
 
     @classmethod
     def from_order(cls, order) -> "ProformaCarrier":
-        """Construye el portador desde una orden (snapshot + precios congelados)."""
+        """Construye el portador desde una orden (snapshot + precios congelados).
+
+        El desglose (tableros vs tapacantos) se toma del snapshot inmutable; el
+        gran total congelado vive en ``order.total`` (= tableros + tapacantos).
+        """
         snapshot = order.optimization_snapshot or {}
         reference = order.code or f"ORD-{order.id:06d}"
         carrier = cls.from_payload(snapshot, order.client, reference=reference)
-        # La orden congela totales al confirmar: prevalecen sobre el snapshot.
+        # La orden congela el conteo de tableros al confirmar.
         carrier.total_boards_used = order.total_boards_used
-        carrier.total_boards_cost = order.total
         return carrier

--- a/src/modules/optimizations/proforma.py
+++ b/src/modules/optimizations/proforma.py
@@ -153,6 +153,14 @@ class ProformaService:
         story.extend(_section("RESUMEN DE MATERIALES", heading_style))
         story.append(ProformaService._build_materials_table(carrier, cell_style))
         story.append(Spacer(1, 0.2 * inch))
+
+        if carrier.edge_bandings_summary:
+            story.extend(_section("RESUMEN DE TAPACANTOS", heading_style))
+            story.append(
+                ProformaService._build_edge_bandings_table(carrier, cell_style)
+            )
+            story.append(Spacer(1, 0.2 * inch))
+
         story.append(ProformaService._build_totals_table(carrier))
 
         story.append(PageBreak())
@@ -211,6 +219,15 @@ class ProformaService:
         story.append(ProformaService._build_materials_plain_table(carrier, cell_style))
         story.append(Spacer(1, 0.2 * inch))
         story.append(ProformaService._build_boards_total_table(carrier))
+
+        if carrier.edge_bandings_summary:
+            story.append(Spacer(1, 0.25 * inch))
+            story.extend(_section("TAPACANTOS A APLICAR", heading_style))
+            story.append(
+                ProformaService._build_edge_bandings_table(
+                    carrier, cell_style, with_prices=False
+                )
+            )
 
         story.append(PageBreak())
         story.extend(_section("DISPOSICIÓN DE CORTES", heading_style))
@@ -386,7 +403,7 @@ class ProformaService:
     @staticmethod
     def _build_requirements_table(carrier: ProformaCarrier, cell_style) -> Table:
         requirements = carrier.requirements
-        req_data = [["#", "Alto", "Ancho", "Cantidad", "Tablero", "Etiqueta"]]
+        req_data = [["#", "Alto", "Ancho", "Cant.", "Tablero", "Cantos", "Etiqueta"]]
         if isinstance(requirements, list):
             for idx, req in enumerate(requirements, 1):
                 req_data.append(
@@ -396,6 +413,7 @@ class ProformaService:
                         f"{req.get('width', 0)} mm",
                         str(req.get("quantity", 1)),
                         req.get("product_code", "N/A"),
+                        Paragraph(_edge_sides_label(req), cell_style),
                         Paragraph(req.get("label") or "-", cell_style),
                     ]
                 )
@@ -403,17 +421,74 @@ class ProformaService:
         req_table = Table(
             req_data,
             colWidths=[
-                0.4 * inch,
+                0.35 * inch,
+                0.8 * inch,
+                0.8 * inch,
+                0.55 * inch,
                 0.9 * inch,
-                0.9 * inch,
-                0.95 * inch,
-                1.0 * inch,
-                CONTENT_WIDTH - 4.15 * inch,
+                1.1 * inch,
+                CONTENT_WIDTH - 4.5 * inch,
             ],
             repeatRows=1,
         )
         req_table.setStyle(_data_table_style(header_size=10, body_size=9))
         return req_table
+
+    @staticmethod
+    def _build_edge_bandings_table(
+        carrier: ProformaCarrier, cell_style, with_prices: bool = True
+    ) -> Table:
+        """Resumen de tapacantos por tipo. Con precios (proforma) o sin ellos
+        (hoja de producción)."""
+        summary = carrier.edge_bandings_summary
+        if with_prices:
+            header = [
+                "Código",
+                "Descripción",
+                "Espesor",
+                "Metros",
+                "P. Unit.",
+                "Subtotal",
+            ]
+        else:
+            header = ["Código", "Descripción", "Espesor", "Metros"]
+        eb_data = [header]
+        for entry in summary:
+            row = [
+                entry.get("product_code", "N/A"),
+                Paragraph(entry.get("product_name", "N/A"), cell_style),
+                f"{(entry.get('thickness') or 0):.2f} mm",
+                f"{entry.get('billed_linear_m', 0)} m",
+            ]
+            if with_prices:
+                row.append(f"${entry.get('price_per_m', 0):.2f}")
+                row.append(f"${entry.get('total_cost', 0):.2f}")
+            eb_data.append(row)
+
+        if with_prices:
+            col_widths = [
+                0.9 * inch,
+                CONTENT_WIDTH - 4.3 * inch,
+                0.9 * inch,
+                0.8 * inch,
+                0.8 * inch,
+                0.9 * inch,
+            ]
+        else:
+            col_widths = [
+                1.0 * inch,
+                CONTENT_WIDTH - 3.0 * inch,
+                1.0 * inch,
+                1.0 * inch,
+            ]
+        eb_table = Table(eb_data, colWidths=col_widths, repeatRows=1)
+        eb_table.setStyle(
+            _data_table_style(
+                header_size=9 if with_prices else 10,
+                body_size=8 if with_prices else 9,
+            )
+        )
+        return eb_table
 
     @staticmethod
     def _build_materials_table(carrier: ProformaCarrier, cell_style) -> Table:
@@ -503,10 +578,17 @@ class ProformaService:
 
     @staticmethod
     def _build_totals_table(carrier: ProformaCarrier) -> Table:
-        summary_data = [
-            ["Total de tableros utilizados:", str(carrier.total_boards_used)],
-            ["Costo total estimado:", f"${carrier.total_boards_cost:.2f}"],
-        ]
+        if carrier.edge_bandings_summary:
+            summary_data = [
+                ["Costo de tableros:", f"${carrier.total_boards_cost:.2f}"],
+                ["Costo de tapacantos:", f"${carrier.total_edge_banding_cost:.2f}"],
+                ["Costo total estimado:", f"${carrier.total_cost:.2f}"],
+            ]
+        else:
+            summary_data = [
+                ["Total de tableros utilizados:", str(carrier.total_boards_used)],
+                ["Costo total estimado:", f"${carrier.total_boards_cost:.2f}"],
+            ]
         return _totals_table(summary_data)
 
     @staticmethod
@@ -570,6 +652,19 @@ def pdf_response(
         media_type="application/pdf",
         headers={"Content-Disposition": f"attachment; filename={filename}"},
     )
+
+
+_SIDE_LABELS = {"top": "Sup", "bottom": "Inf", "left": "Izq", "right": "Der"}
+
+
+def _edge_sides_label(req: dict) -> str:
+    """Notación compacta de los lados canteados de una pieza (Sup/Inf/Izq/Der)."""
+    spec = req.get("edge_banding")
+    if not spec:
+        return "-"
+    sides = set(spec.get("sides") or [])
+    labels = [_SIDE_LABELS[s] for s in ("top", "bottom", "left", "right") if s in sides]
+    return ", ".join(labels) if labels else "-"
 
 
 def _heading_style(styles) -> ParagraphStyle:

--- a/src/modules/optimizations/schemas.py
+++ b/src/modules/optimizations/schemas.py
@@ -1,6 +1,7 @@
+from enum import Enum
 from typing import List, Optional
 
-from pydantic import Field, NonNegativeInt, PositiveInt
+from pydantic import Field, NonNegativeInt, PositiveInt, field_validator
 
 from src.modules.clients.schemas import ClientResponse
 from src.shared.schemas import CamelModel
@@ -17,6 +18,54 @@ class MaterialSummary(CamelModel):
     total_area_m2: float
     avg_efficiency: float
     cost_per_unit: float
+    total_cost: float
+
+
+class EdgeSide(str, Enum):
+    """Lados nominales de una pieza (marco sin rotar).
+
+    ``top``/``bottom`` son los lados de longitud ``width`` (ancho); ``left``/
+    ``right`` los de longitud ``height`` (alto).
+    """
+
+    top = "top"
+    bottom = "bottom"
+    left = "left"
+    right = "right"
+
+
+class EdgeBandingSpec(CamelModel):
+    """Tapacanto a aplicar en una pieza: un producto y los lados a tapar."""
+
+    product_id: int = Field(
+        ..., description="Edge banding product ID (type=edge_banding)"
+    )
+    sides: List[EdgeSide] = Field(
+        ...,
+        min_length=1,
+        description="Nominal sides to band (top/bottom=ancho, left/right=alto)",
+    )
+
+    @field_validator("sides")
+    @classmethod
+    def _unique_sides(cls, sides: List[EdgeSide]) -> List[EdgeSide]:
+        if len(set(sides)) != len(sides):
+            raise ValueError("sides must not contain duplicates")
+        return sides
+
+
+class EdgeBandingSummary(CamelModel):
+    product_id: int
+    product_code: str
+    product_name: str
+    thickness: float
+    color: Optional[str] = None
+    net_linear_m: float = Field(
+        ..., description="Net linear meters (sum of banded sides)"
+    )
+    linear_m: float = Field(..., description="Linear meters including waste factor")
+    billed_linear_m: int = Field(..., description="Whole meters charged (rounded up)")
+    price_per_m: float = Field(..., description="Frozen price per linear meter")
     total_cost: float
 
 
@@ -37,8 +86,13 @@ class Requirement(CamelModel):
         default=True,
         description=(
             "If true, the optimizer may swap height↔width (rotate 90°) to improve "
-            "yield. Set false for pieces with a fixed orientation (grain/pattern)."
+            "yield. Set false for pieces with a fixed orientation (grain/pattern). "
+            "Edge banding is remapped to the rotated sides, so it does not block "
+            "rotation."
         ),
+    )
+    edge_banding: Optional[EdgeBandingSpec] = Field(
+        default=None, description="Optional edge banding for this piece"
     )
 
 
@@ -85,6 +139,10 @@ class PlacedPiece(CamelModel):
     )
     original_width: float = Field(
         ..., description="Piece width (ancho) before rotation"
+    )
+    edges: Optional[dict] = Field(
+        default=None,
+        description="Edge banding on the geometric sides of the placed piece",
     )
 
 
@@ -140,11 +198,17 @@ class OptimizeResponse(CamelModel):
     )
     total_boards_used: int = Field(..., description="Total number of boards used")
     total_boards_cost: float = Field(..., description="Total cost of boards used")
+    total_edge_banding_cost: float = Field(
+        default=0.0, description="Total cost of edge banding used"
+    )
     layouts: List[Layout] = Field(
         ..., description="Per-sheet cutting layouts of the optimization"
     )
     materials_summary: Optional[List[MaterialSummary]] = Field(
         default=None, description="Aggregated materials grouped by board type"
+    )
+    edge_bandings_summary: Optional[List[EdgeBandingSummary]] = Field(
+        default=None, description="Aggregated edge banding grouped by type"
     )
     layout_groups: Optional[List[LayoutGroup]] = Field(
         default=None, description="Cutting layouts deduplicated by identical pattern"

--- a/src/modules/optimizations/service.py
+++ b/src/modules/optimizations/service.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import math
 from collections import defaultdict
 from typing import Dict, List, Tuple
 
@@ -17,8 +18,10 @@ from src.cutting import (
 from src.modules.clients.model import ClientModel
 from src.modules.clients.service import require_phone
 from src.modules.optimizations.carrier import ProformaCarrier
-from src.modules.optimizations.patterns import group_layouts
+from src.modules.optimizations.patterns import base_label, group_layouts
 from src.modules.optimizations.schemas import (
+    EdgeBandingSpec,
+    EdgeSide,
     OptimizeRequest,
     OptimizeResponse,
     Requirement,
@@ -33,6 +36,12 @@ from src.shared.exceptions import (
     EntityNotFoundError,
     ValidationError,
 )
+
+# Reubicación de cantos cuando la pieza sale rotada del optimizador. Convención:
+# giro de 90° en sentido horario (top→right→bottom→left→top). El optimizador solo
+# intercambia ancho↔alto, así que fijamos esta convención para dibujar el canto en
+# el lado físico correcto de la pieza ya rotada.
+_CW_ROTATION = {"top": "right", "right": "bottom", "bottom": "left", "left": "top"}
 
 
 class OptimizationService:
@@ -66,8 +75,10 @@ class OptimizationService:
             optimization_hash=optimization_hash,
             total_boards_used=payload["total_boards_used"],
             total_boards_cost=payload["total_boards_cost"],
+            total_edge_banding_cost=payload.get("total_edge_banding_cost", 0.0),
             layouts=payload["layouts"],
             materials_summary=payload["materials_summary"],
+            edge_bandings_summary=payload.get("edge_bandings_summary"),
             layout_groups=payload["layout_groups"],
         )
 
@@ -129,7 +140,11 @@ class OptimizationService:
                 )
             products[product_id] = product
 
-        optimization_hash = self._compute_hash(request, cutting_params, products)
+        eb_products = self._resolve_edge_banding_products(request.requirements)
+
+        optimization_hash = self._compute_hash(
+            request, cutting_params, products, eb_products
+        )
 
         cached = cache.get_json(optimization_hash)
         if cached is not None:
@@ -138,41 +153,75 @@ class OptimizationService:
         product_codes = {pid: product.code for pid, product in products.items()}
         product_names = {pid: product.name for pid, product in products.items()}
         results = [
-            self._optimize(
-                pieces=requirements_by_product[pid],
-                product=products[pid],
-                cutting_params=cutting_params,
+            (
+                reqs,
+                self._optimize(
+                    pieces=reqs,
+                    product=products[pid],
+                    cutting_params=cutting_params,
+                )[0],
             )
-            for pid in requirements_by_product
+            for pid, reqs in requirements_by_product.items()
         ]
 
         payload = self._build_result_payload(
-            request, results, product_codes, product_names
+            request, results, product_codes, product_names, eb_products
         )
         cache.set_json(optimization_hash, payload)
         return payload, optimization_hash
+
+    def _resolve_edge_banding_products(
+        self, requirements: List[Requirement]
+    ) -> Dict[int, ProductModel]:
+        """Resuelve y valida los productos de tapacanto referenciados por las piezas.
+
+        Mismo contrato que la validación de tableros: 404 si no existe, regla de
+        negocio si el producto no es de tipo ``edge_banding``.
+        """
+        eb_products: Dict[int, ProductModel] = {}
+        for req in requirements:
+            if req.edge_banding is None:
+                continue
+            pid = req.edge_banding.product_id
+            if pid in eb_products:
+                continue
+            product = self.product_service.get(pid)
+            if product is None:
+                raise EntityNotFoundError("Product", pid)
+            if product.type != ProductType.EDGE_BANDING.value:
+                raise BusinessRuleError(
+                    f"El producto {product.code} no es un tapacanto"
+                )
+            eb_products[pid] = product
+        return eb_products
 
     def _compute_hash(
         self,
         request: OptimizeRequest,
         cutting_params: CuttingParameters,
         products: Dict[int, ProductModel],
+        eb_products: Dict[int, ProductModel],
     ) -> str:
         """Hash sha256 determinista de las entradas que afectan el resultado.
 
         No incluye ``client_id`` (el cómputo no depende del cliente); la dedupe de
-        órdenes sí combina ``client_id`` con este hash.
+        órdenes sí combina ``client_id`` con este hash. Incluye los precios de
+        tableros y tapacantos y el factor de merma para invalidar la caché cuando
+        cambian.
         """
+        prices = {str(pid): product.price for pid, product in products.items()}
+        prices.update({str(pid): p.price for pid, p in eb_products.items()})
         digest_input = {
-            "requirements": [r.model_dump() for r in request.requirements],
+            "requirements": [r.model_dump(mode="json") for r in request.requirements],
             "params": {
                 "kerf": cutting_params.kerf,
                 "top_trim": cutting_params.top_trim,
                 "bottom_trim": cutting_params.bottom_trim,
                 "left_trim": cutting_params.left_trim,
                 "right_trim": cutting_params.right_trim,
+                "edge_banding_waste_factor": config.EDGE_BANDING_WASTE_FACTOR,
             },
-            "prices": {str(pid): product.price for pid, product in products.items()},
+            "prices": prices,
         }
         canonical = json.dumps(digest_input, sort_keys=True, separators=(",", ":"))
         return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
@@ -232,36 +281,132 @@ class OptimizationService:
         )
         return optimizer.optimize(piece_objects)
 
+    def _edge_map_for(self, reqs: List[Requirement]) -> Dict[str, EdgeBandingSpec]:
+        """Mapa ``id asignado -> EdgeBandingSpec`` (mismo id que arma ``_optimize``)."""
+        edge_map: Dict[str, EdgeBandingSpec] = {}
+        for i, p in enumerate(reqs):
+            if p.edge_banding is not None:
+                edge_map[p.label or f"piece_{i+1}"] = p.edge_banding
+        return edge_map
+
+    def _geometric_edges(
+        self, spec: EdgeBandingSpec, eb_products: Dict[int, ProductModel], rotated: bool
+    ) -> dict:
+        """Traduce los lados nominales a los lados geométricos de la pieza dibujada.
+
+        Sin rotar: identidad. Rotada: el optimizador solo intercambia ancho↔alto
+        (un bounding box, sin sentido de giro), así que adoptamos por convención un
+        giro de 90° horario y reubicamos cada canto (``_CW_ROTATION``). Una
+        rotación pura siempre es físicamente realizable, por lo que el canteado
+        asimétrico no impide rotar: simplemente se intercambian los lados.
+        """
+        sides = {s.value for s in spec.sides}
+        if rotated:
+            sides = {_CW_ROTATION[s] for s in sides}
+        geo = [s for s in ("top", "bottom", "left", "right") if s in sides]
+        product = eb_products.get(spec.product_id)
+        attrs = (product.attributes if product else None) or {}
+        return {
+            "sides": geo,
+            "product_id": spec.product_id,
+            "code": product.code if product else None,
+            "color": attrs.get("color"),
+        }
+
+    def _enrich_layout_pieces(
+        self,
+        layout_dict: dict,
+        edge_map: Dict[str, EdgeBandingSpec],
+        eb_products: Dict[int, ProductModel],
+    ) -> None:
+        """Añade ``edges`` (lados geométricos canteados) a cada pieza colocada."""
+        for placed in layout_dict.get("placed_pieces", []):
+            spec = edge_map.get(base_label(str(placed.get("piece_id", ""))))
+            if spec is None:
+                continue
+            placed["edges"] = self._geometric_edges(
+                spec, eb_products, bool(placed.get("rotated"))
+            )
+
+    def _build_edge_bandings_summary(
+        self,
+        requirements: List[Requirement],
+        eb_products: Dict[int, ProductModel],
+    ) -> Tuple[List[dict], float]:
+        """Agrega el metraje de tapacanto por tipo y devuelve ``(summary, total)``.
+
+        El metraje neto es la suma de los lados tapados (``width`` para
+        ``top/bottom``, ``height`` para ``left/right``) por la cantidad; es
+        independiente de la rotación. Se aplica la merma configurada y se redondea
+        al metro entero que se cobra.
+        """
+        waste = config.EDGE_BANDING_WASTE_FACTOR
+        net_mm: Dict[int, float] = defaultdict(float)
+        for req in requirements:
+            spec = req.edge_banding
+            if spec is None:
+                continue
+            per_piece = sum(
+                req.width if side in (EdgeSide.top, EdgeSide.bottom) else req.height
+                for side in spec.sides
+            )
+            net_mm[spec.product_id] += per_piece * req.quantity
+
+        summary: List[dict] = []
+        total_cost = 0.0
+        for pid, mm in net_mm.items():
+            product = eb_products[pid]
+            attrs = product.attributes or {}
+            net_m = mm / 1000.0
+            with_waste = net_m * (1 + waste)
+            billed = math.ceil(with_waste)
+            cost = round(billed * product.price, 2)
+            total_cost += cost
+            summary.append(
+                {
+                    "product_id": pid,
+                    "product_code": product.code,
+                    "product_name": product.name,
+                    "thickness": attrs.get("thickness"),
+                    "color": attrs.get("color"),
+                    "net_linear_m": round(net_m, 2),
+                    "linear_m": round(with_waste, 2),
+                    "billed_linear_m": billed,
+                    "price_per_m": product.price,
+                    "total_cost": cost,
+                }
+            )
+        return summary, round(total_cost, 2)
+
     def _build_materials_summary(
         self,
-        results: List[Tuple[List[CuttingLayout], List[Piece]]],
+        layouts: List[CuttingLayout],
         product_codes: Dict[int, str],
         product_names: Dict[int, str],
     ) -> List[dict]:
         """Agrega los layouts por tipo de tablero con métricas y costos."""
         summary: Dict[int, dict] = {}
-        for layouts, _ in results:
-            for layout in layouts:
-                pid = layout.material.id
-                if pid not in summary:
-                    summary[pid] = {
-                        "product_id": pid,
-                        "product_code": product_codes.get(pid, "N/A"),
-                        "product_name": product_names.get(pid, "N/A"),
-                        "width": layout.material.width,
-                        "height": layout.material.height,
-                        "thickness": layout.material.thickness,
-                        "count": 0,
-                        "total_area_m2": 0.0,
-                        "_efficiencies": [],
-                        "cost_per_unit": layout.material.cost_per_unit,
-                        "total_cost": 0.0,
-                    }
-                entry = summary[pid]
-                entry["count"] += 1
-                entry["total_area_m2"] += round(layout.material.area / 1_000_000, 4)
-                entry["_efficiencies"].append(layout.efficiency * 100)
-                entry["total_cost"] += layout.material.cost_per_unit
+        for layout in layouts:
+            pid = layout.material.id
+            if pid not in summary:
+                summary[pid] = {
+                    "product_id": pid,
+                    "product_code": product_codes.get(pid, "N/A"),
+                    "product_name": product_names.get(pid, "N/A"),
+                    "width": layout.material.width,
+                    "height": layout.material.height,
+                    "thickness": layout.material.thickness,
+                    "count": 0,
+                    "total_area_m2": 0.0,
+                    "_efficiencies": [],
+                    "cost_per_unit": layout.material.cost_per_unit,
+                    "total_cost": 0.0,
+                }
+            entry = summary[pid]
+            entry["count"] += 1
+            entry["total_area_m2"] += round(layout.material.area / 1_000_000, 4)
+            entry["_efficiencies"].append(layout.efficiency * 100)
+            entry["total_cost"] += layout.material.cost_per_unit
 
         result = []
         for entry in summary.values():
@@ -275,37 +420,49 @@ class OptimizationService:
     def _build_result_payload(
         self,
         request: OptimizeRequest,
-        results: List[Tuple[List[CuttingLayout], List[Piece]]],
+        results: List[Tuple[List[Requirement], List[CuttingLayout]]],
         product_codes: Dict[int, str],
         product_names: Dict[int, str],
+        eb_products: Dict[int, ProductModel],
     ) -> dict:
         """Arma el payload cacheable/serializable del resultado de optimización.
 
         Mismas claves que consumen ``proforma`` y el snapshot de las órdenes.
+        ``results`` agrupa por tablero como ``(requerimientos, layouts)`` para
+        enriquecer cada pieza colocada con sus lados canteados sin colisión de ids.
         """
-        total_boards_used = sum(len(layouts) for layouts, _ in results)
-        total_boards_cost = sum(
-            layout.material.cost_per_unit
-            for layouts, _ in results
-            for layout in layouts
+        all_layouts = [layout for _, layouts in results for layout in layouts]
+        total_boards_used = len(all_layouts)
+        total_boards_cost = sum(layout.material.cost_per_unit for layout in all_layouts)
+
+        layout_dicts: List[dict] = []
+        for reqs, layouts in results:
+            edge_map = self._edge_map_for(reqs)
+            for layout in layouts:
+                layout_dict = layout.to_dict()
+                if edge_map:
+                    self._enrich_layout_pieces(layout_dict, edge_map, eb_products)
+                layout_dicts.append(layout_dict)
+
+        edge_bandings_summary, total_edge_banding_cost = (
+            self._build_edge_bandings_summary(request.requirements, eb_products)
         )
-        layout_dicts = [
-            layout.to_dict() for layouts, _ in results for layout in layouts
-        ]
         return {
             "total_boards_used": total_boards_used,
             "total_boards_cost": total_boards_cost,
+            "total_edge_banding_cost": total_edge_banding_cost,
             "requirements": [
                 {
-                    **r.model_dump(),
+                    **r.model_dump(mode="json"),
                     "product_code": product_codes.get(r.product_id, "N/A"),
                 }
                 for r in request.requirements
             ],
             "layouts": layout_dicts,
             "materials_summary": self._build_materials_summary(
-                results, product_codes, product_names
+                all_layouts, product_codes, product_names
             ),
+            "edge_bandings_summary": edge_bandings_summary,
             "layout_groups": group_layouts(layout_dicts),
         }
 

--- a/src/modules/optimizations/visualization.py
+++ b/src/modules/optimizations/visualization.py
@@ -24,6 +24,24 @@ COLOR_EFFICIENCY = "#2E7D32"
 COLOR_WASTE_FILL = "#ECECEC"  # gris neutro: contrasta con el coral de las piezas
 COLOR_WASTE_OUTLINE = "#9E9E9E"
 
+# Paleta para distinguir tipos de tapacanto en el diagrama. El color del producto
+# suele ser un nombre (p. ej. "Nogal") no parseable por Pillow, así que se asigna
+# un color de esta paleta de forma determinista por código.
+EDGE_BANDING_PALETTE = [
+    "#1E88E5",
+    "#8E24AA",
+    "#00897B",
+    "#F4511E",
+    "#3949AB",
+    "#6D4C41",
+]
+
+
+def _edge_banding_color(code: str) -> str:
+    """Color estable (mismo en todas las páginas) para un código de tapacanto."""
+    idx = sum(ord(c) for c in (code or "")) % len(EDGE_BANDING_PALETTE)
+    return EDGE_BANDING_PALETTE[idx]
+
 
 def _load_font(size: int) -> ImageFont.FreeTypeFont:
     """Carga una fuente TrueType escalable; cae al bitmap por defecto si no hay."""
@@ -104,7 +122,17 @@ class VisualizationService:
         label_font = _load_font(30)
         legend_font = _load_font(32)
 
-        VisualizationService._draw_legend(draw, margin, 24, legend_font)
+        # Tapacantos presentes en este patrón (código -> color) para la leyenda.
+        edge_legend: dict = {}
+        for piece in layout.get("placed_pieces", []):
+            edges = piece.get("edges") or {}
+            if edges.get("sides"):
+                code = edges.get("code") or "Tapacanto"
+                edge_legend.setdefault(code, _edge_banding_color(code))
+
+        VisualizationService._draw_legend(
+            draw, margin, 24, legend_font, edge_legend, max_x=canvas_width - margin
+        )
 
         board_x = margin
         board_y = info_height
@@ -164,26 +192,38 @@ class VisualizationService:
         x: int,
         y: int,
         legend_font: ImageFont.ImageFont,
+        edge_legend: Optional[dict] = None,
+        max_x: Optional[int] = None,
     ) -> None:
-        """Dibuja la leyenda de colores (pieza vs retazo)."""
+        """Dibuja la leyenda de colores (pieza, retazo y tipos de tapacanto).
+
+        Envuelve en una nueva fila cuando una entrada se saldría de ``max_x`` para
+        que no se recorte al haber varios tipos de tapacanto.
+        """
         legend = [
             (COLOR_PIECE_FILL, COLOR_PIECE_OUTLINE, "Pieza"),
             (COLOR_WASTE_FILL, COLOR_WASTE_OUTLINE, "Retazo / Desperdicio"),
         ]
+        for code, color in (edge_legend or {}).items():
+            legend.append((color, color, f"Tapacanto {code}"))
         box = 32
+        start_x = x
         for fill, outline, text in legend:
+            tw, th = _text_size(text, legend_font)
+            item_w = box + 12 + tw + 50
+            if max_x is not None and x > start_x and x + box + 12 + tw > max_x:
+                x = start_x
+                y += box + 16
             draw.rectangle(
                 [x, y, x + box, y + box], fill=fill, outline=outline, width=2
             )
-            th = _text_size(text, legend_font)[1]
             draw.text(
                 (x + box + 12, y + (box - th) // 2),
                 text,
                 fill="black",
                 font=legend_font,
             )
-            tw, _ = _text_size(text, legend_font)
-            x += box + 12 + tw + 50
+            x += item_w
 
     @staticmethod
     def _draw_piece(
@@ -209,6 +249,22 @@ class VisualizationService:
             outline=COLOR_PIECE_OUTLINE,
             width=2,
         )
+
+        # Franjas de tapacanto sobre los lados geométricos canteados (se dibujan
+        # antes de las cotas para que los números queden legibles encima).
+        edges = piece.get("edges") or {}
+        sides = set(edges.get("sides") or [])
+        if sides:
+            color = _edge_banding_color(edges.get("code") or "Tapacanto")
+            t = max(6, int(min(pw, ph) * 0.06))
+            if "top" in sides:
+                draw.rectangle([px, py, px + pw, py + t], fill=color)
+            if "bottom" in sides:
+                draw.rectangle([px, py + ph - t, px + pw, py + ph], fill=color)
+            if "left" in sides:
+                draw.rectangle([px, py, px + t, py + ph], fill=color)
+            if "right" in sides:
+                draw.rectangle([px + pw - t, py, px + pw, py + ph], fill=color)
 
         pad = 4
 

--- a/src/modules/orders/model.py
+++ b/src/modules/orders/model.py
@@ -108,6 +108,9 @@ class OrderLineModel(Base):
     line_total: Mapped[float] = mapped_column(Float)
     avg_efficiency: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
     total_area_m2: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    # Tapacanto: metros lineales exactos (con merma) para mostrar; ``quantity``
+    # guarda los metros enteros cobrados. Nulo para tableros.
+    linear_m: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
 
     order: Mapped["OrderModel"] = relationship("OrderModel", back_populates="lines")
 
@@ -129,6 +132,9 @@ class OrderPieceModel(Base):
     quantity: Mapped[int] = mapped_column(Integer)
     priority: Mapped[int] = mapped_column(Integer, default=0)
     can_rotate: Mapped[bool] = mapped_column(Boolean, default=True)
+    # Tapacanto de la pieza (lados nominales + producto), p. ej.
+    # ``{"product_id": 42, "sides": ["top", "left"]}``. Nulo si no lleva canto.
+    edges: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
 
     order: Mapped["OrderModel"] = relationship("OrderModel", back_populates="pieces")
 

--- a/src/modules/orders/schemas.py
+++ b/src/modules/orders/schemas.py
@@ -67,11 +67,17 @@ class OrderLineResponse(CamelModel):
     product_id: int
     product_code: Optional[str] = None
     product_name: Optional[str] = None
-    quantity: int = Field(..., description="Number of boards charged (cobro=tableros)")
+    quantity: int = Field(
+        ...,
+        description="Units charged: boards for tableros, whole linear meters for edge banding",
+    )
     unit_price_snapshot: float
     line_total: float
     avg_efficiency: Optional[float] = None
     total_area_m2: Optional[float] = None
+    linear_m: Optional[float] = Field(
+        default=None, description="Exact linear meters (incl. waste) for edge banding"
+    )
 
 
 class OrderPieceResponse(CamelModel):
@@ -83,6 +89,9 @@ class OrderPieceResponse(CamelModel):
     quantity: int
     priority: int
     can_rotate: bool
+    edges: Optional[dict] = Field(
+        default=None, description="Edge banding spec (nominal sides + product)"
+    )
 
 
 class OrderStatusHistoryResponse(CamelModel):

--- a/src/modules/orders/service.py
+++ b/src/modules/orders/service.py
@@ -83,6 +83,10 @@ class OrderService:
 
         self._enforce_pending_cap(data.client_id)
 
+        total_boards_cost = payload["total_boards_cost"]
+        total_edge_banding_cost = payload.get("total_edge_banding_cost", 0.0)
+        grand_total = round(total_boards_cost + total_edge_banding_cost, 2)
+
         now = datetime.utcnow()
         order = OrderModel(
             client_id=data.client_id,
@@ -90,8 +94,8 @@ class OrderService:
             optimization_snapshot=payload,
             optimization_hash=optimization_hash,
             currency="USD",
-            subtotal=payload["total_boards_cost"],
-            total=payload["total_boards_cost"],
+            subtotal=grand_total,
+            total=grand_total,
             total_boards_used=payload["total_boards_used"],
             source=data.source,
             notes=data.notes,
@@ -99,7 +103,7 @@ class OrderService:
             confirmed_at=now,
             expires_at=now + timedelta(days=config.ORDER_VALIDITY_DAYS),
         )
-        # Líneas de cobro = tableros usados (desde materials_summary).
+        # Líneas de cobro = tableros usados + tapacantos (productos consumidos).
         order.lines = [
             OrderLineModel(
                 product_id=m["product_id"],
@@ -112,6 +116,17 @@ class OrderService:
                 total_area_m2=m.get("total_area_m2"),
             )
             for m in payload["materials_summary"]
+        ] + [
+            OrderLineModel(
+                product_id=e["product_id"],
+                product_code=e.get("product_code"),
+                product_name=e.get("product_name"),
+                quantity=e["billed_linear_m"],
+                unit_price_snapshot=e["price_per_m"],
+                line_total=e["total_cost"],
+                linear_m=e.get("linear_m"),
+            )
+            for e in payload.get("edge_bandings_summary", [])
         ]
         # Lista de corte = piezas (insumo de producción; no se cobra).
         order.pieces = [
@@ -123,6 +138,7 @@ class OrderService:
                 quantity=r["quantity"],
                 priority=r.get("priority", 0),
                 can_rotate=r.get("can_rotate", True),
+                edges=r.get("edge_banding"),
             )
             for r in payload["requirements"]
         ]

--- a/src/shared/config.py
+++ b/src/shared/config.py
@@ -68,6 +68,10 @@ class Config:
     LEFT_TRIM = env.float("LEFT_TRIM", 0.0)
     RIGHT_TRIM = env.float("RIGHT_TRIM", 0.0)
 
+    # Tapacantos: merma (sobrante de canteadora) aplicada al metraje neto antes de
+    # redondear al metro entero que se cobra. 0.10 = +10%.
+    EDGE_BANDING_WASTE_FACTOR = env.float("EDGE_BANDING_WASTE_FACTOR", 0.10)
+
     OPT_RESULT_TTL_SECONDS = env.int("OPT_RESULT_TTL_SECONDS", 259200)
 
     # Órdenes: vigencia de la cotización y tope de pendientes por cliente (antiabuso)

--- a/tests/test_edge_banding.py
+++ b/tests/test_edge_banding.py
@@ -1,0 +1,336 @@
+"""Tests de tapacantos: metraje, validación, regla de rotación y cobro en órdenes."""
+
+import math
+
+import pytest
+
+from src.modules.optimizations.schemas import EdgeBandingSpec, EdgeSide
+from src.modules.optimizations.service import OptimizationService
+from src.shared.config import config
+
+
+def _create_client(client, identifier="0991112233", phone="0991112233"):
+    return client.post(
+        "/api/v1/clients/",
+        json={
+            "identifier": identifier,
+            "firstName": "Ada",
+            "lastName": "Lovelace",
+            "phone": phone,
+        },
+    ).json()["data"]
+
+
+def _create_board(client, code="MEL18", price=45.5):
+    return client.post(
+        "/api/v1/products/",
+        json={
+            "type": "board",
+            "code": code,
+            "name": f"Melamina {code}",
+            "price": price,
+            "attributes": {"height": 2440, "width": 1220, "thickness": 18},
+        },
+    ).json()["data"]
+
+
+def _create_edge_banding(client, code="TAP22", price=2.0, color="Blanco"):
+    return client.post(
+        "/api/v1/products/",
+        json={
+            "type": "edge_banding",
+            "code": code,
+            "name": f"Tapacanto {code}",
+            "price": price,
+            "attributes": {
+                "thickness": 0.45,
+                "width": 22,
+                "color": color,
+                "length": 50000,
+            },
+        },
+    ).json()["data"]
+
+
+def _requirement(board_id, eb_id, sides, height=500, width=1000, quantity=1):
+    return {
+        "priority": 0,
+        "height": height,
+        "width": width,
+        "quantity": quantity,
+        "productId": board_id,
+        "label": "Costado",
+        "canRotate": True,
+        "edgeBanding": {"productId": eb_id, "sides": sides},
+    }
+
+
+def _expected_meters(net_m: float):
+    """Replica la fórmula del servicio: merma + redondeo al metro entero."""
+    with_waste = net_m * (1 + config.EDGE_BANDING_WASTE_FACTOR)
+    return round(with_waste, 2), math.ceil(with_waste)
+
+
+# --------------------------------------------------------------------------- #
+# Metraje y costo (endpoint /optimize)
+# --------------------------------------------------------------------------- #
+def test_optimize_aggregates_edge_banding_meters_and_cost(client):
+    c = _create_client(client)
+    b = _create_board(client)
+    eb = _create_edge_banding(client, price=2.0)
+
+    # height=500 (alto), width=1000 (ancho); lados top+bottom = 2×ancho = 2000 mm.
+    resp = client.post(
+        "/api/v1/optimize/",
+        json={
+            "clientId": c["id"],
+            "requirements": [_requirement(b["id"], eb["id"], ["top", "bottom"])],
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+
+    summary = data["edgeBandingsSummary"]
+    assert summary is not None and len(summary) == 1
+    entry = summary[0]
+    assert entry["productCode"] == "TAP22"
+    assert entry["color"] == "Blanco"
+    assert entry["netLinearM"] == pytest.approx(2.0)
+
+    linear_m, billed = _expected_meters(2.0)
+    assert entry["linearM"] == pytest.approx(linear_m)
+    assert entry["billedLinearM"] == billed
+    assert entry["pricePerM"] == 2.0
+    assert entry["totalCost"] == pytest.approx(round(billed * 2.0, 2))
+    assert data["totalEdgeBandingCost"] == pytest.approx(round(billed * 2.0, 2))
+
+
+def test_optimize_uses_height_for_left_right_sides(client):
+    """left/right miden el alto; top/bottom el ancho."""
+    c = _create_client(client)
+    b = _create_board(client)
+    eb = _create_edge_banding(client, price=1.0)
+
+    # alto=500: left+right = 2×500 = 1000 mm = 1.0 m neto.
+    resp = client.post(
+        "/api/v1/optimize/",
+        json={
+            "clientId": c["id"],
+            "requirements": [_requirement(b["id"], eb["id"], ["left", "right"])],
+        },
+    )
+    data = resp.json()["data"]
+    assert data["edgeBandingsSummary"][0]["netLinearM"] == pytest.approx(1.0)
+
+
+def test_optimize_aggregates_multiple_edge_banding_types(client):
+    c = _create_client(client)
+    b = _create_board(client)
+    eb1 = _create_edge_banding(client, code="TAP22", price=2.0)
+    eb2 = _create_edge_banding(client, code="TAP15", price=3.0, color="Nogal")
+
+    resp = client.post(
+        "/api/v1/optimize/",
+        json={
+            "clientId": c["id"],
+            "requirements": [
+                _requirement(b["id"], eb1["id"], ["top", "bottom"]),
+                _requirement(b["id"], eb2["id"], ["left", "right"], height=1000),
+            ],
+        },
+    )
+    data = resp.json()["data"]
+    summary = {e["productCode"]: e for e in data["edgeBandingsSummary"]}
+    assert set(summary) == {"TAP22", "TAP15"}
+    total = sum(e["totalCost"] for e in data["edgeBandingsSummary"])
+    assert data["totalEdgeBandingCost"] == pytest.approx(round(total, 2))
+
+
+def test_optimize_without_edge_banding_has_empty_summary(client):
+    c = _create_client(client)
+    b = _create_board(client)
+    resp = client.post(
+        "/api/v1/optimize/",
+        json={
+            "clientId": c["id"],
+            "requirements": [
+                {
+                    "priority": 0,
+                    "height": 400,
+                    "width": 600,
+                    "quantity": 1,
+                    "productId": b["id"],
+                    "label": "P",
+                    "canRotate": True,
+                }
+            ],
+        },
+    )
+    data = resp.json()["data"]
+    assert data["totalEdgeBandingCost"] == 0.0
+    assert data["edgeBandingsSummary"] in (None, [])
+
+
+# --------------------------------------------------------------------------- #
+# Validación del producto de tapacanto
+# --------------------------------------------------------------------------- #
+def test_edge_banding_unknown_product_returns_404(client):
+    c = _create_client(client)
+    b = _create_board(client)
+    resp = client.post(
+        "/api/v1/optimize/",
+        json={
+            "clientId": c["id"],
+            "requirements": [_requirement(b["id"], 99999, ["top"])],
+        },
+    )
+    assert resp.status_code == 404
+    assert "Product 99999" in resp.json()["errors"][0]["message"]
+
+
+def test_edge_banding_non_edge_banding_product_rejected(client):
+    """Si edgeBanding.productId apunta a un tablero → regla de negocio 422."""
+    c = _create_client(client)
+    b = _create_board(client)
+    other_board = _create_board(client, code="MEL15")
+    resp = client.post(
+        "/api/v1/optimize/",
+        json={
+            "clientId": c["id"],
+            "requirements": [_requirement(b["id"], other_board["id"], ["top"])],
+        },
+    )
+    assert resp.status_code == 422
+    assert "no es un tapacanto" in resp.json()["errors"][0]["message"].lower()
+
+
+def test_edge_banding_rejects_duplicate_sides(client):
+    c = _create_client(client)
+    b = _create_board(client)
+    eb = _create_edge_banding(client)
+    resp = client.post(
+        "/api/v1/optimize/",
+        json={
+            "clientId": c["id"],
+            "requirements": [_requirement(b["id"], eb["id"], ["top", "top"])],
+        },
+    )
+    assert resp.status_code == 422
+
+
+# --------------------------------------------------------------------------- #
+# Lados geométricos y remapeo al rotar
+# --------------------------------------------------------------------------- #
+def test_geometric_edges_mapping(db_session):
+    svc = OptimizationService(db_session)
+    spec_tb = EdgeBandingSpec(product_id=2, sides=[EdgeSide.top, EdgeSide.bottom])
+    spec_lr = EdgeBandingSpec(product_id=2, sides=[EdgeSide.left, EdgeSide.right])
+    spec_asym = EdgeBandingSpec(
+        product_id=2, sides=[EdgeSide.top, EdgeSide.left, EdgeSide.right]
+    )
+
+    # Sin rotar: identidad.
+    assert svc._geometric_edges(spec_tb, {}, False)["sides"] == ["top", "bottom"]
+    assert svc._geometric_edges(spec_asym, {}, False)["sides"] == [
+        "top",
+        "left",
+        "right",
+    ]
+    # Rotada (giro 90° horario): top→right, right→bottom, bottom→left, left→top.
+    assert svc._geometric_edges(spec_tb, {}, True)["sides"] == ["left", "right"]
+    assert svc._geometric_edges(spec_lr, {}, True)["sides"] == ["top", "bottom"]
+    # Asimétrico también se remapea (no se bloquea la rotación).
+    assert svc._geometric_edges(spec_asym, {}, True)["sides"] == [
+        "top",
+        "bottom",
+        "right",
+    ]
+
+
+def test_asymmetric_banding_rotates_and_swaps_edges(client):
+    """Canteado asimétrico NO bloquea la rotación: si la pieza sale rotada, los
+    cantos se intercambian al lado físico correspondiente."""
+    c = _create_client(client)
+    b = _create_board(client)  # 2440 (alto) × 1220 (ancho)
+    eb = _create_edge_banding(client)
+
+    # Pieza 1000(alto) × 2000(ancho): solo entra rotada (ancho 2000 > tablero 1220).
+    resp = client.post(
+        "/api/v1/optimize/",
+        json={
+            "clientId": c["id"],
+            "requirements": [
+                _requirement(
+                    b["id"], eb["id"], ["top", "left"], height=1000, width=2000
+                )
+            ],
+        },
+    )
+    placed = resp.json()["data"]["layouts"][0]["placedPieces"][0]
+    assert placed["rotated"] is True
+    # CW: top→right, left→top ⇒ lados geométricos {top, right}.
+    assert placed["edges"]["sides"] == ["top", "right"]
+    assert placed["edges"]["code"] == "TAP22"
+
+
+# --------------------------------------------------------------------------- #
+# Cobro durable en órdenes
+# --------------------------------------------------------------------------- #
+def test_order_charges_edge_banding(client):
+    c = _create_client(client)
+    b = _create_board(client, price=45.5)
+    eb = _create_edge_banding(client, price=2.0)
+
+    resp = client.post(
+        "/api/v1/orders/",
+        json={
+            "clientId": c["id"],
+            "requirements": [_requirement(b["id"], eb["id"], ["top", "bottom"])],
+        },
+    )
+    assert resp.status_code == 201
+    data = resp.json()["data"]
+
+    # Dos líneas de cobro: tablero + tapacanto.
+    lines = {line["productCode"]: line for line in data["lines"]}
+    assert "MEL18" in lines and "TAP22" in lines
+
+    _, billed = _expected_meters(2.0)
+    eb_line = lines["TAP22"]
+    assert eb_line["quantity"] == billed
+    assert eb_line["unitPriceSnapshot"] == 2.0
+    assert eb_line["lineTotal"] == pytest.approx(round(billed * 2.0, 2))
+    assert eb_line["linearM"] is not None
+
+    # Totales inmutables = tableros + tapacantos.
+    expected_total = round(sum(line["lineTotal"] for line in data["lines"]), 2)
+    assert data["subtotal"] == data["total"] == pytest.approx(expected_total)
+
+    # La pieza congela su canteado (lados nominales).
+    assert data["pieces"][0]["edges"]["sides"] == ["top", "bottom"]
+
+    # El export de facturación incluye la línea de tapacanto.
+    exported = client.get(f"/api/v1/orders/{data['id']}/export").json()["data"]
+    codes = {line["productCode"] for line in exported["lines"]}
+    assert {"MEL18", "TAP22"} <= codes
+
+
+def test_order_proforma_with_edge_banding_renders(client):
+    c = _create_client(client)
+    b = _create_board(client)
+    eb = _create_edge_banding(client)
+    order = client.post(
+        "/api/v1/orders/",
+        json={
+            "clientId": c["id"],
+            "requirements": [_requirement(b["id"], eb["id"], ["top", "bottom"])],
+        },
+    ).json()["data"]
+
+    proforma = client.get(f"/api/v1/orders/{order['id']}/proforma")
+    assert proforma.status_code == 200
+    assert len(proforma.content) > 1000
+
+    sheet = client.get(f"/api/v1/orders/{order['id']}/production-sheet")
+    assert sheet.status_code == 200
+    assert len(sheet.content) > 1000


### PR DESCRIPTION
  Let users specify which sides of each cut piece get edge banding, then
  price it on proformas/orders and mark it on the production diagram.

  - Input: each requirement accepts an optional `edgeBanding` { productId, sides } where top/bottom span the width (ancho) and left/right the height (alto).
  - Linear meters are aggregated per edge-banding product in OptimizationService, with a configurable waste factor (EDGE_BANDING_WASTE_FACTOR) and charged per whole meter, rounded up.
  - Edge banding never blocks rotation: when a piece is placed rotated, its banded sides are remapped via a fixed 90° clockwise convention so the diagram marks the correct physical edges.
  - Proforma gains an edge-banding cost breakdown and a "Cantos" column; the production sheet lists banded meters, and the diagram draws colored strips per edge-banding type.
  - Orders charge edge banding as order_lines (with exact linear_m) and freeze the per-piece spec in order_pieces.edges (alembic migration c1d2e3f4a5b6).
  - The pure cutting domain (src/cutting/) is left untouched.