### PR TITLE
refactor: unify proforma materials table and restyle diagram edge bandings

### DIFF
--- a/src/modules/optimizations/proforma.py
+++ b/src/modules/optimizations/proforma.py
@@ -154,13 +154,6 @@ class ProformaService:
         story.append(ProformaService._build_materials_table(carrier, cell_style))
         story.append(Spacer(1, 0.2 * inch))
 
-        if carrier.edge_bandings_summary:
-            story.extend(_section("RESUMEN DE TAPACANTOS", heading_style))
-            story.append(
-                ProformaService._build_edge_bandings_table(carrier, cell_style)
-            )
-            story.append(Spacer(1, 0.2 * inch))
-
         story.append(ProformaService._build_totals_table(carrier))
 
         story.append(PageBreak())
@@ -425,9 +418,9 @@ class ProformaService:
                 0.8 * inch,
                 0.8 * inch,
                 0.55 * inch,
-                0.9 * inch,
+                1.25 * inch,
                 1.1 * inch,
-                CONTENT_WIDTH - 4.5 * inch,
+                CONTENT_WIDTH - 4.85 * inch,
             ],
             repeatRows=1,
         )
@@ -492,51 +485,49 @@ class ProformaService:
 
     @staticmethod
     def _build_materials_table(carrier: ProformaCarrier, cell_style) -> Table:
-        materials_summary = carrier.materials_summary
-        mat_data = [
-            [
-                "Código",
-                "Nombre",
-                "Dimensiones",
-                "Cant.",
-                "Área Total",
-                "Efic. Prom.",
-                "P. Unit.",
-                "Subtotal",
-            ]
-        ]
-        if isinstance(materials_summary, list) and materials_summary:
-            for entry in materials_summary:
-                mat_data.append(
-                    [
-                        entry.get("product_code", "N/A"),
-                        Paragraph(entry.get("product_name", "N/A"), cell_style),
-                        f"{entry.get('height', 0):.0f}×{entry.get('width', 0):.0f} mm",
-                        str(entry.get("count", 0)),
-                        f"{entry.get('total_area_m2', 0):.2f} m²",
-                        f"{entry.get('avg_efficiency', 0):.1f}%",
-                        f"${entry.get('cost_per_unit', 0):.2f}",
-                        f"${entry.get('total_cost', 0):.2f}",
-                    ]
-                )
-        else:
-            mat_data.append(["Sin datos de materiales", "", "", "", "", "", "", ""])
+        """Resumen único de materiales: tableros (cantidad en unidades) y tapacantos
+        (cantidad en metros) en una sola tabla con código, descripción, cantidad,
+        precio unitario y subtotal. Ocupa el ancho completo del contenido."""
+        mat_data = [["Código", "Descripción", "Cantidad", "P. Unit.", "Subtotal"]]
+
+        has_rows = False
+        for entry in carrier.materials_summary or []:
+            has_rows = True
+            mat_data.append(
+                [
+                    entry.get("product_code", "N/A"),
+                    Paragraph(entry.get("product_name", "N/A"), cell_style),
+                    f"{entry.get('count', 0)} u",
+                    f"${entry.get('cost_per_unit', 0):.2f}",
+                    f"${entry.get('total_cost', 0):.2f}",
+                ]
+            )
+        for entry in carrier.edge_bandings_summary or []:
+            has_rows = True
+            mat_data.append(
+                [
+                    entry.get("product_code", "N/A"),
+                    Paragraph(entry.get("product_name", "N/A"), cell_style),
+                    f"{entry.get('billed_linear_m', 0)} m",
+                    f"${entry.get('price_per_m', 0):.2f}",
+                    f"${entry.get('total_cost', 0):.2f}",
+                ]
+            )
+        if not has_rows:
+            mat_data.append(["Sin datos de materiales", "", "", "", ""])
 
         mat_table = Table(
             mat_data,
             colWidths=[
-                0.75 * inch,
-                CONTENT_WIDTH - 5.65 * inch,
-                1.1 * inch,
-                0.5 * inch,
+                1.3 * inch,
+                CONTENT_WIDTH - 3.9 * inch,
                 0.8 * inch,
-                0.7 * inch,
-                0.7 * inch,
                 0.8 * inch,
+                1.0 * inch,
             ],
             repeatRows=1,
         )
-        mat_table.setStyle(_data_table_style(header_size=9, body_size=8))
+        mat_table.setStyle(_data_table_style(header_size=10, body_size=9))
         return mat_table
 
     @staticmethod

--- a/src/modules/optimizations/visualization.py
+++ b/src/modules/optimizations/visualization.py
@@ -24,23 +24,10 @@ COLOR_EFFICIENCY = "#2E7D32"
 COLOR_WASTE_FILL = "#ECECEC"  # gris neutro: contrasta con el coral de las piezas
 COLOR_WASTE_OUTLINE = "#9E9E9E"
 
-# Paleta para distinguir tipos de tapacanto en el diagrama. El color del producto
-# suele ser un nombre (p. ej. "Nogal") no parseable por Pillow, así que se asigna
-# un color de esta paleta de forma determinista por código.
-EDGE_BANDING_PALETTE = [
-    "#1E88E5",
-    "#8E24AA",
-    "#00897B",
-    "#F4511E",
-    "#3949AB",
-    "#6D4C41",
-]
-
-
-def _edge_banding_color(code: str) -> str:
-    """Color estable (mismo en todas las páginas) para un código de tapacanto."""
-    idx = sum(ord(c) for c in (code or "")) % len(EDGE_BANDING_PALETTE)
-    return EDGE_BANDING_PALETTE[idx]
+# Grosor del borde de la pieza. Los lados canteados se resaltan con el mismo color
+# del borde, solo que con una línea más gruesa (sin franja de color por tipo).
+PIECE_OUTLINE_WIDTH = 2
+EDGE_BANDING_WIDTH = PIECE_OUTLINE_WIDTH + 5
 
 
 def _load_font(size: int) -> ImageFont.FreeTypeFont:
@@ -122,16 +109,14 @@ class VisualizationService:
         label_font = _load_font(30)
         legend_font = _load_font(32)
 
-        # Tapacantos presentes en este patrón (código -> color) para la leyenda.
-        edge_legend: dict = {}
-        for piece in layout.get("placed_pieces", []):
-            edges = piece.get("edges") or {}
-            if edges.get("sides"):
-                code = edges.get("code") or "Tapacanto"
-                edge_legend.setdefault(code, _edge_banding_color(code))
+        # ¿Hay alguna pieza canteada en este patrón? (para la entrada de leyenda).
+        has_edge_banding = any(
+            (piece.get("edges") or {}).get("sides")
+            for piece in layout.get("placed_pieces", [])
+        )
 
         VisualizationService._draw_legend(
-            draw, margin, 24, legend_font, edge_legend, max_x=canvas_width - margin
+            draw, margin, 24, legend_font, has_edge_banding, max_x=canvas_width - margin
         )
 
         board_x = margin
@@ -192,30 +177,36 @@ class VisualizationService:
         x: int,
         y: int,
         legend_font: ImageFont.ImageFont,
-        edge_legend: Optional[dict] = None,
+        has_edge_banding: bool = False,
         max_x: Optional[int] = None,
     ) -> None:
-        """Dibuja la leyenda de colores (pieza, retazo y tipos de tapacanto).
+        """Dibuja la leyenda de colores (pieza, retazo y, si aplica, lado canteado).
 
-        Envuelve en una nueva fila cuando una entrada se saldría de ``max_x`` para
-        que no se recorte al haber varios tipos de tapacanto.
+        Envuelve en una nueva fila cuando una entrada se saldría de ``max_x``.
         """
         legend = [
-            (COLOR_PIECE_FILL, COLOR_PIECE_OUTLINE, "Pieza"),
-            (COLOR_WASTE_FILL, COLOR_WASTE_OUTLINE, "Retazo / Desperdicio"),
+            (COLOR_PIECE_FILL, COLOR_PIECE_OUTLINE, PIECE_OUTLINE_WIDTH, "Pieza"),
+            (
+                COLOR_WASTE_FILL,
+                COLOR_WASTE_OUTLINE,
+                PIECE_OUTLINE_WIDTH,
+                "Retazo / Desperdicio",
+            ),
         ]
-        for code, color in (edge_legend or {}).items():
-            legend.append((color, color, f"Tapacanto {code}"))
+        if has_edge_banding:
+            legend.append(
+                ("white", COLOR_PIECE_OUTLINE, EDGE_BANDING_WIDTH, "Lado canteado")
+            )
         box = 32
         start_x = x
-        for fill, outline, text in legend:
+        for fill, outline, width, text in legend:
             tw, th = _text_size(text, legend_font)
             item_w = box + 12 + tw + 50
             if max_x is not None and x > start_x and x + box + 12 + tw > max_x:
                 x = start_x
                 y += box + 16
             draw.rectangle(
-                [x, y, x + box, y + box], fill=fill, outline=outline, width=2
+                [x, y, x + box, y + box], fill=fill, outline=outline, width=width
             )
             draw.text(
                 (x + box + 12, y + (box - th) // 2),
@@ -247,24 +238,28 @@ class VisualizationService:
             [px, py, px + pw, py + ph],
             fill=COLOR_PIECE_FILL,
             outline=COLOR_PIECE_OUTLINE,
-            width=2,
+            width=PIECE_OUTLINE_WIDTH,
         )
 
-        # Franjas de tapacanto sobre los lados geométricos canteados (se dibujan
+        # Lados canteados: se resaltan con el mismo color del borde de la pieza, solo
+        # que con una banda más gruesa pintada DESDE el borde HACIA ADENTRO (se dibujan
         # antes de las cotas para que los números queden legibles encima).
         edges = piece.get("edges") or {}
         sides = set(edges.get("sides") or [])
         if sides:
-            color = _edge_banding_color(edges.get("code") or "Tapacanto")
-            t = max(6, int(min(pw, ph) * 0.06))
+            w = EDGE_BANDING_WIDTH
             if "top" in sides:
-                draw.rectangle([px, py, px + pw, py + t], fill=color)
+                draw.rectangle([px, py, px + pw, py + w], fill=COLOR_PIECE_OUTLINE)
             if "bottom" in sides:
-                draw.rectangle([px, py + ph - t, px + pw, py + ph], fill=color)
+                draw.rectangle(
+                    [px, py + ph - w, px + pw, py + ph], fill=COLOR_PIECE_OUTLINE
+                )
             if "left" in sides:
-                draw.rectangle([px, py, px + t, py + ph], fill=color)
+                draw.rectangle([px, py, px + w, py + ph], fill=COLOR_PIECE_OUTLINE)
             if "right" in sides:
-                draw.rectangle([px + pw - t, py, px + pw, py + ph], fill=color)
+                draw.rectangle(
+                    [px + pw - w, py, px + pw, py + ph], fill=COLOR_PIECE_OUTLINE
+                )
 
         pad = 4
 

--- a/src/modules/products/router.py
+++ b/src/modules/products/router.py
@@ -1,10 +1,11 @@
-from typing import Optional
+from typing import List, Optional
 
 from fastapi import APIRouter, Depends, Query
 
 from src.modules.products.model import ProductType
 from src.modules.products.schemas import ProductCreate, ProductResponse, ProductUpdate
 from src.modules.products.service import ProductService, product_service
+from src.modules.products.types.edge_banding import BandType
 from src.shared.exceptions import EntityNotFoundError
 from src.shared.pagination import PageParams
 from src.shared.responses import (
@@ -36,6 +37,26 @@ def list_products(
     """Lista productos con filtro por tipo, búsqueda y paginación opcionales."""
     items, total = svc.search_paginated(search, type, paging.limit, paging.offset)
     return page(items, total, paging.limit, paging.offset)
+
+
+@router.get(
+    "/{board_id}/edge-bandings",
+    response_model=DataResponse[List[ProductResponse]],
+)
+def get_board_edge_bandings(
+    board_id: int,
+    band_type: Optional[BandType] = Query(
+        None, description="Filtra por tipo de canto: Suave o Duro"
+    ),
+    svc: ProductService = Depends(product_service),
+):
+    """Tapacantos coordinados con un tablero (mismo diseño y ancho según grosor).
+
+    Empareja por la clave de diseño del código (evita falsos positivos por nombre)
+    y aplica la regla grosor→ancho. ``data`` vacío significa que no hay tapacanto
+    coordinado para esa combinación.
+    """
+    return ok(svc.find_edge_bandings_for_board(board_id, band_type))
 
 
 @router.get("/{product_id}", response_model=DataResponse[ProductResponse])

--- a/src/modules/products/service.py
+++ b/src/modules/products/service.py
@@ -6,8 +6,15 @@ from sqlalchemy.orm import Session
 from src.modules.products.model import ProductModel, ProductType
 from src.modules.products.registry import attributes_schema_for
 from src.modules.products.schemas import ProductBase, ProductCreate, ProductUpdate
+from src.modules.products.types.edge_banding import BandType
 from src.shared.crud import CRUDService
 from src.shared.database import get_db
+from src.shared.exceptions import BusinessRuleError
+
+# Regla de negocio: ancho de tapacanto (mm) coordinado con el grosor del tablero.
+# El canto debe cubrir el canto del tablero más un margen, así que un tablero de
+# 15 mm usa cinta de 19 mm y uno de 36 mm usa cinta de 40 mm.
+BOARD_THICKNESS_TO_EDGE_WIDTH = {15: 19, 36: 40}
 
 
 class ProductService(CRUDService[ProductModel, ProductBase, ProductUpdate]):
@@ -27,7 +34,9 @@ class ProductService(CRUDService[ProductModel, ProductBase, ProductUpdate]):
     def create(self, data: ProductCreate) -> ProductModel:
         payload = data.model_dump()
         payload["type"] = data.type.value
-        payload["attributes"] = data.attributes.model_dump(by_alias=True)
+        # mode="json" garantiza valores JSON-serializables (enums -> su valor)
+        # para el bag ``attributes`` que se persiste en la columna JSON.
+        payload["attributes"] = data.attributes.model_dump(by_alias=True, mode="json")
         return self._persist(ProductModel(**payload))
 
     def update(self, id: int, data: ProductUpdate) -> ProductModel:
@@ -36,7 +45,7 @@ class ProductService(CRUDService[ProductModel, ProductBase, ProductUpdate]):
         if fields.get("attributes") is not None:
             schema = attributes_schema_for(obj.type)
             fields["attributes"] = schema(**fields["attributes"]).model_dump(
-                by_alias=True
+                by_alias=True, mode="json"
             )
         for field, value in fields.items():
             setattr(obj, field, value)
@@ -63,6 +72,64 @@ class ProductService(CRUDService[ProductModel, ProductBase, ProductUpdate]):
                 ProductModel.code.ilike(pattern) | ProductModel.name.ilike(pattern)
             )
         return self._paginate(query, limit, offset)
+
+    @staticmethod
+    def _design_key(code: str) -> Optional[str]:
+        """Clave de diseño compartida por un tablero y su tapacanto coordinado.
+
+        Los códigos siguen ``{prefijo}-{categoría}-{abreviatura}-…`` (p. ej.
+        ``MDP-SL-CSH-15`` y ``TAP-SL-CSH-045``), así que ``{categoría}-{abreviatura}``
+        (``SL-CSH``) identifica el diseño de forma única —a diferencia del ``name``,
+        que comparte tokens entre diseños (p. ej. varios "Barroco")—. Devuelve
+        ``None`` si el código no tiene suficientes segmentos.
+        """
+        parts = code.split("-")
+        if len(parts) < 3:
+            return None
+        return f"{parts[1]}-{parts[2]}"
+
+    def find_edge_bandings_for_board(
+        self, board_id: int, band_type: Optional[BandType] = None
+    ) -> List[ProductModel]:
+        """Tapacantos coordinados con un tablero (mismo diseño y ancho correcto).
+
+        Empareja por la clave de diseño del código (no por nombre, que da falsos
+        positivos) y aplica la regla grosor→ancho (``BOARD_THICKNESS_TO_EDGE_WIDTH``).
+        Filtra de forma opcional por tipo de canto (``BandType``). Devuelve ``[]`` si
+        no hay coordinado para esa combinación (hueco real del catálogo, p. ej. canto
+        suave para un tablero de 36 mm).
+        """
+        board = self.get_or_404(board_id)
+        if board.type != ProductType.BOARD.value:
+            raise BusinessRuleError(f"El producto {board.code} no es un tablero")
+
+        key = self._design_key(board.code)
+        if key is None:
+            return []
+
+        target_width = BOARD_THICKNESS_TO_EDGE_WIDTH.get(
+            int(board.attributes["thickness"])
+        )
+        if target_width is None:
+            return []
+
+        candidates = (
+            self.db.query(ProductModel)
+            .filter(
+                ProductModel.type == ProductType.EDGE_BANDING.value,
+                ProductModel.code.ilike(f"%-{key}-%"),
+            )
+            .all()
+        )
+
+        matches = [
+            p
+            for p in candidates
+            if self._design_key(p.code) == key
+            and p.attributes.get("width") == target_width
+            and (band_type is None or p.attributes.get("bandType") == band_type.value)
+        ]
+        return sorted(matches, key=lambda p: p.attributes.get("thickness", 0))
 
 
 def product_service(db: Session = Depends(get_db)) -> ProductService:

--- a/src/modules/products/types/edge_banding.py
+++ b/src/modules/products/types/edge_banding.py
@@ -1,8 +1,30 @@
+from enum import Enum
 from typing import Optional
 
 from pydantic import Field, PositiveFloat, PositiveInt
 
 from src.shared.schemas import CamelModel
+
+
+class BandType(str, Enum):
+    """Tipo de tapacanto (cerrado).
+
+    ``SUAVE`` (canto suave, ~0.45 mm) y ``DURO`` (canto duro, 1.0/1.5 mm). El
+    ``_missing_`` acepta la entrada sin distinguir mayúsculas (p. ej. ``"suave"``)
+    pero la normaliza al valor canónico, así que el campo queda cerrado a estos dos
+    valores tanto al crear/actualizar productos como al filtrar en el endpoint.
+    """
+
+    SUAVE = "Suave"
+    DURO = "Duro"
+
+    @classmethod
+    def _missing_(cls, value):
+        if isinstance(value, str):
+            for member in cls:
+                if member.value.lower() == value.strip().lower():
+                    return member
+        return None
 
 
 class EdgeBandingAttributes(CamelModel):
@@ -17,8 +39,8 @@ class EdgeBandingAttributes(CamelModel):
         ..., description="Grosor en mm (p. ej. 0.45, 1.0, 1.5)"
     )
     width: PositiveInt = Field(..., description="Ancho en mm (p. ej. 19, 40)")
-    band_type: Optional[str] = Field(
-        None, max_length=16, description="Tipo de tapacanto: Suave o Duro"
+    band_type: Optional[BandType] = Field(
+        None, description="Tipo de tapacanto: Suave o Duro"
     )
     color: Optional[str] = Field(
         None, max_length=64, description="Color/diseño coordinado"

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -137,3 +137,166 @@ def test_delete_product(client):
     created = client.post("/api/v1/products/", json=_board_payload()).json()["data"]
     assert client.delete(f"/api/v1/products/{created['id']}").status_code == 204
     assert client.get(f"/api/v1/products/{created['id']}").status_code == 404
+
+
+# --- Emparejamiento tablero -> tapacanto coordinado --------------------------
+
+
+def _seed_board(client, code, name, thickness):
+    return client.post(
+        "/api/v1/products/",
+        json={
+            "type": "board",
+            "code": code,
+            "name": name,
+            "price": 50.0,
+            "attributes": {"height": 2800, "width": 2070, "thickness": thickness},
+        },
+    ).json()["data"]
+
+
+def _seed_edge(client, code, name, band_type, thickness, width, color):
+    return client.post(
+        "/api/v1/products/",
+        json={
+            "type": "edge_banding",
+            "code": code,
+            "name": name,
+            "price": 12.0,
+            "attributes": {
+                "bandType": band_type,
+                "thickness": thickness,
+                "width": width,
+                "color": color,
+            },
+        },
+    ).json()["data"]
+
+
+def _seed_cashmere_catalog(client):
+    """Tablero Cashmere 15 y 36 + sus tapacantos coordinados (estilo seed real)."""
+    _seed_board(client, "MDP-SL-CSH-15", "MDP 15mm Cashmere", 15)
+    _seed_board(client, "MDP-SL-CSH-36", "MDP 36mm Cashmere", 36)
+    _seed_edge(
+        client,
+        "TAP-SL-CSH-045",
+        "Tapacanto Cashmere Suave 0.45x19mm",
+        "Suave",
+        0.45,
+        19,
+        "Cashmere",
+    )
+    _seed_edge(
+        client,
+        "TAP-SL-CSH-100",
+        "Tapacanto Cashmere Duro 1x40mm",
+        "Duro",
+        1.0,
+        40,
+        "Cashmere",
+    )
+    _seed_edge(
+        client,
+        "TAP-SL-CSH-150",
+        "Tapacanto Cashmere Duro 1.5x19mm",
+        "Duro",
+        1.5,
+        19,
+        "Cashmere",
+    )
+
+
+def test_edge_bandings_for_15mm_board(client):
+    _seed_cashmere_catalog(client)
+    board = client.get("/api/v1/products/code/MDP-SL-CSH-15").json()["data"]
+
+    resp = client.get(f"/api/v1/products/{board['id']}/edge-bandings")
+    assert resp.status_code == 200
+    bands = resp.json()["data"]
+    # 15mm -> ancho 19: Suave 0.45 y Duro 1.5 (ordenados por grosor)
+    assert [b["attributes"]["width"] for b in bands] == [19, 19]
+    assert [b["attributes"]["bandType"] for b in bands] == ["Suave", "Duro"]
+
+    # El enum BandType acepta la entrada sin distinguir mayúsculas ("suave").
+    suave = client.get(
+        f"/api/v1/products/{board['id']}/edge-bandings", params={"band_type": "suave"}
+    ).json()["data"]
+    assert len(suave) == 1
+    assert suave[0]["code"] == "TAP-SL-CSH-045"
+
+
+def test_edge_bandings_for_36mm_board_only_hard(client):
+    _seed_cashmere_catalog(client)
+    board = client.get("/api/v1/products/code/MDP-SL-CSH-36").json()["data"]
+
+    bands = client.get(f"/api/v1/products/{board['id']}/edge-bandings").json()["data"]
+    # 36mm -> ancho 40: solo existe el Duro 1.0x40
+    assert len(bands) == 1
+    assert bands[0]["code"] == "TAP-SL-CSH-100"
+    assert bands[0]["attributes"]["width"] == 40
+
+    # No hay canto suave para 36mm: hueco real del catálogo -> lista vacía
+    suave = client.get(
+        f"/api/v1/products/{board['id']}/edge-bandings", params={"band_type": "Suave"}
+    ).json()["data"]
+    assert suave == []
+
+
+def test_edge_bandings_excludes_other_designs(client):
+    """No debe traer tapacantos de otro diseño aunque compartan tokens de nombre."""
+    _seed_cashmere_catalog(client)
+    # Otro diseño con nombre que comparte token pero distinto code (abreviatura)
+    _seed_board(client, "MDP-RO-BRD-15", "MDP 15mm Barroco Dorado", 15)
+    _seed_edge(
+        client,
+        "TAP-RO-BRR-045",
+        "Tapacanto Barroco Ristretto Suave",
+        "Suave",
+        0.45,
+        19,
+        "Roble Barroco Ristretto",
+    )
+    board = client.get("/api/v1/products/code/MDP-RO-BRD-15").json()["data"]
+
+    bands = client.get(f"/api/v1/products/{board['id']}/edge-bandings").json()["data"]
+    # BRD no tiene tapacanto coordinado sembrado; BRR no debe colarse
+    assert bands == []
+
+
+def test_edge_bandings_invalid_band_type_returns_422(client):
+    """El query param está cerrado al enum BandType: un valor fuera de él falla."""
+    _seed_cashmere_catalog(client)
+    board = client.get("/api/v1/products/code/MDP-SL-CSH-15").json()["data"]
+    resp = client.get(
+        f"/api/v1/products/{board['id']}/edge-bandings",
+        params={"band_type": "Medio"},
+    )
+    assert resp.status_code == 422
+
+
+def test_edge_banding_invalid_band_type_on_create_returns_422(client):
+    """El atributo band_type también queda cerrado al enum al crear el producto."""
+    resp = client.post(
+        "/api/v1/products/",
+        json={
+            "type": "edge_banding",
+            "code": "TAP-XX-YY-045",
+            "name": "Tapacanto inválido",
+            "price": 1.0,
+            "attributes": {"bandType": "Medio", "thickness": 0.45, "width": 19},
+        },
+    )
+    assert resp.status_code == 422
+
+
+def test_edge_bandings_board_not_found(client):
+    assert client.get("/api/v1/products/999999/edge-bandings").status_code == 404
+
+
+def test_edge_bandings_for_non_board_returns_business_rule_error(client):
+    _seed_cashmere_catalog(client)
+    edge = client.get("/api/v1/products/code/TAP-SL-CSH-045").json()["data"]
+
+    resp = client.get(f"/api/v1/products/{edge['id']}/edge-bandings")
+    assert resp.status_code == 422
+    assert resp.json()["errors"][0]["code"] == "BUSINESS_RULE_ERROR"


### PR DESCRIPTION
Proforma / order PDF:
    - Merge the separate boards and edge-bandings tables into a single "Resumen de materiales" table with columns: code, description, quantity (boards in units, edge bandings in linear meters), unit price and subtotal.
    - Make the materials table span the full content width so it matches the requirements detail table.
    - Widen the board-code column in the requirements table and the code column in the materials table, trimming the label / quantity / unit price columns to keep both tables at the same total width.

    Cutting diagram:
    - Drop the per-type colored edge-banding strips; highlight banded sides with a thicker band in the piece outline color, painted from the edge inward.
    - Replace the per-code legend entries with a single "Lado canteado" item shown only when the pattern has banded pieces.
    - Remove the now-unused edge-banding color palette and helper.