### PR TITLE
refactor: switch edge banding BandType values to English (Soft/Hard)

### DIFF
--- a/scripts/seed_boards.py
+++ b/scripts/seed_boards.py
@@ -126,13 +126,19 @@ def build_boards():
 # --- Tapacantos -----------------------------------------------------------
 #
 # Cada diseño de tablero tiene su tapacanto de PVC coordinado (mapeo 1:1 con
-# DESIGNS). Salvo el Blanco, todos vienen en las 3 medidas estándar:
+# DESIGNS). Salvo el Blanco, todos vienen en las 3 medidas estándar. El "tipo" es
+# la etiqueta en español que ve el cliente en el nombre/descripción; el valor que
+# se guarda en attributes.bandType es su equivalente canónico en inglés (ver
+# BAND_TYPE_VALUE), que es lo que filtra el endpoint.
 #   (tipo, espesor_mm, ancho_mm)
 EDGE_BAND_VARIANTS = [
     ("Suave", 0.45, 19),
     ("Duro", 1.00, 40),
     ("Duro", 1.50, 19),
 ]
+
+# Etiqueta español (visible al cliente) -> valor canónico inglés del enum BandType.
+BAND_TYPE_VALUE = {"Suave": "Soft", "Duro": "Hard"}
 
 # TODO: precios PLACEHOLDER (no provistos). Reemplazar con los reales.
 EDGE_PRICES = {
@@ -156,6 +162,7 @@ def edge_label(abbr, name, cat):
 def make_edge_banding(abbr, name, cat, band_type, thickness, width):
     label = edge_label(abbr, name, cat)
     thick_txt = f"{thickness:g}"  # 0.45, 1, 1.5 (sin ceros sobrantes)
+    band_value = BAND_TYPE_VALUE[band_type]  # valor canónico inglés (Soft/Hard)
     description = (
         f"Tapacanto PVC {label}, tipo {band_type}, {thick_txt}mm x {width}mm, "
         f"coordinado con tablero MDP {label}"
@@ -169,7 +176,7 @@ def make_edge_banding(abbr, name, cat, band_type, thickness, width):
         "is_active": True,
         # Atributos en la forma canónica camelCase del catálogo de productos.
         "attributes": {
-            "bandType": band_type,
+            "bandType": band_value,
             "thickness": thickness,
             "width": width,
             "color": label,

--- a/src/modules/products/router.py
+++ b/src/modules/products/router.py
@@ -46,7 +46,7 @@ def list_products(
 def get_board_edge_bandings(
     board_id: int,
     band_type: Optional[BandType] = Query(
-        None, description="Filtra por tipo de canto: Suave o Duro"
+        None, description="Filtra por tipo de canto: Soft o Hard"
     ),
     svc: ProductService = Depends(product_service),
 ):

--- a/src/modules/products/types/edge_banding.py
+++ b/src/modules/products/types/edge_banding.py
@@ -5,32 +5,41 @@ from pydantic import Field, PositiveFloat, PositiveInt
 
 from src.shared.schemas import CamelModel
 
+# Alias de entrada en español aceptados además del valor canónico inglés. Es una
+# red de seguridad por si el bot o datos antiguos envían "Suave"/"Duro": se
+# normalizan al valor del enum (``Soft``/``Hard``) que se almacena y compara.
+_SPANISH_ALIASES = {"suave": "Soft", "duro": "Hard"}
+
 
 class BandType(str, Enum):
     """Tipo de tapacanto (cerrado).
 
-    ``SUAVE`` (canto suave, ~0.45 mm) y ``DURO`` (canto duro, 1.0/1.5 mm). El
-    ``_missing_`` acepta la entrada sin distinguir mayúsculas (p. ej. ``"suave"``)
-    pero la normaliza al valor canónico, así que el campo queda cerrado a estos dos
-    valores tanto al crear/actualizar productos como al filtrar en el endpoint.
+    ``SOFT`` (canto suave, ~0.45 mm) y ``HARD`` (canto duro, 1.0/1.5 mm); el valor
+    canónico es inglés (``"Soft"``/``"Hard"``). El ``_missing_`` acepta la entrada
+    sin distinguir mayúsculas y traduce los alias en español (``"suave"``/``"duro"``)
+    al valor canónico, así que el campo queda cerrado a estos dos valores tanto al
+    crear/actualizar productos como al filtrar en el endpoint.
     """
 
-    SUAVE = "Suave"
-    DURO = "Duro"
+    SOFT = "Soft"
+    HARD = "Hard"
 
     @classmethod
     def _missing_(cls, value):
         if isinstance(value, str):
+            norm = value.strip().lower()
             for member in cls:
-                if member.value.lower() == value.strip().lower():
+                if member.value.lower() == norm:
                     return member
+            if norm in _SPANISH_ALIASES:
+                return cls(_SPANISH_ALIASES[norm])
         return None
 
 
 class EdgeBandingAttributes(CamelModel):
     """Atributos de un tapacanto de PVC.
 
-    Se identifica por su grosor y ancho, y se clasifica por tipo (Suave/Duro). El
+    Se identifica por su grosor y ancho, y se clasifica por tipo (Soft/Hard). El
     grosor real es fraccionario (p. ej. 0.45 mm), de ahí el float. La lógica de
     negocio (cálculo de metraje, etc.) se implementará en una fase posterior.
     """
@@ -40,7 +49,7 @@ class EdgeBandingAttributes(CamelModel):
     )
     width: PositiveInt = Field(..., description="Ancho en mm (p. ej. 19, 40)")
     band_type: Optional[BandType] = Field(
-        None, description="Tipo de tapacanto: Suave o Duro"
+        None, description="Tipo de tapacanto: Soft o Hard"
     )
     color: Optional[str] = Field(
         None, max_length=64, description="Color/diseño coordinado"

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -181,7 +181,7 @@ def _seed_cashmere_catalog(client):
         client,
         "TAP-SL-CSH-045",
         "Tapacanto Cashmere Suave 0.45x19mm",
-        "Suave",
+        "Soft",
         0.45,
         19,
         "Cashmere",
@@ -190,7 +190,7 @@ def _seed_cashmere_catalog(client):
         client,
         "TAP-SL-CSH-100",
         "Tapacanto Cashmere Duro 1x40mm",
-        "Duro",
+        "Hard",
         1.0,
         40,
         "Cashmere",
@@ -199,7 +199,7 @@ def _seed_cashmere_catalog(client):
         client,
         "TAP-SL-CSH-150",
         "Tapacanto Cashmere Duro 1.5x19mm",
-        "Duro",
+        "Hard",
         1.5,
         19,
         "Cashmere",
@@ -213,16 +213,19 @@ def test_edge_bandings_for_15mm_board(client):
     resp = client.get(f"/api/v1/products/{board['id']}/edge-bandings")
     assert resp.status_code == 200
     bands = resp.json()["data"]
-    # 15mm -> ancho 19: Suave 0.45 y Duro 1.5 (ordenados por grosor)
+    # 15mm -> ancho 19: Soft 0.45 y Hard 1.5 (ordenados por grosor)
     assert [b["attributes"]["width"] for b in bands] == [19, 19]
-    assert [b["attributes"]["bandType"] for b in bands] == ["Suave", "Duro"]
+    assert [b["attributes"]["bandType"] for b in bands] == ["Soft", "Hard"]
 
-    # El enum BandType acepta la entrada sin distinguir mayúsculas ("suave").
-    suave = client.get(
-        f"/api/v1/products/{board['id']}/edge-bandings", params={"band_type": "suave"}
-    ).json()["data"]
-    assert len(suave) == 1
-    assert suave[0]["code"] == "TAP-SL-CSH-045"
+    # El enum BandType acepta la entrada sin distinguir mayúsculas ("soft") y el
+    # alias en español ("suave"), ambos normalizados al valor canónico inglés.
+    for value in ("soft", "suave"):
+        soft = client.get(
+            f"/api/v1/products/{board['id']}/edge-bandings",
+            params={"band_type": value},
+        ).json()["data"]
+        assert len(soft) == 1
+        assert soft[0]["code"] == "TAP-SL-CSH-045"
 
 
 def test_edge_bandings_for_36mm_board_only_hard(client):
@@ -235,11 +238,11 @@ def test_edge_bandings_for_36mm_board_only_hard(client):
     assert bands[0]["code"] == "TAP-SL-CSH-100"
     assert bands[0]["attributes"]["width"] == 40
 
-    # No hay canto suave para 36mm: hueco real del catálogo -> lista vacía
-    suave = client.get(
-        f"/api/v1/products/{board['id']}/edge-bandings", params={"band_type": "Suave"}
+    # No hay canto suave (Soft) para 36mm: hueco real del catálogo -> lista vacía
+    soft = client.get(
+        f"/api/v1/products/{board['id']}/edge-bandings", params={"band_type": "Soft"}
     ).json()["data"]
-    assert suave == []
+    assert soft == []
 
 
 def test_edge_bandings_excludes_other_designs(client):
@@ -251,7 +254,7 @@ def test_edge_bandings_excludes_other_designs(client):
         client,
         "TAP-RO-BRR-045",
         "Tapacanto Barroco Ristretto Suave",
-        "Suave",
+        "Soft",
         0.45,
         19,
         "Roble Barroco Ristretto",


### PR DESCRIPTION
    BandType canonical values change from Suave/Duro to Soft/Hard. The enum
    stays closed but `_missing_` now also accepts the Spanish aliases
    (suave→Soft, duro→Hard) as a safety net. Product display names/descriptions
    in the seed stay in Spanish (Suave/Duro) for the client-facing proforma,
    decoupled from the stored attribute via BAND_TYPE_VALUE.