### PR TITLE
feat: edge-banding workshop notation and production sheet table polish

### DIFF
--- a/src/modules/optimizations/labels.py
+++ b/src/modules/optimizations/labels.py
@@ -1,0 +1,31 @@
+"""Notación de taller para los cantos (tapacantos) de una pieza."""
+
+from typing import Iterable, Optional
+
+# Abreviatura del tipo de canto: Suave→CS, Duro→CD (valores canónicos de BandType).
+_BAND_TYPE_ABBR = {"Soft": "CS", "Hard": "CD"}
+
+
+def edge_banding_notation(sides: Iterable[str], band_type: Optional[str] = None) -> str:
+    """Notación de taller de los lados canteados: ``'2L1C CS'`` (largos/cortos + tipo).
+
+    Clasifica por la medida del lado **nominal**: ``left``/``right`` son los lados del
+    alto (primera medida) → ``L`` (largo); ``top``/``bottom`` son los del ancho →
+    ``C`` (corto). Se omite el conteo en cero (``1L``, ``2C``) y, sin tipo de canto
+    conocido, se omite el sufijo. Devuelve ``''`` si no hay lados canteados.
+
+    Importante: usar siempre los lados **nominales** (los del ``EdgeBandingSpec``), no
+    los geométricos remapeados por rotación; así el conteo es estable bajo rotación.
+    """
+    sides = list(sides or [])
+    if not sides:
+        return ""
+    long_count = sum(1 for s in sides if s in ("left", "right"))  # alto = Largo
+    short_count = sum(1 for s in sides if s in ("top", "bottom"))  # ancho = Corto
+    parts = ""
+    if long_count:
+        parts += f"{long_count}L"
+    if short_count:
+        parts += f"{short_count}C"
+    suffix = _BAND_TYPE_ABBR.get(band_type)
+    return f"{parts} {suffix}" if (parts and suffix) else parts

--- a/src/modules/optimizations/proforma.py
+++ b/src/modules/optimizations/proforma.py
@@ -23,6 +23,7 @@ from reportlab.platypus import (
 )
 
 from src.modules.optimizations.carrier import ProformaCarrier
+from src.modules.optimizations.labels import edge_banding_notation
 from src.modules.optimizations.patterns import group_layouts
 from src.modules.optimizations.visualization import VisualizationService
 from src.shared.config import config
@@ -406,7 +407,7 @@ class ProformaService:
                         f"{req.get('width', 0)} mm",
                         str(req.get("quantity", 1)),
                         req.get("product_code", "N/A"),
-                        Paragraph(_edge_sides_label(req), cell_style),
+                        Paragraph(_edge_banding_notation(req), cell_style),
                         Paragraph(req.get("label") or "-", cell_style),
                     ]
                 )
@@ -469,10 +470,10 @@ class ProformaService:
             ]
         else:
             col_widths = [
-                1.0 * inch,
-                CONTENT_WIDTH - 3.0 * inch,
-                1.0 * inch,
-                1.0 * inch,
+                1.4 * inch,  # Código (más ancho: códigos largos tipo TAP-SL-CSH-22)
+                CONTENT_WIDTH - 3.0 * inch,  # Descripción (flexible)
+                0.8 * inch,  # Espesor
+                0.8 * inch,  # Metros
             ]
         eb_table = Table(eb_data, colWidths=col_widths, repeatRows=1)
         eb_table.setStyle(
@@ -532,11 +533,11 @@ class ProformaService:
 
     @staticmethod
     def _build_materials_plain_table(carrier: ProformaCarrier, cell_style) -> Table:
-        """Tableros a usar SIN precios (hoja de producción): código, dimensiones, cant."""
+        """Tableros a usar SIN precios (hoja de producción): código, dimensiones, cant.
+
+        Ocupa el ancho completo del contenido para alinear con la lista de corte."""
         materials_summary = carrier.materials_summary
-        mat_data = [
-            ["Código", "Nombre", "Dimensiones", "Espesor", "Cantidad", "Efic. Prom."]
-        ]
+        mat_data = [["Código", "Nombre", "Dimensiones", "Espesor", "Cantidad"]]
         if isinstance(materials_summary, list) and materials_summary:
             for entry in materials_summary:
                 mat_data.append(
@@ -546,21 +547,19 @@ class ProformaService:
                         f"{entry.get('height', 0):.0f}×{entry.get('width', 0):.0f} mm",
                         f"{entry.get('thickness', 0):.0f} mm",
                         str(entry.get("count", 0)),
-                        f"{entry.get('avg_efficiency', 0):.1f}%",
                     ]
                 )
         else:
-            mat_data.append(["Sin datos de materiales", "", "", "", "", ""])
+            mat_data.append(["Sin datos de materiales", "", "", "", ""])
 
         mat_table = Table(
             mat_data,
             colWidths=[
-                0.9 * inch,
-                CONTENT_WIDTH - 4.5 * inch,
-                1.3 * inch,
-                0.9 * inch,
-                0.9 * inch,
-                0.9 * inch,
+                1.3 * inch,  # Código (más ancho: códigos largos tipo MDP-SL-CSH-15)
+                CONTENT_WIDTH - 4.0 * inch,  # Nombre (flexible)
+                1.1 * inch,  # Dimensiones
+                0.7 * inch,  # Espesor
+                0.9 * inch,  # Cantidad
             ],
             repeatRows=1,
         )
@@ -645,17 +644,13 @@ def pdf_response(
     )
 
 
-_SIDE_LABELS = {"top": "Sup", "bottom": "Inf", "left": "Izq", "right": "Der"}
-
-
-def _edge_sides_label(req: dict) -> str:
-    """Notación compacta de los lados canteados de una pieza (Sup/Inf/Izq/Der)."""
+def _edge_banding_notation(req: dict) -> str:
+    """Notación de taller de los cantos de una pieza (``2L1C CS``) o ``-`` si no lleva."""
     spec = req.get("edge_banding")
     if not spec:
         return "-"
-    sides = set(spec.get("sides") or [])
-    labels = [_SIDE_LABELS[s] for s in ("top", "bottom", "left", "right") if s in sides]
-    return ", ".join(labels) if labels else "-"
+    text = edge_banding_notation(spec.get("sides") or [], spec.get("band_type"))
+    return text or "-"
 
 
 def _heading_style(styles) -> ParagraphStyle:

--- a/src/modules/optimizations/service.py
+++ b/src/modules/optimizations/service.py
@@ -18,6 +18,7 @@ from src.cutting import (
 from src.modules.clients.model import ClientModel
 from src.modules.clients.service import require_phone
 from src.modules.optimizations.carrier import ProformaCarrier
+from src.modules.optimizations.labels import edge_banding_notation
 from src.modules.optimizations.patterns import base_label, group_layouts
 from src.modules.optimizations.schemas import (
     EdgeBandingSpec,
@@ -300,9 +301,8 @@ class OptimizationService:
         rotación pura siempre es físicamente realizable, por lo que el canteado
         asimétrico no impide rotar: simplemente se intercambian los lados.
         """
-        sides = {s.value for s in spec.sides}
-        if rotated:
-            sides = {_CW_ROTATION[s] for s in sides}
+        nominal = {s.value for s in spec.sides}
+        sides = {_CW_ROTATION[s] for s in nominal} if rotated else nominal
         geo = [s for s in ("top", "bottom", "left", "right") if s in sides]
         product = eb_products.get(spec.product_id)
         attrs = (product.attributes if product else None) or {}
@@ -311,6 +311,10 @@ class OptimizationService:
             "product_id": spec.product_id,
             "code": product.code if product else None,
             "color": attrs.get("color"),
+            # Notación de taller calculada desde los lados NOMINALES (estable bajo
+            # rotación); ``geo`` solo sirve para pintar las bandas en el lado correcto.
+            # ``attributes`` se persiste en camelCase → ``bandType``.
+            "notation": edge_banding_notation(nominal, attrs.get("bandType")),
         }
 
     def _enrich_layout_pieces(
@@ -417,6 +421,29 @@ class OptimizationService:
             result.append(entry)
         return result
 
+    @staticmethod
+    def _dump_requirement(
+        req: Requirement,
+        product_codes: Dict[int, str],
+        eb_products: Dict[int, ProductModel],
+    ) -> dict:
+        """Vuelca un requirement al payload y le anexa ``band_type`` del tapacanto.
+
+        El ``band_type`` vive en los atributos del producto, no en el
+        ``EdgeBandingSpec``; se inyecta aquí para que la proforma arme la notación de
+        cantos (``2L1C CS``) sin volver a resolver el producto al renderizar.
+        """
+        data = {
+            **req.model_dump(mode="json"),
+            "product_code": product_codes.get(req.product_id, "N/A"),
+        }
+        if req.edge_banding is not None and data.get("edge_banding"):
+            product = eb_products.get(req.edge_banding.product_id)
+            attrs = (product.attributes if product else None) or {}
+            # ``attributes`` se persiste en camelCase → ``bandType``.
+            data["edge_banding"]["band_type"] = attrs.get("bandType")
+        return data
+
     def _build_result_payload(
         self,
         request: OptimizeRequest,
@@ -452,10 +479,7 @@ class OptimizationService:
             "total_boards_cost": total_boards_cost,
             "total_edge_banding_cost": total_edge_banding_cost,
             "requirements": [
-                {
-                    **r.model_dump(mode="json"),
-                    "product_code": product_codes.get(r.product_id, "N/A"),
-                }
+                self._dump_requirement(r, product_codes, eb_products)
                 for r in request.requirements
             ],
             "layouts": layout_dicts,

--- a/src/modules/optimizations/visualization.py
+++ b/src/modules/optimizations/visualization.py
@@ -279,18 +279,28 @@ class VisualizationService:
         if alto.height <= ph - 2 * pad and alto.width <= pw - 2 * pad:
             img.paste(alto, (px + pad, py + (ph - alto.height) // 2), alto)
 
-        # Etiqueta de la pieza al centro: usar la etiqueta base (sin sufijo de
-        # instancia) y omitir las auto-generadas piece_N.
+        # Texto centrado: la etiqueta de la pieza (etiqueta base, sin sufijo de
+        # instancia y omitiendo las auto-generadas piece_N) y, debajo, la notación de
+        # cantos (p. ej. "2L1C CS"). Se apilan y se centran como bloque; cada línea se
+        # omite si no cabe, cubriendo etiqueta+notación, solo etiqueta o solo notación.
+        stack = []
         piece_id = base_label(str(piece.get("piece_id", "")))
         if piece_id and not piece_id.startswith("piece_"):
             label = _fit_label(piece_id, label_font, pw - 2 * pad, ph - 2 * pad)
             if label:
-                label_img = _text_image(label, label_font, COLOR_LABEL)
-                img.paste(
-                    label_img,
-                    (
-                        px + (pw - label_img.width) // 2,
-                        py + (ph - label_img.height) // 2,
-                    ),
-                    label_img,
-                )
+                stack.append(_text_image(label, label_font, COLOR_LABEL))
+
+        notation = edges.get("notation")
+        if notation:
+            fitted = _fit_label(notation, dim_font, pw - 2 * pad, ph - 2 * pad)
+            if fitted:
+                stack.append(_text_image(fitted, dim_font, COLOR_LABEL))
+
+        if stack:
+            gap = 2
+            total_h = sum(im.height for im in stack) + gap * (len(stack) - 1)
+            if total_h <= ph - 2 * pad:
+                y = py + (ph - total_h) // 2
+                for im in stack:
+                    img.paste(im, (px + (pw - im.width) // 2, y), im)
+                    y += im.height + gap

--- a/tests/test_edge_banding.py
+++ b/tests/test_edge_banding.py
@@ -4,6 +4,7 @@ import math
 
 import pytest
 
+from src.modules.optimizations.labels import edge_banding_notation
 from src.modules.optimizations.schemas import EdgeBandingSpec, EdgeSide
 from src.modules.optimizations.service import OptimizationService
 from src.shared.config import config
@@ -34,7 +35,12 @@ def _create_board(client, code="MEL18", price=45.5):
     ).json()["data"]
 
 
-def _create_edge_banding(client, code="TAP22", price=2.0, color="Blanco"):
+def _create_edge_banding(
+    client, code="TAP22", price=2.0, color="Blanco", band_type=None
+):
+    attributes = {"thickness": 0.45, "width": 22, "color": color, "length": 50000}
+    if band_type is not None:
+        attributes["band_type"] = band_type
     return client.post(
         "/api/v1/products/",
         json={
@@ -42,12 +48,7 @@ def _create_edge_banding(client, code="TAP22", price=2.0, color="Blanco"):
             "code": code,
             "name": f"Tapacanto {code}",
             "price": price,
-            "attributes": {
-                "thickness": 0.45,
-                "width": 22,
-                "color": color,
-                "length": 50000,
-            },
+            "attributes": attributes,
         },
     ).json()["data"]
 
@@ -69,6 +70,24 @@ def _expected_meters(net_m: float):
     """Replica la fórmula del servicio: merma + redondeo al metro entero."""
     with_waste = net_m * (1 + config.EDGE_BANDING_WASTE_FACTOR)
     return round(with_waste, 2), math.ceil(with_waste)
+
+
+# --------------------------------------------------------------------------- #
+# Notación de taller de los cantos (2L1C CS)
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "sides, band_type, expected",
+    [
+        (["left", "right", "top"], "Soft", "2L1C CS"),  # 2 largos (alto) + 1 corto
+        (["left"], "Soft", "1L CS"),  # solo largo: omite la parte en cero
+        (["top", "bottom"], "Hard", "2C CD"),  # solo cortos (ancho), canto duro
+        (["left", "right", "top", "bottom"], "Soft", "2L2C CS"),  # todos
+        ([], "Soft", ""),  # sin lados → vacío
+        (["left", "right"], None, "2L"),  # sin band_type → sin sufijo
+    ],
+)
+def test_edge_banding_notation(sides, band_type, expected):
+    assert edge_banding_notation(sides, band_type) == expected
 
 
 # --------------------------------------------------------------------------- #
@@ -247,6 +266,18 @@ def test_geometric_edges_mapping(db_session):
     ]
 
 
+def test_geometric_edges_notation_is_rotation_invariant(db_session):
+    """La notación se calcula desde los lados NOMINALES, así que no cambia al rotar."""
+    svc = OptimizationService(db_session)
+    # top+left+right: 2 largos (left/right=alto) + 1 corto (top=ancho). Sin producto
+    # en el mapa → sin band_type → sin sufijo CS/CD.
+    spec = EdgeBandingSpec(
+        product_id=2, sides=[EdgeSide.top, EdgeSide.left, EdgeSide.right]
+    )
+    assert svc._geometric_edges(spec, {}, False)["notation"] == "2L1C"
+    assert svc._geometric_edges(spec, {}, True)["notation"] == "2L1C"
+
+
 def test_asymmetric_banding_rotates_and_swaps_edges(client):
     """Canteado asimétrico NO bloquea la rotación: si la pieza sale rotada, los
     cantos se intercambian al lado físico correspondiente."""
@@ -271,6 +302,24 @@ def test_asymmetric_banding_rotates_and_swaps_edges(client):
     # CW: top→right, left→top ⇒ lados geométricos {top, right}.
     assert placed["edges"]["sides"] == ["top", "right"]
     assert placed["edges"]["code"] == "TAP22"
+
+
+def test_placed_piece_notation_includes_band_type(client):
+    """La pieza colocada lleva la notación de cantos con sufijo CS/CD del band_type."""
+    c = _create_client(client)
+    b = _create_board(client)
+    eb = _create_edge_banding(client, band_type="Soft")
+
+    # alto=500, ancho=1000, sin rotar: left+right = 2 largos, top = 1 corto; Soft → CS.
+    req = _requirement(b["id"], eb["id"], ["left", "right", "top"])
+    req["canRotate"] = False
+    resp = client.post(
+        "/api/v1/optimize/",
+        json={"clientId": c["id"], "requirements": [req]},
+    )
+    placed = resp.json()["data"]["layouts"][0]["placedPieces"][0]
+    assert placed["rotated"] is False
+    assert placed["edges"]["notation"] == "2L1C CS"
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
    Replace the per-side edge-banding column (Sup/Inf/Izq/Der) with a workshop
    notation NLNC CS|CD (e.g. 2L1C CS = 2 long + 1 short sides, soft edge) in the
    proforma, production sheet and order, and render it under each piece's label in
    the cutting diagram.

    - labels.py: new pure helper edge_banding_notation(sides, band_type); left/right = L (alto), top/bottom = C (ancho); drops zero counts, appends CS/CD.
    - service.py: attach band_type to requirements and a precomputed, rotation-stable notation to each placed piece (reads camelCase bandType).
    - proforma.py: the Cantos column uses the new notation.
    - visualization.py: stack label + notation centered in each piece.
    - Production sheet: drop the Efic. Prom. column, make the boards and edge bandings tables span full width, and widen the Código column.