### PR TITLE
feat: add analytics module for dashboard statistics

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse
 
+from src.modules.analytics.router import router as analytics_router
 from src.modules.clients.router import router as clients_router
 from src.modules.optimizations.router import router as optimizations_router
 from src.modules.orders.router import router as orders_router
@@ -61,6 +62,7 @@ app.include_router(products_router, prefix="/api/v1")
 app.include_router(clients_router, prefix="/api/v1")
 app.include_router(optimizations_router, prefix="/api/v1")
 app.include_router(orders_router, prefix="/api/v1")
+app.include_router(analytics_router, prefix="/api/v1")
 
 
 @app.get("/")

--- a/src/modules/analytics/constants.py
+++ b/src/modules/analytics/constants.py
@@ -1,0 +1,59 @@
+"""Semántica compartida de la analítica: estados de ingreso, granularidad y utilidades.
+
+Es la columna vertebral del módulo: todos los endpoints coinciden en qué estados
+cuentan como ingreso realizado/comprometido/perdido. Reutiliza ``OrderStatus`` y los
+sets ya definidos en el módulo de órdenes en lugar de repetir strings.
+"""
+
+from enum import Enum
+from typing import Iterable
+
+from src.modules.orders.model import OrderStatus
+
+# Ingreso ganado: la orden llegó a su fin productivo.
+REALIZED_STATUSES = {OrderStatus.completed}
+
+# Ingreso perdido: no se cobrará nunca.
+LOST_STATUSES = {OrderStatus.cancelled, OrderStatus.expired}
+
+# Pipeline comprometido: vinculado pero aún no completado.
+BOOKED_STATUSES = {
+    OrderStatus.confirmed,
+    OrderStatus.approved,
+    OrderStatus.in_production,
+    OrderStatus.cut,
+}
+
+# ``draft``/``quoted`` se excluyen de todo ingreso (no vinculantes; hoy las órdenes
+# nacen en ``confirmed``).
+
+# Etiquetas legibles por estado para los desgloses (eje del embudo).
+STATUS_LABELS = {
+    OrderStatus.draft: "Borrador",
+    OrderStatus.quoted: "Cotizada",
+    OrderStatus.confirmed: "Confirmada",
+    OrderStatus.approved: "Aprobada",
+    OrderStatus.in_production: "En producción",
+    OrderStatus.cut: "Cortada",
+    OrderStatus.completed: "Completada",
+    OrderStatus.cancelled: "Cancelada",
+    OrderStatus.expired: "Expirada",
+}
+
+
+class Granularity(str, Enum):
+    """Tamaño de bucket para las series temporales."""
+
+    day = "day"
+    week = "week"
+    month = "month"
+
+
+def status_values(statuses: Iterable[OrderStatus]) -> list[str]:
+    """Proyecta un conjunto de estados a sus valores string (para ``.in_(...)``)."""
+    return [s.value for s in statuses]
+
+
+def safe_div(num: float, denom: float) -> float:
+    """División protegida: devuelve ``0.0`` si el denominador es cero."""
+    return num / denom if denom else 0.0

--- a/src/modules/analytics/dates.py
+++ b/src/modules/analytics/dates.py
@@ -1,0 +1,80 @@
+"""Rango de fechas y bucketing temporal, portables entre SQLite y Postgres.
+
+``DateRange`` es una dependencia inyectable (como ``PageParams``) que parsea y valida
+los query params ``from``/``to``. El bucketing se hace en Python (no en SQL) para tener
+un único camino: SQLite no tiene ``date_trunc`` y Postgres no tiene ``strftime``.
+
+Todos los timestamps del dominio son naive UTC (``datetime.utcnow()``); aquí se tratan
+como tales, sin conversión de zona.
+"""
+
+from datetime import date, datetime, time, timedelta
+
+from fastapi import Query
+
+from src.modules.analytics.constants import Granularity
+from src.shared.exceptions import ValidationError
+
+_DEFAULT_WINDOW_DAYS = 30
+
+
+class DateRange:
+    """Ventana ``[start, end)`` medio-abierta sobre ``created_at``.
+
+    Defaults: últimos 30 días terminando hoy (UTC). El borde superior es exclusivo
+    (``end = to + 1 día``) para evitar el bug del límite ``23:59:59``.
+    """
+
+    def __init__(
+        self,
+        date_from: date | None = Query(
+            None, alias="from", description="Inicio del rango (YYYY-MM-DD, inclusivo)"
+        ),
+        date_to: date | None = Query(
+            None, alias="to", description="Fin del rango (YYYY-MM-DD, inclusivo)"
+        ),
+    ):
+        today = datetime.utcnow().date()
+        self.date_to = date_to or today
+        self.date_from = date_from or (
+            self.date_to - timedelta(days=_DEFAULT_WINDOW_DAYS)
+        )
+        if self.date_from > self.date_to:
+            raise ValidationError(
+                "'from' debe ser menor o igual que 'to'", field="from"
+            )
+        self.start = datetime.combine(self.date_from, time.min)
+        self.end = datetime.combine(self.date_to, time.min) + timedelta(days=1)
+
+
+def bucket_key(d: date, granularity: Granularity) -> date:
+    """Fecha de inicio del bucket al que pertenece ``d``."""
+    if granularity is Granularity.day:
+        return d
+    if granularity is Granularity.week:
+        return d - timedelta(days=d.weekday())  # lunes ISO
+    return d.replace(day=1)  # month
+
+
+def _advance(d: date, granularity: Granularity) -> date:
+    """Siguiente fecha de bucket."""
+    if granularity is Granularity.day:
+        return d + timedelta(days=1)
+    if granularity is Granularity.week:
+        return d + timedelta(days=7)
+    if d.month == 12:
+        return d.replace(year=d.year + 1, month=1)
+    return d.replace(month=d.month + 1)
+
+
+def iter_buckets(
+    date_from: date, date_to: date, granularity: Granularity
+) -> list[date]:
+    """Eje denso de fechas de bucket que cubre ``[date_from, date_to]`` (sin huecos)."""
+    keys: list[date] = []
+    cur = bucket_key(date_from, granularity)
+    last = bucket_key(date_to, granularity)
+    while cur <= last:
+        keys.append(cur)
+        cur = _advance(cur, granularity)
+    return keys

--- a/src/modules/analytics/router.py
+++ b/src/modules/analytics/router.py
@@ -1,0 +1,59 @@
+"""Endpoints read-only de analítica para el dashboard.
+
+Cuatro endpoints cohesivos, uno por familia de gráfico. Todos devuelven payloads
+agregados listos para graficar, envueltos en ``DataResponse[T]``.
+"""
+
+from fastapi import APIRouter, Depends, Query
+
+from src.modules.analytics.constants import Granularity
+from src.modules.analytics.dates import DateRange
+from src.modules.analytics.schemas import (
+    AnalyticsSummary,
+    Breakdown,
+    OperationsReport,
+    TimeSeries,
+)
+from src.modules.analytics.service import AnalyticsService, analytics_service
+from src.shared.responses import ERROR_RESPONSES, DataResponse, ok
+
+router = APIRouter(prefix="/analytics", tags=["analytics"], responses=ERROR_RESPONSES)
+
+
+@router.get("/summary", response_model=DataResponse[AnalyticsSummary])
+def get_summary(
+    dr: DateRange = Depends(),
+    svc: AnalyticsService = Depends(analytics_service),
+):
+    """Tarjetas KPI del periodo: operación, pipeline y tendencia base."""
+    return ok(svc.summary(dr))
+
+
+@router.get("/timeseries", response_model=DataResponse[TimeSeries])
+def get_timeseries(
+    dr: DateRange = Depends(),
+    granularity: Granularity = Query(
+        Granularity.day, description="Tamaño de bucket: day | week | month"
+    ),
+    svc: AnalyticsService = Depends(analytics_service),
+):
+    """Tendencias temporales (eje denso, huecos en cero)."""
+    return ok(svc.timeseries(dr, granularity))
+
+
+@router.get("/breakdown/status", response_model=DataResponse[Breakdown])
+def get_breakdown_status(
+    dr: DateRange = Depends(),
+    svc: AnalyticsService = Depends(analytics_service),
+):
+    """Embudo de estados: conteo e ingreso por estado (todos los estados, incl. cero)."""
+    return ok(svc.breakdown_status(dr))
+
+
+@router.get("/operations", response_model=DataResponse[OperationsReport])
+def get_operations(
+    dr: DateRange = Depends(),
+    svc: AnalyticsService = Depends(analytics_service),
+):
+    """Eficiencia de material (ponderada por área), merma y ciclo de vida."""
+    return ok(svc.operations(dr))

--- a/src/modules/analytics/schemas.py
+++ b/src/modules/analytics/schemas.py
@@ -1,0 +1,90 @@
+"""Contratos de respuesta de la analítica (chart-ready, camelCase vía ``CamelModel``).
+
+Convenciones: ningún campo numérico es opcional (rango vacío → ceros, nunca nulos);
+las series temporales son arrays paralelos sobre un mismo eje ``buckets``.
+"""
+
+from datetime import date
+from typing import List
+
+from src.modules.analytics.constants import Granularity
+from src.shared.schemas import CamelModel
+
+
+class RangeInfo(CamelModel):
+    """Ventana efectivamente aplicada (eco de los defaults resueltos)."""
+
+    date_from: date
+    date_to: date
+
+
+class AnalyticsSummary(CamelModel):
+    """Tarjetas KPI: operación, pipeline y tendencia base del periodo."""
+
+    range: RangeInfo
+    # Operación (sobre órdenes completadas).
+    total_boards_consumed: int
+    average_efficiency: float  # ponderada por área, 0..100
+    total_area_cut_m2: float
+    waste_estimate_m2: float
+    # Estados / pipeline.
+    pending_orders_count: int
+    cancellation_rate: float  # 0..1
+    expiry_rate: float  # 0..1
+    # Tendencia base.
+    order_count: int
+    realized_revenue: float
+    average_ticket: float
+    active_clients_count: int
+
+
+class TimeSeriesData(CamelModel):
+    """Series paralelas alineadas al eje ``buckets`` de ``TimeSeries``."""
+
+    revenue: List[float]  # ingreso realizado por bucket
+    order_count: List[int]
+    boards_consumed: List[int]
+    new_clients: List[int]
+
+
+class TimeSeries(CamelModel):
+    """Tendencias temporales con eje denso (huecos en cero)."""
+
+    granularity: Granularity
+    buckets: List[str]  # fechas de bucket ISO (eje x)
+    series: TimeSeriesData
+
+
+class BreakdownItem(CamelModel):
+    """Una categoría del desglose con sus métricas."""
+
+    key: str
+    label: str
+    revenue: float
+    order_count: int
+
+
+class Breakdown(CamelModel):
+    """Desglose categórico (p. ej. embudo de estados)."""
+
+    dimension: str
+    items: List[BreakdownItem]
+
+
+class DwellTime(CamelModel):
+    """Tiempo medio que las órdenes pasan en ``from_status`` antes de ``to_status``."""
+
+    from_status: str
+    to_status: str
+    avg_hours: float
+    sample_count: int  # transiciones observadas (transparencia de muestra)
+
+
+class OperationsReport(CamelModel):
+    """Eficiencia de material y ciclo de vida de las órdenes."""
+
+    average_efficiency: float
+    total_area_cut_m2: float
+    waste_estimate_m2: float
+    expiry_before_approval_rate: float
+    lifecycle: List[DwellTime]

--- a/src/modules/analytics/service.py
+++ b/src/modules/analytics/service.py
@@ -1,0 +1,275 @@
+"""Agregaciones read-only para el dashboard.
+
+Único módulo que usa agregación SQL (``func.sum``/``func.count``/``group_by``); el
+bucketing temporal y la ponderación de eficiencia se hacen en Python para ser portables
+y explícitos. La única historia durable es la orden (las optimizaciones son efímeras en
+Redis), así que todo se construye sobre ``orders`` + ``order_lines`` + ``order_status_history``.
+"""
+
+from collections import defaultdict
+
+from fastapi import Depends
+from sqlalchemy import distinct, func
+from sqlalchemy.orm import Session
+
+from src.modules.analytics.constants import (
+    REALIZED_STATUSES,
+    STATUS_LABELS,
+    Granularity,
+    safe_div,
+    status_values,
+)
+from src.modules.analytics.dates import DateRange, bucket_key, iter_buckets
+from src.modules.analytics.schemas import (
+    AnalyticsSummary,
+    Breakdown,
+    BreakdownItem,
+    DwellTime,
+    OperationsReport,
+    RangeInfo,
+    TimeSeries,
+    TimeSeriesData,
+)
+from src.modules.orders.model import (
+    PENDING_STATUSES,
+    OrderLineModel,
+    OrderModel,
+    OrderStatus,
+)
+from src.shared.database import get_db
+
+
+class AnalyticsService:
+    """Calcula métricas agregadas sobre el agregado de órdenes."""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    # ------------------------------------------------------------------ summary
+    def summary(self, dr: DateRange) -> AnalyticsSummary:
+        order_count = self._count(dr)
+        completed_count = self._count(dr, REALIZED_STATUSES)
+        cancelled = self._count(dr, {OrderStatus.cancelled})
+        expired = self._count(dr, {OrderStatus.expired})
+
+        realized_revenue = self._revenue(dr, REALIZED_STATUSES)
+        boards = self._boards_consumed(dr)
+        avg_eff, area = self._efficiency_and_area(dr)
+        waste = round(area * (1 - avg_eff / 100), 4)
+
+        active_clients = (
+            self.db.query(func.count(distinct(OrderModel.client_id)))
+            .filter(*self._range(dr))
+            .scalar()
+        ) or 0
+
+        return AnalyticsSummary(
+            range=RangeInfo(date_from=dr.date_from, date_to=dr.date_to),
+            total_boards_consumed=boards,
+            average_efficiency=avg_eff,
+            total_area_cut_m2=area,
+            waste_estimate_m2=waste,
+            pending_orders_count=self._count(dr, PENDING_STATUSES),
+            cancellation_rate=round(safe_div(cancelled, order_count), 4),
+            expiry_rate=round(safe_div(expired, order_count), 4),
+            order_count=order_count,
+            realized_revenue=realized_revenue,
+            average_ticket=round(safe_div(realized_revenue, completed_count), 2),
+            active_clients_count=active_clients,
+        )
+
+    # --------------------------------------------------------------- timeseries
+    def timeseries(self, dr: DateRange, granularity: Granularity) -> TimeSeries:
+        buckets = iter_buckets(dr.date_from, dr.date_to, granularity)
+        labels = [b.isoformat() for b in buckets]
+        index = {b: i for i, b in enumerate(buckets)}
+        n = len(buckets)
+        revenue = [0.0] * n
+        order_count = [0] * n
+        boards = [0] * n
+        new_clients = [0] * n
+
+        completed = OrderStatus.completed.value
+        rows = (
+            self.db.query(
+                OrderModel.created_at,
+                OrderModel.total,
+                OrderModel.status,
+                OrderModel.total_boards_used,
+            )
+            .filter(*self._range(dr))
+            .all()
+        )
+        for created_at, total, status, tboards in rows:
+            i = index.get(bucket_key(created_at.date(), granularity))
+            if i is None:
+                continue
+            order_count[i] += 1
+            if status == completed:  # ingreso/tableros realizados
+                revenue[i] += total or 0.0
+                boards[i] += tboards or 0
+
+        # Clientes nuevos: primer pedido (MIN created_at) por cliente sobre TODA la
+        # historia; se cuenta en el bucket de ese primer pedido si cae en el rango.
+        first_orders = (
+            self.db.query(OrderModel.client_id, func.min(OrderModel.created_at))
+            .group_by(OrderModel.client_id)
+            .all()
+        )
+        for _, first_dt in first_orders:
+            if dr.start <= first_dt < dr.end:
+                i = index.get(bucket_key(first_dt.date(), granularity))
+                if i is not None:
+                    new_clients[i] += 1
+
+        return TimeSeries(
+            granularity=granularity,
+            buckets=labels,
+            series=TimeSeriesData(
+                revenue=[round(r, 2) for r in revenue],
+                order_count=order_count,
+                boards_consumed=boards,
+                new_clients=new_clients,
+            ),
+        )
+
+    # ----------------------------------------------------------- breakdown/status
+    def breakdown_status(self, dr: DateRange) -> Breakdown:
+        rows = (
+            self.db.query(
+                OrderModel.status,
+                func.count(OrderModel.id),
+                func.coalesce(func.sum(OrderModel.total), 0.0),
+            )
+            .filter(*self._range(dr))
+            .group_by(OrderModel.status)
+            .all()
+        )
+        by_status = {status: (count, rev) for status, count, rev in rows}
+        items = [
+            BreakdownItem(
+                key=st.value,
+                label=STATUS_LABELS[st],
+                revenue=round(by_status.get(st.value, (0, 0.0))[1], 2),
+                order_count=by_status.get(st.value, (0, 0.0))[0],
+            )
+            for st in OrderStatus  # densifica: todos los estados, incluso en cero
+        ]
+        return Breakdown(dimension="status", items=items)
+
+    # ------------------------------------------------------------------ operations
+    def operations(self, dr: DateRange) -> OperationsReport:
+        avg_eff, area = self._efficiency_and_area(dr)
+        waste = round(area * (1 - avg_eff / 100), 4)
+
+        orders = self.db.query(OrderModel).filter(*self._range(dr)).all()
+        return OperationsReport(
+            average_efficiency=avg_eff,
+            total_area_cut_m2=area,
+            waste_estimate_m2=waste,
+            expiry_before_approval_rate=self._expiry_before_approval(orders),
+            lifecycle=self._lifecycle(orders),
+        )
+
+    # --------------------------------------------------------------------- helpers
+    def _range(self, dr: DateRange) -> list:
+        """Filtro medio-abierto ``[start, end)`` sobre ``created_at``."""
+        return [OrderModel.created_at >= dr.start, OrderModel.created_at < dr.end]
+
+    def _count(self, dr: DateRange, statuses=None) -> int:
+        query = self.db.query(func.count(OrderModel.id)).filter(*self._range(dr))
+        if statuses is not None:
+            query = query.filter(OrderModel.status.in_(status_values(statuses)))
+        return query.scalar() or 0
+
+    def _revenue(self, dr: DateRange, statuses) -> float:
+        val = (
+            self.db.query(func.coalesce(func.sum(OrderModel.total), 0.0))
+            .filter(*self._range(dr))
+            .filter(OrderModel.status.in_(status_values(statuses)))
+            .scalar()
+        )
+        return round(val or 0.0, 2)
+
+    def _boards_consumed(self, dr: DateRange) -> int:
+        """Tableros de órdenes completadas (producción realizada)."""
+        val = (
+            self.db.query(func.coalesce(func.sum(OrderModel.total_boards_used), 0))
+            .filter(*self._range(dr))
+            .filter(OrderModel.status.in_(status_values(REALIZED_STATUSES)))
+            .scalar()
+        )
+        return int(val or 0)
+
+    def _efficiency_and_area(self, dr: DateRange) -> tuple[float, float]:
+        """Eficiencia ponderada por área (0..100) y área total (m²) de líneas de tablero.
+
+        Excluye líneas de tapacanto (``total_area_m2``/``avg_efficiency`` nulos). El
+        promedio se pondera por área: una orden de 1 tablero no pesa igual que una de 50.
+        """
+        rows = (
+            self.db.query(OrderLineModel.avg_efficiency, OrderLineModel.total_area_m2)
+            .join(OrderModel, OrderLineModel.order_id == OrderModel.id)
+            .filter(*self._range(dr))
+            .filter(OrderModel.status.in_(status_values(REALIZED_STATUSES)))
+            .filter(OrderLineModel.total_area_m2.isnot(None))
+            .filter(OrderLineModel.avg_efficiency.isnot(None))
+            .all()
+        )
+        total_area = sum(area for _, area in rows)
+        if not total_area:
+            return 0.0, 0.0
+        weighted = sum(eff * area for eff, area in rows) / total_area
+        return round(weighted, 2), round(total_area, 4)
+
+    def _expiry_before_approval(self, orders: list[OrderModel]) -> float:
+        """Fracción de órdenes confirmadas que expiraron sin llegar a ``approved``.
+
+        No usa timestamps (el ``created_at`` de ``expired`` es perezoso); solo el
+        conjunto de estados visitados por cada orden en su historial.
+        """
+        confirmed = OrderStatus.confirmed.value
+        approved = OrderStatus.approved.value
+        expired = OrderStatus.expired.value
+        ever_confirmed = 0
+        numerator = 0
+        for o in orders:
+            visited = {h.to_status for h in o.history}
+            if confirmed not in visited:
+                continue
+            ever_confirmed += 1
+            if expired in visited and approved not in visited:
+                numerator += 1
+        return round(safe_div(numerator, ever_confirmed), 4)
+
+    def _lifecycle(self, orders: list[OrderModel]) -> list[DwellTime]:
+        """Horas medias en cada estado, por par ``(from_status, to_status)``.
+
+        El tiempo en un estado = intervalo entre el evento que entró a él y el que lo
+        dejó. El ``created_at`` de ``expired`` es perezoso (se escribe al leer la orden),
+        así que esos tramos son aproximados; ``sample_count`` transparenta la muestra.
+        """
+        acc: dict[tuple[str, str], list[float]] = defaultdict(lambda: [0.0, 0])
+        for o in orders:
+            hist = sorted(o.history, key=lambda h: (h.created_at, h.id))
+            for prev, cur in zip(hist, hist[1:]):
+                if prev.to_status != cur.from_status:
+                    continue
+                hours = (cur.created_at - prev.created_at).total_seconds() / 3600.0
+                bucket = acc[(cur.from_status, cur.to_status)]
+                bucket[0] += hours
+                bucket[1] += 1
+        return [
+            DwellTime(
+                from_status=frm,
+                to_status=to,
+                avg_hours=round(safe_div(total_hours, count), 2),
+                sample_count=count,
+            )
+            for (frm, to), (total_hours, count) in sorted(acc.items())
+        ]
+
+
+def analytics_service(db: Session = Depends(get_db)) -> AnalyticsService:
+    """Provider de ``AnalyticsService`` para inyección en rutas."""
+    return AnalyticsService(db)

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,342 @@
+"""Tests del módulo analytics: summary, timeseries, breakdown de estados y operaciones.
+
+Se siembra directo por ``db_session`` para fijar estados, ``created_at`` e historial con
+precisión (la máquina de estados no deja alcanzar todos los casos limpio). El ``client``
+y el ``db_session`` comparten la misma SQLite en memoria por el override de ``get_db``.
+"""
+
+from datetime import datetime, timedelta
+
+from src.modules.orders.model import (
+    OrderLineModel,
+    OrderModel,
+    OrderStatusHistoryModel,
+)
+
+_BASE = datetime(2026, 6, 15, 12, 0, 0)
+_RANGE = {"from": "2026-06-01", "to": "2026-06-30"}
+
+
+def _board_line(efficiency, area, *, product_id=1, qty=2, price=45.5):
+    return OrderLineModel(
+        product_id=product_id,
+        quantity=qty,
+        unit_price_snapshot=price,
+        line_total=qty * price,
+        avg_efficiency=efficiency,
+        total_area_m2=area,
+    )
+
+
+def _edge_line(linear_m, *, product_id=42, price=1.5):
+    """Línea de tapacanto: sin área/eficiencia (no debe contaminar la ponderación)."""
+    return OrderLineModel(
+        product_id=product_id,
+        quantity=int(linear_m),
+        unit_price_snapshot=price,
+        line_total=linear_m * price,
+        linear_m=linear_m,
+    )
+
+
+def _seed_order(
+    db,
+    *,
+    client_id=1,
+    status="completed",
+    total=100.0,
+    boards=2,
+    created_at=_BASE,
+    lines=None,
+    history=None,
+    optimization_hash="h",
+):
+    order = OrderModel(
+        client_id=client_id,
+        status=status,
+        optimization_snapshot={},
+        optimization_hash=optimization_hash,
+        currency="USD",
+        subtotal=total,
+        total=total,
+        total_boards_used=boards,
+        created_at=created_at,
+        confirmed_at=created_at,
+        expires_at=created_at + timedelta(days=15),
+    )
+    if lines is not None:
+        order.lines = lines
+    if history is not None:
+        order.history = history
+    db.add(order)
+    db.commit()
+    db.refresh(order)
+    return order
+
+
+def _hist(to_status, created_at, from_status=None):
+    return OrderStatusHistoryModel(
+        from_status=from_status,
+        to_status=to_status,
+        actor="system",
+        created_at=created_at,
+    )
+
+
+# --------------------------------------------------------------------- summary
+def test_summary_empty_range_returns_zeros_not_nulls(client):
+    data = client.get("/api/v1/analytics/summary", params=_RANGE).json()["data"]
+
+    for key in (
+        "totalBoardsConsumed",
+        "averageEfficiency",
+        "totalAreaCutM2",
+        "wasteEstimateM2",
+        "pendingOrdersCount",
+        "cancellationRate",
+        "expiryRate",
+        "orderCount",
+        "realizedRevenue",
+        "averageTicket",
+        "activeClientsCount",
+    ):
+        assert data[key] == 0, key
+        assert data[key] is not None
+    assert data["range"]["dateFrom"] == "2026-06-01"
+    assert data["range"]["dateTo"] == "2026-06-30"
+
+
+def test_summary_revenue_and_rates_isolated_by_status(client, db_session):
+    _seed_order(db_session, client_id=1, status="completed", total=100.0)
+    _seed_order(db_session, client_id=2, status="confirmed", total=200.0)
+    _seed_order(db_session, client_id=1, status="cancelled", total=50.0)
+    _seed_order(db_session, client_id=3, status="expired", total=30.0)
+
+    data = client.get("/api/v1/analytics/summary", params=_RANGE).json()["data"]
+
+    assert data["orderCount"] == 4
+    assert data["realizedRevenue"] == 100.0  # solo completed
+    assert data["averageTicket"] == 100.0  # 100 / 1 completada
+    assert data["pendingOrdersCount"] == 1  # confirmed (approved: 0)
+    assert data["cancellationRate"] == 0.25  # 1 / 4
+    assert data["expiryRate"] == 0.25  # 1 / 4
+    assert data["activeClientsCount"] == 3  # clientes 1, 2, 3 distintos
+
+
+def test_summary_efficiency_is_area_weighted_and_ignores_edge_banding(
+    client, db_session
+):
+    _seed_order(
+        db_session,
+        status="completed",
+        boards=2,
+        lines=[_board_line(90.0, 10.0), _edge_line(5.0)],
+    )
+    _seed_order(
+        db_session, status="completed", boards=5, lines=[_board_line(70.0, 30.0)]
+    )
+
+    data = client.get("/api/v1/analytics/summary", params=_RANGE).json()["data"]
+
+    # Ponderada: (90*10 + 70*30) / (10+30) = 3000/40 = 75.0
+    assert data["averageEfficiency"] == 75.0
+    assert data["totalAreaCutM2"] == 40.0
+    assert data["wasteEstimateM2"] == 10.0  # 40 * (1 - 0.75)
+    assert data["totalBoardsConsumed"] == 7  # 2 + 5
+
+
+def test_summary_uses_default_range_when_omitted(client):
+    data = client.get("/api/v1/analytics/summary").json()["data"]
+    assert data["range"]["dateFrom"] < data["range"]["dateTo"]
+
+
+def test_invalid_range_returns_422_with_envelope(client):
+    resp = client.get(
+        "/api/v1/analytics/summary", params={"from": "2026-06-30", "to": "2026-06-01"}
+    )
+    assert resp.status_code == 422
+    assert resp.json()["errors"][0]["field"] == "from"
+
+
+# ------------------------------------------------------------- date filtering
+def test_date_filter_is_half_open(client, db_session):
+    _seed_order(db_session, total=100.0, created_at=datetime(2026, 6, 1, 0, 0, 0))
+    _seed_order(db_session, total=50.0, created_at=datetime(2026, 6, 10, 23, 0, 0))
+    _seed_order(db_session, total=999.0, created_at=datetime(2026, 5, 31, 23, 0, 0))
+    _seed_order(db_session, total=999.0, created_at=datetime(2026, 6, 11, 0, 0, 0))
+
+    data = client.get(
+        "/api/v1/analytics/summary", params={"from": "2026-06-01", "to": "2026-06-10"}
+    ).json()["data"]
+    assert data["orderCount"] == 2
+    assert data["realizedRevenue"] == 150.0
+
+
+# ------------------------------------------------------------------ timeseries
+def test_timeseries_daily_dense_axis_with_zero_gaps(client, db_session):
+    _seed_order(
+        db_session, total=100.0, boards=2, created_at=datetime(2026, 6, 1, 9, 0)
+    )
+    _seed_order(db_session, total=50.0, boards=1, created_at=datetime(2026, 6, 3, 9, 0))
+
+    data = client.get(
+        "/api/v1/analytics/timeseries",
+        params={"from": "2026-06-01", "to": "2026-06-03", "granularity": "day"},
+    ).json()["data"]
+
+    assert data["granularity"] == "day"
+    assert data["buckets"] == ["2026-06-01", "2026-06-02", "2026-06-03"]
+    assert data["series"]["revenue"] == [100.0, 0.0, 50.0]
+    assert data["series"]["orderCount"] == [1, 0, 1]
+    assert data["series"]["boardsConsumed"] == [2, 0, 1]
+
+
+def test_timeseries_monthly_buckets(client, db_session):
+    _seed_order(db_session, total=100.0, created_at=datetime(2026, 6, 20, 9, 0))
+
+    data = client.get(
+        "/api/v1/analytics/timeseries",
+        params={"from": "2026-05-15", "to": "2026-07-10", "granularity": "month"},
+    ).json()["data"]
+
+    assert data["buckets"] == ["2026-05-01", "2026-06-01", "2026-07-01"]
+    assert data["series"]["revenue"] == [0.0, 100.0, 0.0]
+
+
+def test_timeseries_monthly_crosses_year_boundary(client, db_session):
+    _seed_order(db_session, total=100.0, created_at=datetime(2026, 1, 10, 9, 0))
+
+    data = client.get(
+        "/api/v1/analytics/timeseries",
+        params={"from": "2025-12-01", "to": "2026-01-31", "granularity": "month"},
+    ).json()["data"]
+
+    assert data["buckets"] == ["2025-12-01", "2026-01-01"]
+    assert data["series"]["revenue"] == [0.0, 100.0]
+
+
+def test_timeseries_weekly_buckets(client, db_session):
+    # 2026-06-01 es lunes; las semanas ISO arrancan en 06-01 y 06-08.
+    _seed_order(db_session, total=100.0, created_at=datetime(2026, 6, 3, 9, 0))
+    _seed_order(db_session, total=50.0, created_at=datetime(2026, 6, 10, 9, 0))
+
+    data = client.get(
+        "/api/v1/analytics/timeseries",
+        params={"from": "2026-06-01", "to": "2026-06-14", "granularity": "week"},
+    ).json()["data"]
+
+    assert data["buckets"] == ["2026-06-01", "2026-06-08"]
+    assert data["series"]["revenue"] == [100.0, 50.0]
+
+
+def test_timeseries_new_clients_counts_first_order_only(client, db_session):
+    # Cliente 1: primer pedido el 06-01, segundo el 06-02 (no recuenta).
+    _seed_order(db_session, client_id=1, created_at=datetime(2026, 6, 1, 9, 0))
+    _seed_order(db_session, client_id=1, created_at=datetime(2026, 6, 2, 9, 0))
+    # Cliente 2: nuevo el 06-02.
+    _seed_order(db_session, client_id=2, created_at=datetime(2026, 6, 2, 9, 0))
+    # Cliente 3: su primer pedido fue antes del rango → no es "nuevo" aquí.
+    _seed_order(db_session, client_id=3, created_at=datetime(2026, 5, 1, 9, 0))
+    _seed_order(db_session, client_id=3, created_at=datetime(2026, 6, 2, 9, 0))
+
+    data = client.get(
+        "/api/v1/analytics/timeseries",
+        params={"from": "2026-06-01", "to": "2026-06-03", "granularity": "day"},
+    ).json()["data"]
+
+    assert data["series"]["newClients"] == [1, 1, 0]
+
+
+# ------------------------------------------------------------- breakdown/status
+def test_breakdown_status_densifies_all_states(client, db_session):
+    _seed_order(db_session, status="completed", total=100.0)
+    _seed_order(db_session, status="completed", total=200.0)
+    _seed_order(db_session, status="cancelled", total=50.0)
+
+    data = client.get("/api/v1/analytics/breakdown/status", params=_RANGE).json()[
+        "data"
+    ]
+
+    assert data["dimension"] == "status"
+    assert len(data["items"]) == 9  # todos los OrderStatus
+    by_key = {it["key"]: it for it in data["items"]}
+    assert by_key["completed"]["orderCount"] == 2
+    assert by_key["completed"]["revenue"] == 300.0
+    assert by_key["completed"]["label"] == "Completada"
+    assert by_key["cancelled"]["orderCount"] == 1
+    assert by_key["cancelled"]["revenue"] == 50.0
+    assert by_key["confirmed"]["orderCount"] == 0  # densificado en cero
+
+
+def test_breakdown_status_empty_range(client):
+    data = client.get("/api/v1/analytics/breakdown/status", params=_RANGE).json()[
+        "data"
+    ]
+    assert len(data["items"]) == 9
+    assert all(it["orderCount"] == 0 and it["revenue"] == 0 for it in data["items"])
+
+
+# ------------------------------------------------------------------ operations
+def test_operations_efficiency_mirrors_summary(client, db_session):
+    _seed_order(db_session, status="completed", lines=[_board_line(90.0, 10.0)])
+    _seed_order(db_session, status="completed", lines=[_board_line(70.0, 30.0)])
+
+    data = client.get("/api/v1/analytics/operations", params=_RANGE).json()["data"]
+    assert data["averageEfficiency"] == 75.0
+    assert data["totalAreaCutM2"] == 40.0
+    assert data["wasteEstimateM2"] == 10.0
+
+
+def test_operations_lifecycle_dwell_times(client, db_session):
+    history = [
+        _hist("confirmed", datetime(2026, 6, 15, 0, 0)),
+        _hist("approved", datetime(2026, 6, 15, 2, 0), from_status="confirmed"),
+        _hist("in_production", datetime(2026, 6, 15, 5, 0), from_status="approved"),
+    ]
+    _seed_order(db_session, status="in_production", history=history)
+
+    data = client.get("/api/v1/analytics/operations", params=_RANGE).json()["data"]
+    cycle = {(d["fromStatus"], d["toStatus"]): d for d in data["lifecycle"]}
+    assert cycle[("confirmed", "approved")]["avgHours"] == 2.0
+    assert cycle[("confirmed", "approved")]["sampleCount"] == 1
+    assert cycle[("approved", "in_production")]["avgHours"] == 3.0
+
+
+def test_operations_expiry_before_approval_rate(client, db_session):
+    # A: confirmed → expired (sin aprobar) → numerador.
+    _seed_order(
+        db_session,
+        status="expired",
+        history=[
+            _hist("confirmed", datetime(2026, 6, 15, 0, 0)),
+            _hist("expired", datetime(2026, 6, 16, 0, 0), from_status="confirmed"),
+        ],
+    )
+    # B: confirmed → approved → expired → no cuenta (llegó a approved).
+    _seed_order(
+        db_session,
+        status="expired",
+        history=[
+            _hist("confirmed", datetime(2026, 6, 15, 0, 0)),
+            _hist("approved", datetime(2026, 6, 15, 1, 0), from_status="confirmed"),
+            _hist("expired", datetime(2026, 6, 16, 0, 0), from_status="approved"),
+        ],
+    )
+    # C: solo confirmed → denominador, no numerador.
+    _seed_order(
+        db_session,
+        status="confirmed",
+        history=[_hist("confirmed", datetime(2026, 6, 15, 0, 0))],
+    )
+
+    data = client.get("/api/v1/analytics/operations", params=_RANGE).json()["data"]
+    assert data["expiryBeforeApprovalRate"] == round(1 / 3, 4)
+
+
+def test_operations_empty_range(client):
+    data = client.get("/api/v1/analytics/operations", params=_RANGE).json()["data"]
+    assert data["averageEfficiency"] == 0
+    assert data["totalAreaCutM2"] == 0
+    assert data["wasteEstimateM2"] == 0
+    assert data["expiryBeforeApprovalRate"] == 0
+    assert data["lifecycle"] == []


### PR DESCRIPTION
    Add a read-only `analytics` vertical slice that aggregates durable order
    data into chart-ready payloads for a frontend dashboard. Phase 1 covers
    three families: operations/efficiency, time-series trends and the status
    funnel.

    Four endpoints under /api/v1/analytics:
    - GET /summary: KPI cards (boards consumed, area-weighted efficiency, waste estimate, pending orders, cancellation/expiry rates, realized revenue, average ticket, active clients).
    - GET /timeseries: revenue, order count, boards consumed and new clients bucketed by day/week/month on a dense axis.
    - GET /breakdown/status: order funnel densified across all 9 states.
    - GET /operations: area-weighted efficiency, waste, status dwell times and expiry-before-approval rate.

    Implementation notes:
    - No new tables or migrations; reads orders, order_lines and order_status_history (the only durable history).
    - Time bucketing is done in Python to stay portable across SQLite (local) and Postgres (prod).
    - Efficiency/area/waste are derived from order_lines columns (area-weighted), not the optimization snapshot JSON; edge-banding lines are excluded.
    - New clients are derived from MIN(orders.created_at) per client, since the clients table has no created_at.
    - Revenue/status semantics are centralized in constants.py, reusing the orders status sets.

    Add tests/test_analytics.py (17 tests) covering empty ranges, status
    isolation, area-weighted efficiency, half-open date filtering,
    day/week/month bucketing (incl. year boundary), status densification and
    lifecycle metrics. Full suite passes at 95.6% coverage.