### PR TITLE
feat: linear meters of cut and edge banding (total and per board)

### DIFF
--- a/src/cutting/__init__.py
+++ b/src/cutting/__init__.py
@@ -4,11 +4,19 @@ Sin dependencias de frameworks: solo dataclasses y lógica de optimización.
 """
 
 from src.cutting.enums import SplitRule
-from src.cutting.models import CuttingLayout, Material, Piece, PlacedPiece, Rectangle
+from src.cutting.models import (
+    Cut,
+    CuttingLayout,
+    Material,
+    Piece,
+    PlacedPiece,
+    Rectangle,
+)
 from src.cutting.optimizer import GuillotineOptimizer, MultiSheetGuillotineOptimizer
 from src.cutting.parameters import CuttingParameters
 
 __all__ = [
+    "Cut",
     "CuttingLayout",
     "CuttingParameters",
     "GuillotineOptimizer",

--- a/src/cutting/models.py
+++ b/src/cutting/models.py
@@ -32,6 +32,21 @@ class Rectangle:
 
 
 @dataclass
+class Cut:
+    """Representa un corte de guillotina (segmento de recorrido de la sierra).
+
+    ``length`` es el largo del recorrido (eje del corte); el ``kerf`` es el ancho
+    de hoja (perpendicular) y no afecta esta longitud. Se guardan las coordenadas
+    de inicio para un eventual dibujo, aunque el uso inmediato es sumar ``length``.
+    """
+
+    x: float
+    y: float
+    length: float
+    is_horizontal: bool
+
+
+@dataclass
 class Piece:
     """Representa una pieza a cortar"""
 
@@ -125,11 +140,17 @@ class CuttingLayout:
     placed_pieces: List[PlacedPiece] = field(default_factory=list)
     remainders: List[Rectangle] = field(default_factory=list)
     sheet_number: int = 1
+    cuts: List[Cut] = field(default_factory=list)
 
     @property
     def used_area(self) -> float:
         """Calcula el área utilizada (sin considerar kerf)"""
         return sum(p.width * p.height for p in self.placed_pieces)
+
+    @property
+    def cut_length(self) -> float:
+        """Largo total de corte (mm): suma del recorrido de la sierra en la plancha."""
+        return sum(c.length for c in self.cuts)
 
     @property
     def efficiency(self) -> float:

--- a/src/cutting/optimizer.py
+++ b/src/cutting/optimizer.py
@@ -1,7 +1,14 @@
 from typing import List, Tuple
 
 from src.cutting.enums import SplitRule
-from src.cutting.models import CuttingLayout, Material, Piece, PlacedPiece, Rectangle
+from src.cutting.models import (
+    Cut,
+    CuttingLayout,
+    Material,
+    Piece,
+    PlacedPiece,
+    Rectangle,
+)
 from src.cutting.parameters import CuttingParameters
 
 
@@ -46,6 +53,7 @@ class GuillotineOptimizer:
             Rectangle(self.left_trim, self.bottom_trim, usable_width, usable_height)
         ]
         self.placed_pieces: List[PlacedPiece] = []
+        self.cuts: List[Cut] = []
 
     def optimize(self, pieces: List[Piece]) -> Tuple[List[PlacedPiece], List[Piece]]:
         if not pieces:
@@ -132,13 +140,17 @@ class GuillotineOptimizer:
         effective_width = placed.width + (self.kerf if width_leftover > 0 else 0)
         effective_height = placed.height + (self.kerf if height_leftover > 0 else 0)
 
-        new_rects = self._create_split_rectangles(
+        new_rects, orientation = self._create_split_rectangles(
             rect,
             placed,
             effective_width,
             effective_height,
             width_leftover,
             height_leftover,
+        )
+
+        self.cuts.extend(
+            self._cuts_for(rect, placed, width_leftover, height_leftover, orientation)
         )
 
         new_rects = [
@@ -151,6 +163,60 @@ class GuillotineOptimizer:
 
         self.remainders.sort(key=lambda r: r.area)
 
+    def _cuts_for(
+        self,
+        rect: Rectangle,
+        placed: PlacedPiece,
+        width_leftover: float,
+        height_leftover: float,
+        orientation: str,
+    ) -> List[Cut]:
+        """Segmentos de corte que separan la pieza del rectángulo, por orientación.
+
+        ``vertical_first`` deja el sobrante superior a ancho completo (corte
+        horizontal de ``rect.width``) y el lateral derecho a la altura de la pieza
+        (corte vertical de ``placed.height``). ``horizontal_first`` deja el sobrante
+        derecho a alto completo (corte vertical de ``rect.height``) y el superior al
+        ancho de la pieza (corte horizontal de ``placed.width``). El ``kerf`` es ancho
+        de hoja (perpendicular) y no altera la longitud. Sin sobrante en un eje no hay
+        corte en ese eje (ya lo separó un corte previo o el borde del tablero).
+        """
+        cuts: List[Cut] = []
+        if orientation == "vertical_first":
+            if height_leftover > 0:
+                cuts.append(
+                    Cut(rect.x, rect.y + placed.height, rect.width, is_horizontal=True)
+                )
+            if width_leftover > 0:
+                cuts.append(
+                    Cut(
+                        rect.x + placed.width,
+                        rect.y,
+                        placed.height,
+                        is_horizontal=False,
+                    )
+                )
+        else:  # horizontal_first
+            if width_leftover > 0:
+                cuts.append(
+                    Cut(
+                        rect.x + placed.width,
+                        rect.y,
+                        rect.height,
+                        is_horizontal=False,
+                    )
+                )
+            if height_leftover > 0:
+                cuts.append(
+                    Cut(
+                        rect.x,
+                        rect.y + placed.height,
+                        placed.width,
+                        is_horizontal=True,
+                    )
+                )
+        return cuts
+
     def _create_split_rectangles(
         self,
         rect: Rectangle,
@@ -159,145 +225,86 @@ class GuillotineOptimizer:
         effective_height: float,
         width_leftover: float,
         height_leftover: float,
-    ) -> List[Rectangle]:
+    ) -> Tuple[List[Rectangle], str]:
+        """Crea los rectángulos sobrantes y devuelve la orientación de split elegida.
+
+        La orientación (``"vertical_first"`` | ``"horizontal_first"``) la usa
+        ``_cuts_for`` para derivar la longitud de los cortes con la topología real.
+        """
         new_rects = []
+        orientation = "vertical_first"
 
         if self.split_rule == SplitRule.SHORTER_LEFTOVER_AXIS:
-            if width_leftover <= height_leftover:
-                new_rects = self._vertical_split_first(
-                    rect,
-                    effective_width,
-                    effective_height,
-                    width_leftover,
-                    height_leftover,
-                )
-            else:
-                new_rects = self._horizontal_split_first(
-                    rect,
-                    placed,
-                    effective_width,
-                    effective_height,
-                    width_leftover,
-                    height_leftover,
-                )
+            orientation = (
+                "vertical_first"
+                if width_leftover <= height_leftover
+                else "horizontal_first"
+            )
 
         elif self.split_rule == SplitRule.LONGER_LEFTOVER_AXIS:
-            if width_leftover >= height_leftover:
-                new_rects = self._vertical_split_first(
-                    rect,
-                    effective_width,
-                    effective_height,
-                    width_leftover,
-                    height_leftover,
-                )
-            else:
-                new_rects = self._horizontal_split_first(
-                    rect,
-                    placed,
-                    effective_width,
-                    effective_height,
-                    width_leftover,
-                    height_leftover,
-                )
+            orientation = (
+                "vertical_first"
+                if width_leftover >= height_leftover
+                else "horizontal_first"
+            )
 
         elif self.split_rule == SplitRule.SHORTER_AXIS:
-            if rect.width <= rect.height:
-                new_rects = self._vertical_split_first(
-                    rect,
-                    effective_width,
-                    effective_height,
-                    width_leftover,
-                    height_leftover,
-                )
-            else:
-                new_rects = self._horizontal_split_first(
-                    rect,
-                    placed,
-                    effective_width,
-                    effective_height,
-                    width_leftover,
-                    height_leftover,
-                )
+            orientation = (
+                "vertical_first" if rect.width <= rect.height else "horizontal_first"
+            )
 
         elif self.split_rule == SplitRule.LONGER_AXIS:
-            if rect.width >= rect.height:
-                new_rects = self._vertical_split_first(
-                    rect,
-                    effective_width,
-                    effective_height,
-                    width_leftover,
-                    height_leftover,
-                )
+            orientation = (
+                "vertical_first" if rect.width >= rect.height else "horizontal_first"
+            )
+
+        elif self.split_rule in (SplitRule.MINIMIZE_AREA, SplitRule.MAXIMIZE_AREA):
+            vertical_rects = self._vertical_split_first(
+                rect, effective_width, effective_height, width_leftover, height_leftover
+            )
+            horizontal_rects = self._horizontal_split_first(
+                rect,
+                placed,
+                effective_width,
+                effective_height,
+                width_leftover,
+                height_leftover,
+            )
+
+            max_vertical = max((r.area for r in vertical_rects), default=0)
+            max_horizontal = max((r.area for r in horizontal_rects), default=0)
+
+            if self.split_rule == SplitRule.MINIMIZE_AREA:
+                use_vertical = max_vertical <= max_horizontal
             else:
-                new_rects = self._horizontal_split_first(
-                    rect,
-                    placed,
-                    effective_width,
-                    effective_height,
-                    width_leftover,
-                    height_leftover,
-                )
+                use_vertical = max_vertical >= max_horizontal
 
-        elif self.split_rule == SplitRule.MINIMIZE_AREA:
-            vertical_rects = self._vertical_split_first(
-                rect, effective_width, effective_height, width_leftover, height_leftover
-            )
-            horizontal_rects = self._horizontal_split_first(
-                rect,
-                placed,
-                effective_width,
-                effective_height,
-                width_leftover,
-                height_leftover,
-            )
-
-            max_vertical = max((r.area for r in vertical_rects), default=0)
-            max_horizontal = max((r.area for r in horizontal_rects), default=0)
-
-            new_rects = (
-                vertical_rects if max_vertical <= max_horizontal else horizontal_rects
-            )
-
-        elif self.split_rule == SplitRule.MAXIMIZE_AREA:
-            vertical_rects = self._vertical_split_first(
-                rect, effective_width, effective_height, width_leftover, height_leftover
-            )
-            horizontal_rects = self._horizontal_split_first(
-                rect,
-                placed,
-                effective_width,
-                effective_height,
-                width_leftover,
-                height_leftover,
-            )
-
-            max_vertical = max((r.area for r in vertical_rects), default=0)
-            max_horizontal = max((r.area for r in horizontal_rects), default=0)
-
-            new_rects = (
-                vertical_rects if max_vertical >= max_horizontal else horizontal_rects
-            )
+            if use_vertical:
+                return vertical_rects, "vertical_first"
+            return horizontal_rects, "horizontal_first"
 
         else:
-            if width_leftover <= height_leftover:
-                new_rects = self._vertical_split_first(
-                    rect,
-                    effective_width,
-                    effective_height,
-                    width_leftover,
-                    height_leftover,
-                )
-            else:
-                new_rects = self._horizontal_split_first(
-                    rect,
-                    placed,
-                    effective_width,
-                    effective_height,
-                    width_leftover,
-                    height_leftover,
-                )
+            orientation = (
+                "vertical_first"
+                if width_leftover <= height_leftover
+                else "horizontal_first"
+            )
 
-        return new_rects
+        if orientation == "vertical_first":
+            new_rects = self._vertical_split_first(
+                rect, effective_width, effective_height, width_leftover, height_leftover
+            )
+        else:
+            new_rects = self._horizontal_split_first(
+                rect,
+                placed,
+                effective_width,
+                effective_height,
+                width_leftover,
+                height_leftover,
+            )
+
+        return new_rects, orientation
 
     def _vertical_split_first(
         self,
@@ -447,6 +454,7 @@ class MultiSheetGuillotineOptimizer:
                     placed_pieces=placed,
                     remainders=optimizer.remainders,
                     sheet_number=sheet_count,
+                    cuts=optimizer.cuts,
                 )
                 self.layouts.append(layout)
                 remaining_pieces = unplaced

--- a/src/modules/optimizations/carrier.py
+++ b/src/modules/optimizations/carrier.py
@@ -22,6 +22,8 @@ class ProformaCarrier:
     total_boards_used: int = 0
     total_boards_cost: float = 0.0
     total_edge_banding_cost: float = 0.0
+    total_cut_linear_m: float = 0.0
+    total_edge_banding_linear_m: float = 0.0
 
     @property
     def total_cost(self) -> float:
@@ -42,6 +44,8 @@ class ProformaCarrier:
             total_boards_used=payload.get("total_boards_used", 0),
             total_boards_cost=payload.get("total_boards_cost", 0.0),
             total_edge_banding_cost=payload.get("total_edge_banding_cost", 0.0),
+            total_cut_linear_m=payload.get("total_cut_linear_m", 0.0),
+            total_edge_banding_linear_m=payload.get("total_edge_banding_linear_m", 0.0),
         )
 
     @classmethod

--- a/src/modules/optimizations/proforma.py
+++ b/src/modules/optimizations/proforma.py
@@ -223,6 +223,10 @@ class ProformaService:
                 )
             )
 
+        story.append(Spacer(1, 0.25 * inch))
+        story.extend(_section("RESUMEN DE CORTE Y CANTO", heading_style))
+        story.append(ProformaService._build_cut_summary_table(carrier))
+
         story.append(PageBreak())
         story.extend(_section("DISPOSICIÓN DE CORTES", heading_style))
         story.append(Spacer(1, 0.08 * inch))
@@ -587,6 +591,55 @@ class ProformaService:
         return _totals_table(
             [["Total de tableros a cortar:", str(carrier.total_boards_used)]]
         )
+
+    @staticmethod
+    def _build_cut_summary_table(carrier: ProformaCarrier) -> Table:
+        """Metros lineales de corte y canto por plancha + total general (taller).
+
+        Una fila por patrón de corte (deduplicado) con los valores por plancha; la
+        fila TOTAL es la suma sobre todas las planchas físicas.
+        """
+        groups = carrier.layout_groups
+        if not (isinstance(groups, list) and groups):
+            groups = group_layouts(carrier.layouts or [])
+
+        data = [["Patrón", "Planchas", "Corte (m)", "Canto (m)"]]
+        for group in groups:
+            stats = (group.get("layout") or {}).get("statistics") or {}
+            data.append(
+                [
+                    f"#{group.get('pattern_id', '?')}",
+                    str(group.get("count", 0)),
+                    f"{stats.get('cut_linear_m', 0):.2f}",
+                    f"{stats.get('edge_banding_linear_m', 0):.2f}",
+                ]
+            )
+        data.append(
+            [
+                "TOTAL",
+                str(carrier.total_boards_used),
+                f"{carrier.total_cut_linear_m:.2f}",
+                f"{carrier.total_edge_banding_linear_m:.2f}",
+            ]
+        )
+
+        table = Table(
+            data,
+            colWidths=[
+                CONTENT_WIDTH - 3.6 * inch,
+                1.2 * inch,
+                1.2 * inch,
+                1.2 * inch,
+            ],
+            repeatRows=1,
+        )
+        style = _data_table_style(header_size=10, body_size=9)
+        # Resalta la fila TOTAL (última) como caja de totales.
+        style.add("BACKGROUND", (0, -1), (-1, -1), LIGHT_CORAL)
+        style.add("FONTNAME", (0, -1), (-1, -1), "Helvetica-Bold")
+        style.add("TEXTCOLOR", (0, -1), (-1, -1), BRAND_BLACK)
+        table.setStyle(style)
+        return table
 
     @staticmethod
     def _build_layout_pages(carrier: ProformaCarrier) -> List:

--- a/src/modules/optimizations/schemas.py
+++ b/src/modules/optimizations/schemas.py
@@ -158,6 +158,13 @@ class LayoutStatistics(CamelModel):
     waste_area: float = Field(..., description="Unused area of the sheet")
     efficiency: float = Field(..., description="Material usage efficiency (percentage)")
     pieces_count: int = Field(..., description="Number of pieces placed on the sheet")
+    cut_linear_m: float = Field(
+        default=0.0, description="Linear meters of cut (saw travel) for this sheet"
+    )
+    edge_banding_linear_m: float = Field(
+        default=0.0,
+        description="Net linear meters of edge banding on this sheet (informational)",
+    )
 
 
 class Layout(CamelModel):
@@ -200,6 +207,13 @@ class OptimizeResponse(CamelModel):
     total_boards_cost: float = Field(..., description="Total cost of boards used")
     total_edge_banding_cost: float = Field(
         default=0.0, description="Total cost of edge banding used"
+    )
+    total_cut_linear_m: float = Field(
+        default=0.0, description="Total linear meters of cut across all sheets"
+    )
+    total_edge_banding_linear_m: float = Field(
+        default=0.0,
+        description="Total net linear meters of edge banding across all sheets",
     )
     layouts: List[Layout] = Field(
         ..., description="Per-sheet cutting layouts of the optimization"

--- a/src/modules/optimizations/service.py
+++ b/src/modules/optimizations/service.py
@@ -77,6 +77,8 @@ class OptimizationService:
             total_boards_used=payload["total_boards_used"],
             total_boards_cost=payload["total_boards_cost"],
             total_edge_banding_cost=payload.get("total_edge_banding_cost", 0.0),
+            total_cut_linear_m=payload.get("total_cut_linear_m", 0.0),
+            total_edge_banding_linear_m=payload.get("total_edge_banding_linear_m", 0.0),
             layouts=payload["layouts"],
             materials_summary=payload["materials_summary"],
             edge_bandings_summary=payload.get("edge_bandings_summary"),
@@ -290,6 +292,25 @@ class OptimizationService:
                 edge_map[p.label or f"piece_{i+1}"] = p.edge_banding
         return edge_map
 
+    def _net_mm_per_label(self, reqs: List[Requirement]) -> Dict[str, float]:
+        """Metraje neto de canto (mm) por etiqueta de pieza (una instancia).
+
+        Misma fórmula que ``_build_edge_bandings_summary`` (``width`` para
+        ``top/bottom``, ``height`` para ``left/right``), independiente de la rotación.
+        La clave es ``label`` o ``piece_{i+1}`` (== ``base_label`` del id colocado),
+        para agregar el canto por plancha desde las piezas realmente colocadas.
+        """
+        net: Dict[str, float] = {}
+        for i, p in enumerate(reqs):
+            spec = p.edge_banding
+            if spec is None:
+                continue
+            net[p.label or f"piece_{i+1}"] = sum(
+                p.width if side in (EdgeSide.top, EdgeSide.bottom) else p.height
+                for side in spec.sides
+            )
+        return net
+
     def _geometric_edges(
         self, spec: EdgeBandingSpec, eb_products: Dict[int, ProductModel], rotated: bool
     ) -> dict:
@@ -462,13 +483,31 @@ class OptimizationService:
         total_boards_used = len(all_layouts)
         total_boards_cost = sum(layout.material.cost_per_unit for layout in all_layouts)
 
+        # Métricas por plancha (corte = recorrido de sierra; canto = metraje neto de
+        # las piezas colocadas) acumuladas a totales generales. Se inyectan en las
+        # estadísticas del layout antes de ``group_layouts`` para que los patrones
+        # deduplicados hereden las cifras.
         layout_dicts: List[dict] = []
+        total_cut_linear_m = 0.0
+        total_edge_banding_linear_m = 0.0
         for reqs, layouts in results:
             edge_map = self._edge_map_for(reqs)
+            net_mm_per_label = self._net_mm_per_label(reqs)
             for layout in layouts:
                 layout_dict = layout.to_dict()
                 if edge_map:
                     self._enrich_layout_pieces(layout_dict, edge_map, eb_products)
+                cut_linear_m = round(layout.cut_length / 1000.0, 2)
+                eb_mm = sum(
+                    net_mm_per_label.get(base_label(str(p.get("piece_id", ""))), 0.0)
+                    for p in layout_dict.get("placed_pieces", [])
+                )
+                eb_linear_m = round(eb_mm / 1000.0, 2)
+                stats = layout_dict["statistics"]
+                stats["cut_linear_m"] = cut_linear_m
+                stats["edge_banding_linear_m"] = eb_linear_m
+                total_cut_linear_m += cut_linear_m
+                total_edge_banding_linear_m += eb_linear_m
                 layout_dicts.append(layout_dict)
 
         edge_bandings_summary, total_edge_banding_cost = (
@@ -478,6 +517,8 @@ class OptimizationService:
             "total_boards_used": total_boards_used,
             "total_boards_cost": total_boards_cost,
             "total_edge_banding_cost": total_edge_banding_cost,
+            "total_cut_linear_m": round(total_cut_linear_m, 2),
+            "total_edge_banding_linear_m": round(total_edge_banding_linear_m, 2),
             "requirements": [
                 self._dump_requirement(r, product_codes, eb_products)
                 for r in request.requirements

--- a/tests/test_cutting.py
+++ b/tests/test_cutting.py
@@ -91,6 +91,73 @@ def test_guillotine_empty_pieces_returns_empty():
     assert unplaced == []
 
 
+# --- Metros lineales de corte (reconstrucción exacta) --------------------
+
+
+def test_cut_length_single_piece_vertical_first():
+    """SHORTER_LEFTOVER_AXIS con sobrante menor en ancho → ``vertical_first``.
+
+    Pieza 400(ancho)×300(alto) en tablero 1000×1000 (kerf 0): corte horizontal a
+    ancho completo (1000) + corte vertical al alto de la pieza (300) = 1300 mm.
+    """
+    material = Material(id="m1", width=1000, height=1000, thickness=18)
+    optimizer = GuillotineOptimizer(
+        material=material, cutting_params=CuttingParameters(kerf=0)
+    )
+    placed, unplaced = optimizer.optimize(
+        [Piece(id="p", width=400, height=300, can_rotate=False)]
+    )
+    assert len(placed) == 1 and unplaced == []
+
+    horizontals = [c for c in optimizer.cuts if c.is_horizontal]
+    verticals = [c for c in optimizer.cuts if not c.is_horizontal]
+    assert len(horizontals) == 1 and horizontals[0].length == pytest.approx(1000)
+    assert len(verticals) == 1 and verticals[0].length == pytest.approx(300)
+
+    layout = CuttingLayout(
+        material=material,
+        placed_pieces=placed,
+        remainders=optimizer.remainders,
+        sheet_number=1,
+        cuts=optimizer.cuts,
+    )
+    assert layout.cut_length == pytest.approx(1300)
+
+
+def test_cut_length_single_piece_horizontal_first():
+    """Sobrante mayor en ancho → ``horizontal_first``.
+
+    Pieza 300(ancho)×600(alto) en tablero 1000×1000 (kerf 0): corte vertical a alto
+    completo (1000) + corte horizontal al ancho de la pieza (300) = 1300 mm.
+    """
+    material = Material(id="m1", width=1000, height=1000, thickness=18)
+    optimizer = GuillotineOptimizer(
+        material=material, cutting_params=CuttingParameters(kerf=0)
+    )
+    placed, unplaced = optimizer.optimize(
+        [Piece(id="p", width=300, height=600, can_rotate=False)]
+    )
+    assert len(placed) == 1 and unplaced == []
+
+    horizontals = [c for c in optimizer.cuts if c.is_horizontal]
+    verticals = [c for c in optimizer.cuts if not c.is_horizontal]
+    assert len(verticals) == 1 and verticals[0].length == pytest.approx(1000)
+    assert len(horizontals) == 1 and horizontals[0].length == pytest.approx(300)
+
+
+def test_cut_length_full_fill_has_no_cuts():
+    """Una pieza que llena el tablero exacto no genera cortes (no hay sobrante)."""
+    material = Material(id="m1", width=500, height=500, thickness=18)
+    optimizer = GuillotineOptimizer(
+        material=material, cutting_params=CuttingParameters(kerf=0)
+    )
+    placed, unplaced = optimizer.optimize(
+        [Piece(id="p", width=500, height=500, can_rotate=False)]
+    )
+    assert len(placed) == 1 and unplaced == []
+    assert optimizer.cuts == []
+
+
 def test_guillotine_trims_exceeding_material_raise():
     material = Material(id="m1", width=100, height=100, thickness=18)
     with pytest.raises(ValueError):
@@ -133,3 +200,19 @@ def test_multisheet_empty_returns_empty():
     ).optimize([])
     assert layouts == []
     assert remaining == []
+
+
+def test_multisheet_layouts_track_cut_length():
+    """Cada layout reporta su largo de corte (suma de sus segmentos) y es positivo."""
+    material = Material(id="board", width=1000, height=1000, thickness=18)
+    optimizer = MultiSheetGuillotineOptimizer(
+        material_template=material,
+        cutting_params=CuttingParameters(kerf=5),
+    )
+    layouts, remaining = optimizer.optimize(
+        [Piece(id="p", width=400, height=300, quantity=3, can_rotate=False)]
+    )
+    assert layouts and remaining == []
+    for layout in layouts:
+        assert layout.cut_length == pytest.approx(sum(c.length for c in layout.cuts))
+        assert layout.cut_length > 0

--- a/tests/test_edge_banding.py
+++ b/tests/test_edge_banding.py
@@ -124,6 +124,26 @@ def test_optimize_aggregates_edge_banding_meters_and_cost(client):
     assert data["totalEdgeBandingCost"] == pytest.approx(round(billed * 2.0, 2))
 
 
+def test_optimize_reports_edge_banding_linear_m_per_sheet(client):
+    """El metraje neto de canto se expone por plancha y como total general."""
+    c = _create_client(client)
+    b = _create_board(client)
+    eb = _create_edge_banding(client, price=2.0)
+
+    # top+bottom con width=1000 → 2×1000 = 2000 mm = 2.0 m neto (1 pieza, 1 plancha).
+    resp = client.post(
+        "/api/v1/optimize/",
+        json={
+            "clientId": c["id"],
+            "requirements": [_requirement(b["id"], eb["id"], ["top", "bottom"])],
+        },
+    )
+    data = resp.json()["data"]
+    assert data["totalEdgeBandingLinearM"] == pytest.approx(2.0)
+    stats = data["layouts"][0]["statistics"]
+    assert stats["edgeBandingLinearM"] == pytest.approx(2.0)
+
+
 def test_optimize_uses_height_for_left_right_sides(client):
     """left/right miden el alto; top/bottom el ancho."""
     c = _create_client(client)

--- a/tests/test_optimizations.py
+++ b/tests/test_optimizations.py
@@ -70,6 +70,46 @@ def test_optimize_returns_layouts(client):
     assert layout["placedPieces"][0]["originalWidth"] == 600
 
 
+def test_optimize_reports_cut_linear_meters(client):
+    """La respuesta expone metros de corte por plancha y el total general (= suma)."""
+    created_client = _create_client(client)
+    created_board = _create_board(client)
+
+    resp = client.post(
+        "/api/v1/optimize/",
+        json=_optimize_payload(created_client["id"], created_board["id"]),
+    )
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+
+    assert data["totalCutLinearM"] > 0
+    assert "totalEdgeBandingLinearM" in data
+
+    stats = data["layouts"][0]["statistics"]
+    assert stats["cutLinearM"] > 0
+    assert "edgeBandingLinearM" in stats
+
+    total_sheets = sum(lay["statistics"]["cutLinearM"] for lay in data["layouts"])
+    assert data["totalCutLinearM"] == pytest.approx(total_sheets, abs=0.02)
+
+
+def test_carrier_exposes_linear_meter_totals():
+    """``from_payload`` expone los totales nuevos; un payload viejo cae a 0.0."""
+    from src.modules.optimizations.carrier import ProformaCarrier
+
+    carrier = ProformaCarrier.from_payload(
+        {"total_cut_linear_m": 12.5, "total_edge_banding_linear_m": 3.2},
+        client=None,
+        reference="OPT-x",
+    )
+    assert carrier.total_cut_linear_m == 12.5
+    assert carrier.total_edge_banding_linear_m == 3.2
+
+    legacy = ProformaCarrier.from_payload({}, client=None, reference="OPT-y")
+    assert legacy.total_cut_linear_m == 0.0
+    assert legacy.total_edge_banding_linear_m == 0.0
+
+
 def test_optimize_returns_optimization_hash(client):
     """La respuesta expone el hash determinista de las entradas."""
     created_client = _create_client(client)


### PR DESCRIPTION
    Track real guillotine cut segments in the cutting domain and expose
    linear meters of cut (saw travel) and edge banding per sheet plus global
    totals in the optimize response, and add a cut/edge-banding summary
    section to the production sheet.