### PR TITLE
refactor: make cutting optimizer agnostic to material source

### DIFF
--- a/src/cutting/models.py
+++ b/src/cutting/models.py
@@ -168,7 +168,7 @@ class CuttingLayout:
         """Convierte a diccionario para serialización"""
         return {
             "material": {
-                "material_id": self.material.id,
+                "material_key": self.material.id,
                 "sheet_number": self.sheet_number,
                 "width": self.material.width,
                 "height": self.material.height,

--- a/src/modules/optimizations/materials.py
+++ b/src/modules/optimizations/materials.py
@@ -1,0 +1,115 @@
+"""Resolución de materiales agnóstica al origen para el motor de corte.
+
+El optimizador solo necesita dimensiones y costo. Este resolver traduce cada
+``MaterialInput`` (catálogo / retazo / manual) a un ``ResolvedMaterial`` uniforme,
+aislando en un único punto el acoplamiento con el catálogo de productos. Para
+soportar una fuente nueva basta con añadir su ``source`` y su rama (en
+``schemas.py`` y aquí); el dominio ``cutting`` no cambia.
+"""
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+from sqlalchemy.orm import Session
+
+from src.modules.optimizations.schemas import (
+    CatalogMaterialInput,
+    InlineMaterialInput,
+    MaterialInput,
+    MaterialSource,
+)
+from src.modules.products.model import ProductType
+from src.modules.products.service import ProductService
+from src.shared.exceptions import BusinessRuleError, EntityNotFoundError
+
+
+@dataclass
+class ResolvedMaterial:
+    """Material listo para el optimizador: geometría + costo + metadatos de origen.
+
+    ``product_id``/``code``/``name`` solo se pueblan para materiales de catálogo
+    (insumo del cobro de órdenes y de la proforma); las fuentes inline los dejan en
+    ``None`` (``name`` puede llevar la etiqueta libre del material).
+    """
+
+    key: str
+    width: float
+    height: float
+    thickness: float
+    cost_per_unit: float
+    source: str
+    product_id: Optional[int] = None
+    code: Optional[str] = None
+    name: Optional[str] = None
+
+    @property
+    def is_catalog(self) -> bool:
+        return self.source == MaterialSource.catalog.value
+
+    def to_dict(self) -> dict:
+        """Forma serializable para el snapshot/payload de la optimización."""
+        return {
+            "material_key": self.key,
+            "source": self.source,
+            "product_id": self.product_id,
+            "product_code": self.code,
+            "product_name": self.name,
+            "width": self.width,
+            "height": self.height,
+            "thickness": self.thickness,
+            "cost_per_unit": self.cost_per_unit,
+        }
+
+
+class MaterialResolver:
+    """Resuelve cada ``MaterialInput`` a un ``ResolvedMaterial`` según su ``source``."""
+
+    def __init__(self, db: Session):
+        self.product_service = ProductService(db)
+
+    def resolve_all(
+        self, materials: List[MaterialInput]
+    ) -> Dict[str, ResolvedMaterial]:
+        """Resuelve la lista de materiales a un mapa ``key -> ResolvedMaterial``."""
+        return {m.key: self.resolve(m) for m in materials}
+
+    def resolve(self, material: MaterialInput) -> ResolvedMaterial:
+        if isinstance(material, CatalogMaterialInput):
+            return self._resolve_catalog(material)
+        return self._resolve_inline(material)
+
+    def _resolve_catalog(self, material: CatalogMaterialInput) -> ResolvedMaterial:
+        """Resuelve un tablero del catálogo: 404 si no existe, 422 si no es board."""
+        product = self.product_service.get(material.product_id)
+        if product is None:
+            raise EntityNotFoundError("Product", material.product_id)
+        if product.type != ProductType.BOARD.value:
+            raise BusinessRuleError(
+                f"El producto {product.code} no es un tablero optimizable"
+            )
+        attrs = product.attributes
+        return ResolvedMaterial(
+            key=material.key,
+            width=attrs["width"],
+            height=attrs["height"],
+            thickness=attrs["thickness"],
+            cost_per_unit=product.price,
+            source=MaterialSource.catalog.value,
+            product_id=product.id,
+            code=product.code,
+            name=product.name,
+        )
+
+    def _resolve_inline(self, material: InlineMaterialInput) -> ResolvedMaterial:
+        """Retazo (empresa/cliente) o medida manual: dimensiones y costo del input."""
+        return ResolvedMaterial(
+            key=material.key,
+            width=material.width,
+            height=material.height,
+            thickness=material.thickness,
+            cost_per_unit=material.cost_per_unit,
+            source=material.source.value,
+            product_id=None,
+            code=None,
+            name=material.label,
+        )

--- a/src/modules/optimizations/patterns.py
+++ b/src/modules/optimizations/patterns.py
@@ -27,7 +27,7 @@ def layout_signature(layout: dict) -> Tuple:
     Ignora el número de hoja, los remanentes (derivados de las piezas) y el sufijo
     de instancia del ``piece_id``.
     """
-    material_id = layout.get("material", {}).get("material_id")
+    material_key = layout.get("material", {}).get("material_key")
     pieces = [
         (
             base_label(str(piece.get("piece_id", ""))),
@@ -40,7 +40,7 @@ def layout_signature(layout: dict) -> Tuple:
         for piece in layout.get("placed_pieces", [])
     ]
     pieces.sort(key=lambda p: (p[1], p[2], p[3], p[4], p[0]))
-    return (material_id, tuple(pieces))
+    return (material_key, tuple(pieces))
 
 
 def group_layouts(layouts: List[dict]) -> List[dict]:
@@ -53,7 +53,7 @@ def group_layouts(layouts: List[dict]) -> List[dict]:
             "pattern_id": 1,
             "count": 5,
             "sheet_numbers": [1, 2, 3, 4, 5],
-            "material_id": 18,
+            "material_key": "b1",
             "layout": { ...layout representativo... },
         }
     """
@@ -76,7 +76,7 @@ def group_layouts(layouts: List[dict]) -> List[dict]:
                 "pattern_id": len(groups) + 1,
                 "count": 1,
                 "sheet_numbers": [sheet_number],
-                "material_id": layout.get("material", {}).get("material_id"),
+                "material_key": layout.get("material", {}).get("material_key"),
                 "layout": layout,
             }
         )

--- a/src/modules/optimizations/schemas.py
+++ b/src/modules/optimizations/schemas.py
@@ -1,16 +1,39 @@
 from enum import Enum
-from typing import List, Optional
+from typing import Annotated, List, Literal, Optional, Union
 
-from pydantic import Field, NonNegativeInt, PositiveInt, field_validator
+from pydantic import (
+    Field,
+    NonNegativeInt,
+    PositiveInt,
+    confloat,
+    field_validator,
+    model_validator,
+)
 
 from src.modules.clients.schemas import ClientResponse
 from src.shared.schemas import CamelModel
 
 
+class MaterialSource(str, Enum):
+    """Origen del material a optimizar.
+
+    El motor de corte es agnóstico al origen: solo necesita dimensiones y costo.
+    ``catalog`` resuelve un tablero del catálogo de productos; el resto aporta sus
+    dimensiones inline. Una fuente nueva = un valor más + su rama en la unión.
+    """
+
+    catalog = "catalog"
+    company_offcut = "companyOffcut"
+    client_offcut = "clientOffcut"
+    manual = "manual"
+
+
 class MaterialSummary(CamelModel):
-    product_id: int
-    product_code: str
-    product_name: str
+    material_key: str
+    source: MaterialSource
+    product_id: Optional[int] = None
+    product_code: Optional[str] = None
+    product_name: Optional[str] = None
     height: float
     width: float
     thickness: float
@@ -69,6 +92,60 @@ class EdgeBandingSummary(CamelModel):
     total_cost: float
 
 
+class CatalogMaterialInput(CamelModel):
+    """Material del catálogo de productos (tablero)."""
+
+    key: str = Field(
+        ...,
+        min_length=1,
+        max_length=64,
+        description="Stable key referenced by requirements via materialKey",
+    )
+    source: Literal[MaterialSource.catalog]
+    product_id: int = Field(..., description="Board product ID (type=board)")
+
+
+class InlineMaterialInput(CamelModel):
+    """Material con dimensiones inline: retazo de empresa/cliente o medida manual.
+
+    Comparten forma; solo difieren en ``source``. ``quantity`` se acepta pero no se
+    enforca todavía (suministro infinito en Fase 1).
+    """
+
+    key: str = Field(
+        ...,
+        min_length=1,
+        max_length=64,
+        description="Stable key referenced by requirements via materialKey",
+    )
+    source: Literal[
+        MaterialSource.company_offcut,
+        MaterialSource.client_offcut,
+        MaterialSource.manual,
+    ]
+    height: PositiveInt = Field(..., description="Material height (alto) in mm")
+    width: PositiveInt = Field(..., description="Material width (ancho) in mm")
+    thickness: PositiveInt = Field(..., description="Material thickness in mm")
+    cost_per_unit: confloat(ge=0) = Field(
+        default=0.0, description="Unit cost of the material (0 if unknown)"
+    )
+    label: Optional[str] = Field(
+        default=None, max_length=128, description="Human-friendly material label"
+    )
+    quantity: Optional[PositiveInt] = Field(
+        default=None, description="Available units (not enforced in phase 1)"
+    )
+
+
+# Unión discriminada por ``source`` (mismo patrón que ``products/schemas.py``):
+# Pydantic v2 elige y valida la rama según el ``source`` enviado. Una fuente nueva
+# = un valor en ``MaterialSource`` + su rama aquí (o reusar la rama inline).
+MaterialInput = Annotated[
+    Union[CatalogMaterialInput, InlineMaterialInput],
+    Field(discriminator="source"),
+]
+
+
 class Requirement(CamelModel):
     priority: NonNegativeInt = Field(
         ..., description="Cutting priority; higher values are placed first"
@@ -80,7 +157,12 @@ class Requirement(CamelModel):
         ..., description="Piece width (ancho, segunda medida) in mm"
     )
     quantity: PositiveInt = Field(default=1, le=10000)
-    product_id: int = Field(..., description="Target product ID (board) for this piece")
+    material_key: str = Field(
+        ...,
+        min_length=1,
+        max_length=64,
+        description="Key of the material (from `materials`) to cut this piece from",
+    )
     label: Optional[str] = Field(default=None, description="Human-friendly piece label")
     can_rotate: bool = Field(
         default=True,
@@ -97,6 +179,11 @@ class Requirement(CamelModel):
 
 
 class OptimizeRequest(CamelModel):
+    materials: List[MaterialInput] = Field(
+        ...,
+        min_length=1,
+        description="Available materials (stock): catalog boards, offcuts or manual",
+    )
     requirements: List[Requirement] = Field(
         ..., min_length=1, description="List of cuts to optimize"
     )
@@ -109,10 +196,24 @@ class OptimizeRequest(CamelModel):
         ),
     )
 
+    @model_validator(mode="after")
+    def _validate_material_refs(self) -> "OptimizeRequest":
+        """Las keys de materiales son únicas y cada requerimiento referencia una."""
+        keys = [m.key for m in self.materials]
+        if len(set(keys)) != len(keys):
+            raise ValueError("material keys must be unique")
+        keyset = set(keys)
+        for req in self.requirements:
+            if req.material_key not in keyset:
+                raise ValueError(
+                    f"requirement references unknown materialKey '{req.material_key}'"
+                )
+        return self
+
 
 class Material(CamelModel):
-    material_id: int = Field(
-        ..., description="Product ID (board) this sheet was cut from"
+    material_key: str = Field(
+        ..., description="Key of the material (from `materials`) this sheet came from"
     )
     sheet_number: int = Field(
         ..., description="Sheet number within the board (1-based)"
@@ -186,8 +287,8 @@ class LayoutGroup(CamelModel):
     sheet_numbers: List[int] = Field(
         ..., description="Sheet numbers that use this pattern"
     )
-    material_id: int = Field(
-        ..., description="Product ID (board) the pattern is cut from"
+    material_key: str = Field(
+        ..., description="Key of the material the pattern is cut from"
     )
     layout: Layout = Field(..., description="Representative layout for this pattern")
 

--- a/src/modules/optimizations/service.py
+++ b/src/modules/optimizations/service.py
@@ -19,6 +19,7 @@ from src.modules.clients.model import ClientModel
 from src.modules.clients.service import require_phone
 from src.modules.optimizations.carrier import ProformaCarrier
 from src.modules.optimizations.labels import edge_banding_notation
+from src.modules.optimizations.materials import MaterialResolver, ResolvedMaterial
 from src.modules.optimizations.patterns import base_label, group_layouts
 from src.modules.optimizations.schemas import (
     EdgeBandingSpec,
@@ -50,13 +51,15 @@ class OptimizationService:
 
     El cómputo es determinista y efímero: se cachea por un hash de las entradas y
     **no** se persiste en BD (la orden es la fuente de verdad durable). El hash es
-    el identificador con el que se recupera la proforma. Solo los productos de tipo
-    ``board`` se optimizan; el insumo se resuelve del catálogo de productos.
+    el identificador con el que se recupera la proforma. El material es agnóstico al
+    origen: un ``MaterialResolver`` traduce catálogo/retazo/manual a dimensiones y
+    costo antes de optimizar, de modo que ``cutting`` solo ve geometría.
     """
 
     def __init__(self, db: Session):
         self.db = db
         self.product_service = ProductService(db)
+        self.material_resolver = MaterialResolver(db)
 
     def optimize_response(self, request: OptimizeRequest) -> OptimizeResponse:
         """Calcula (cache-first) y arma la respuesta del endpoint ``POST /optimize``.
@@ -112,15 +115,15 @@ class OptimizationService:
     def compute(self, request: OptimizeRequest) -> Tuple[dict, str]:
         """Calcula (o recupera de caché) el resultado de la optimización.
 
-        Cache-first por un hash determinista de entradas (requerimientos +
-        parámetros de corte + precios de los productos). No escribe en BD: lo
-        reutiliza el módulo de órdenes para congelar el snapshot sin depender de la
-        caché. Devuelve ``(payload, optimization_hash)``.
+        Cache-first por un hash determinista de entradas (materiales resueltos +
+        requerimientos + parámetros de corte + precios de tapacanto). No escribe en
+        BD: lo reutiliza el módulo de órdenes para congelar el snapshot sin depender
+        de la caché. Devuelve ``(payload, optimization_hash)``.
         """
         if not request.requirements:
             raise ValidationError("La lista de piezas no puede estar vacía")
 
-        requirements_by_product = self._group_requirements_by_product(
+        requirements_by_key = self._group_requirements_by_material_key(
             request.requirements
         )
 
@@ -132,44 +135,38 @@ class OptimizationService:
             right_trim=config.RIGHT_TRIM,
         )
 
-        products: Dict[int, ProductModel] = {}
-        for product_id in requirements_by_product:
-            product = self.product_service.get(product_id)
-            if product is None:
-                raise EntityNotFoundError("Product", product_id)
-            if product.type != ProductType.BOARD.value:
-                raise BusinessRuleError(
-                    f"El producto {product.code} no es un tablero optimizable"
-                )
-            products[product_id] = product
+        # Resuelve a dimensiones+costo solo los materiales realmente referenciados,
+        # agnóstico al origen (catálogo/retazo/manual). Aquí vive el único punto que
+        # conoce el catálogo; ``cutting`` solo ve geometría.
+        materials_by_key = {m.key: m for m in request.materials}
+        resolved: Dict[str, ResolvedMaterial] = {
+            key: self.material_resolver.resolve(materials_by_key[key])
+            for key in requirements_by_key
+        }
 
         eb_products = self._resolve_edge_banding_products(request.requirements)
 
         optimization_hash = self._compute_hash(
-            request, cutting_params, products, eb_products
+            request, cutting_params, resolved, eb_products
         )
 
         cached = cache.get_json(optimization_hash)
         if cached is not None:
             return cached, optimization_hash
 
-        product_codes = {pid: product.code for pid, product in products.items()}
-        product_names = {pid: product.name for pid, product in products.items()}
         results = [
             (
                 reqs,
                 self._optimize(
                     pieces=reqs,
-                    product=products[pid],
+                    material=resolved[key],
                     cutting_params=cutting_params,
                 )[0],
             )
-            for pid, reqs in requirements_by_product.items()
+            for key, reqs in requirements_by_key.items()
         ]
 
-        payload = self._build_result_payload(
-            request, results, product_codes, product_names, eb_products
-        )
+        payload = self._build_result_payload(request, results, resolved, eb_products)
         cache.set_json(optimization_hash, payload)
         return payload, optimization_hash
 
@@ -202,19 +199,31 @@ class OptimizationService:
         self,
         request: OptimizeRequest,
         cutting_params: CuttingParameters,
-        products: Dict[int, ProductModel],
+        resolved: Dict[str, ResolvedMaterial],
         eb_products: Dict[int, ProductModel],
     ) -> str:
         """Hash sha256 determinista de las entradas que afectan el resultado.
 
         No incluye ``client_id`` (el cómputo no depende del cliente); la dedupe de
-        órdenes sí combina ``client_id`` con este hash. Incluye los precios de
-        tableros y tapacantos y el factor de merma para invalidar la caché cuando
-        cambian.
+        órdenes sí combina ``client_id`` con este hash. Se calcula sobre los
+        materiales resueltos (origen, dimensiones y costo), los requerimientos, los
+        parámetros de corte y los precios de tapacanto, para invalidar la caché
+        cuando cualquiera cambia.
         """
-        prices = {str(pid): product.price for pid, product in products.items()}
-        prices.update({str(pid): p.price for pid, p in eb_products.items()})
+        materials = {
+            key: {
+                "source": rm.source,
+                "width": rm.width,
+                "height": rm.height,
+                "thickness": rm.thickness,
+                "cost_per_unit": rm.cost_per_unit,
+                "product_id": rm.product_id,
+            }
+            for key, rm in resolved.items()
+        }
+        edge_prices = {str(pid): p.price for pid, p in eb_products.items()}
         digest_input = {
+            "materials": materials,
             "requirements": [r.model_dump(mode="json") for r in request.requirements],
             "params": {
                 "kerf": cutting_params.kerf,
@@ -224,39 +233,38 @@ class OptimizationService:
                 "right_trim": cutting_params.right_trim,
                 "edge_banding_waste_factor": config.EDGE_BANDING_WASTE_FACTOR,
             },
-            "prices": prices,
+            "edge_prices": edge_prices,
         }
         canonical = json.dumps(digest_input, sort_keys=True, separators=(",", ":"))
         return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
-    def _group_requirements_by_product(
+    def _group_requirements_by_material_key(
         self, requirements: List[Requirement]
-    ) -> Dict[int, List[Requirement]]:
-        """Agrupa los requerimientos por ID de producto (tablero)."""
-        requirements_by_product = defaultdict(list)
+    ) -> Dict[str, List[Requirement]]:
+        """Agrupa los requerimientos por la key del material a optimizar."""
+        requirements_by_key = defaultdict(list)
         for req in requirements:
-            requirements_by_product[req.product_id].append(req)
-        return requirements_by_product
+            requirements_by_key[req.material_key].append(req)
+        return requirements_by_key
 
     def _optimize(
         self,
         pieces: List[Requirement],
-        product: ProductModel,
+        material: ResolvedMaterial,
         cutting_params: CuttingParameters,
         max_sheets: int = 100,
         min_rect_size: float = 0.1,
     ) -> Tuple[List[CuttingLayout], List[Piece]]:
-        """Optimiza el layout de corte para un tablero específico."""
+        """Optimiza el layout de corte para un material resuelto (cualquier origen)."""
         if not pieces:
             raise ValidationError("La lista de piezas no puede estar vacía")
 
-        attrs = product.attributes
-        material = Material(
-            id=product.id,
-            width=attrs["width"],
-            height=attrs["height"],
-            thickness=attrs["thickness"],
-            cost_per_unit=product.price,
+        domain_material = Material(
+            id=material.key,
+            width=material.width,
+            height=material.height,
+            thickness=material.thickness,
+            cost_per_unit=material.cost_per_unit,
         )
 
         piece_objects = []
@@ -276,7 +284,7 @@ class OptimizationService:
                 raise ValidationError(f"Pieza {i} tiene valores inválidos: {e}")
 
         optimizer = MultiSheetGuillotineOptimizer(
-            material_template=material,
+            material_template=domain_material,
             cutting_params=cutting_params,
             split_rule=SplitRule.SHORTER_LEFTOVER_AXIS,
             max_sheets=max_sheets,
@@ -406,18 +414,27 @@ class OptimizationService:
     def _build_materials_summary(
         self,
         layouts: List[CuttingLayout],
-        product_codes: Dict[int, str],
-        product_names: Dict[int, str],
+        resolved: Dict[str, ResolvedMaterial],
     ) -> List[dict]:
-        """Agrega los layouts por tipo de tablero con métricas y costos."""
-        summary: Dict[int, dict] = {}
+        """Agrega los layouts por material con métricas y costos (cualquier origen).
+
+        Lleva la metadata de origen (``material_key``/``source`` y, solo para
+        catálogo, ``product_id``/``product_code``/``product_name``). Para materiales
+        inline cae a la key como código y a las dimensiones como nombre legible, de
+        modo que la proforma renderiza sin tratamiento especial.
+        """
+        summary: Dict[str, dict] = {}
         for layout in layouts:
-            pid = layout.material.id
-            if pid not in summary:
-                summary[pid] = {
-                    "product_id": pid,
-                    "product_code": product_codes.get(pid, "N/A"),
-                    "product_name": product_names.get(pid, "N/A"),
+            key = layout.material.id
+            if key not in summary:
+                rm = resolved.get(key)
+                dims_label = f"{layout.material.width:g}×{layout.material.height:g}"
+                summary[key] = {
+                    "material_key": key,
+                    "source": rm.source if rm else None,
+                    "product_id": rm.product_id if rm else None,
+                    "product_code": (rm.code if rm and rm.code else key),
+                    "product_name": (rm.name if rm and rm.name else dims_label),
                     "width": layout.material.width,
                     "height": layout.material.height,
                     "thickness": layout.material.thickness,
@@ -427,7 +444,7 @@ class OptimizationService:
                     "cost_per_unit": layout.material.cost_per_unit,
                     "total_cost": 0.0,
                 }
-            entry = summary[pid]
+            entry = summary[key]
             entry["count"] += 1
             entry["total_area_m2"] += round(layout.material.area / 1_000_000, 4)
             entry["_efficiencies"].append(layout.efficiency * 100)
@@ -445,18 +462,22 @@ class OptimizationService:
     @staticmethod
     def _dump_requirement(
         req: Requirement,
-        product_codes: Dict[int, str],
+        resolved: Dict[str, ResolvedMaterial],
         eb_products: Dict[int, ProductModel],
     ) -> dict:
         """Vuelca un requirement al payload y le anexa ``band_type`` del tapacanto.
 
-        El ``band_type`` vive en los atributos del producto, no en el
+        ``product_code`` lleva la etiqueta del material (código de catálogo, o el
+        nombre/key para orígenes inline) que la proforma muestra en la columna
+        "Tablero". El ``band_type`` vive en los atributos del producto, no en el
         ``EdgeBandingSpec``; se inyecta aquí para que la proforma arme la notación de
         cantos (``2L1C CS``) sin volver a resolver el producto al renderizar.
         """
+        rm = resolved.get(req.material_key)
+        material_label = (rm.code or rm.name) if rm else None
         data = {
             **req.model_dump(mode="json"),
-            "product_code": product_codes.get(req.product_id, "N/A"),
+            "product_code": material_label or req.material_key,
         }
         if req.edge_banding is not None and data.get("edge_banding"):
             product = eb_products.get(req.edge_banding.product_id)
@@ -469,8 +490,7 @@ class OptimizationService:
         self,
         request: OptimizeRequest,
         results: List[Tuple[List[Requirement], List[CuttingLayout]]],
-        product_codes: Dict[int, str],
-        product_names: Dict[int, str],
+        resolved: Dict[str, ResolvedMaterial],
         eb_products: Dict[int, ProductModel],
     ) -> dict:
         """Arma el payload cacheable/serializable del resultado de optimización.
@@ -519,14 +539,13 @@ class OptimizationService:
             "total_edge_banding_cost": total_edge_banding_cost,
             "total_cut_linear_m": round(total_cut_linear_m, 2),
             "total_edge_banding_linear_m": round(total_edge_banding_linear_m, 2),
+            "materials": [rm.to_dict() for rm in resolved.values()],
             "requirements": [
-                self._dump_requirement(r, product_codes, eb_products)
+                self._dump_requirement(r, resolved, eb_products)
                 for r in request.requirements
             ],
             "layouts": layout_dicts,
-            "materials_summary": self._build_materials_summary(
-                all_layouts, product_codes, product_names
-            ),
+            "materials_summary": self._build_materials_summary(all_layouts, resolved),
             "edge_bandings_summary": edge_bandings_summary,
             "layout_groups": group_layouts(layout_dicts),
         }

--- a/src/modules/orders/schemas.py
+++ b/src/modules/orders/schemas.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 from pydantic import Field
 
 from src.modules.clients.schemas import ClientResponse
-from src.modules.optimizations.schemas import Requirement
+from src.modules.optimizations.schemas import MaterialInput, Requirement
 from src.modules.orders.model import OrderStatus
 from src.shared.schemas import CamelModel
 
@@ -12,6 +12,11 @@ from src.shared.schemas import CamelModel
 class OrderCreate(CamelModel):
     """Crear una orden: misma forma que ``OptimizeRequest`` + metadatos."""
 
+    materials: List[MaterialInput] = Field(
+        ...,
+        min_length=1,
+        description="Available materials (stock): catalog boards, offcuts or manual",
+    )
     requirements: List[Requirement] = Field(
         ..., min_length=1, description="Cut list to optimize and freeze into the order"
     )

--- a/src/modules/orders/service.py
+++ b/src/modules/orders/service.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 from src.modules.clients.model import ClientModel
 from src.modules.clients.service import require_phone
-from src.modules.optimizations.schemas import OptimizeRequest
+from src.modules.optimizations.schemas import MaterialSource, OptimizeRequest
 from src.modules.optimizations.service import OptimizationService
 from src.modules.orders.model import (
     PENDING_STATUSES,
@@ -73,9 +73,26 @@ class OrderService:
         require_phone(client)
 
         opt_request = OptimizeRequest(
-            requirements=data.requirements, client_id=data.client_id
+            materials=data.materials,
+            requirements=data.requirements,
+            client_id=data.client_id,
         )
         payload, optimization_hash = self.optimization_service.compute(opt_request)
+
+        # Fase 1: el cobro de órdenes solo soporta materiales de catálogo (los
+        # ``order_lines``/``order_pieces`` exigen ``product_id``). Optimizar y
+        # proformar materiales fuera del catálogo sí se permite; convertirlos en
+        # orden se aborda en una iteración posterior.
+        non_catalog = [
+            m
+            for m in payload.get("materials", [])
+            if m.get("source") != MaterialSource.catalog.value
+        ]
+        if non_catalog:
+            raise BusinessRuleError(
+                "Aún no se pueden crear órdenes con materiales fuera del catálogo "
+                "(retazos o medidas manuales); usa tableros del catálogo."
+            )
 
         existing = self._find_active_duplicate(data.client_id, optimization_hash)
         if existing is not None:
@@ -128,10 +145,14 @@ class OrderService:
             )
             for e in payload.get("edge_bandings_summary", [])
         ]
-        # Lista de corte = piezas (insumo de producción; no se cobra).
+        # Lista de corte = piezas (insumo de producción; no se cobra). El producto
+        # se resuelve por la key del material (garantizado de catálogo por el guard).
+        product_id_by_key = {
+            m["material_key"]: m["product_id"] for m in payload.get("materials", [])
+        }
         order.pieces = [
             OrderPieceModel(
-                product_id=r["product_id"],
+                product_id=product_id_by_key[r["material_key"]],
                 label=r.get("label"),
                 height=r["height"],
                 width=r["width"],

--- a/tests/test_cutting.py
+++ b/tests/test_cutting.py
@@ -80,7 +80,7 @@ def test_guillotine_places_pieces_and_reports_efficiency():
 
     as_dict = layout.to_dict()
     assert as_dict["statistics"]["pieces_count"] == 1
-    assert as_dict["material"]["material_id"] == "m1"
+    assert as_dict["material"]["material_key"] == "m1"
     assert as_dict["material"]["sheet_number"] == 1
 
 

--- a/tests/test_edge_banding.py
+++ b/tests/test_edge_banding.py
@@ -53,13 +53,18 @@ def _create_edge_banding(
     ).json()["data"]
 
 
-def _requirement(board_id, eb_id, sides, height=500, width=1000, quantity=1):
+def _materials(board_id, key="b1"):
+    """Stock de catálogo: un tablero referenciado por ``materialKey``."""
+    return [{"key": key, "source": "catalog", "productId": board_id}]
+
+
+def _requirement(eb_id, sides, height=500, width=1000, quantity=1, material_key="b1"):
     return {
         "priority": 0,
         "height": height,
         "width": width,
         "quantity": quantity,
-        "productId": board_id,
+        "materialKey": material_key,
         "label": "Costado",
         "canRotate": True,
         "edgeBanding": {"productId": eb_id, "sides": sides},
@@ -103,7 +108,8 @@ def test_optimize_aggregates_edge_banding_meters_and_cost(client):
         "/api/v1/optimize/",
         json={
             "clientId": c["id"],
-            "requirements": [_requirement(b["id"], eb["id"], ["top", "bottom"])],
+            "materials": _materials(b["id"]),
+            "requirements": [_requirement(eb["id"], ["top", "bottom"])],
         },
     )
     assert resp.status_code == 200
@@ -135,7 +141,8 @@ def test_optimize_reports_edge_banding_linear_m_per_sheet(client):
         "/api/v1/optimize/",
         json={
             "clientId": c["id"],
-            "requirements": [_requirement(b["id"], eb["id"], ["top", "bottom"])],
+            "materials": _materials(b["id"]),
+            "requirements": [_requirement(eb["id"], ["top", "bottom"])],
         },
     )
     data = resp.json()["data"]
@@ -155,7 +162,8 @@ def test_optimize_uses_height_for_left_right_sides(client):
         "/api/v1/optimize/",
         json={
             "clientId": c["id"],
-            "requirements": [_requirement(b["id"], eb["id"], ["left", "right"])],
+            "materials": _materials(b["id"]),
+            "requirements": [_requirement(eb["id"], ["left", "right"])],
         },
     )
     data = resp.json()["data"]
@@ -172,9 +180,10 @@ def test_optimize_aggregates_multiple_edge_banding_types(client):
         "/api/v1/optimize/",
         json={
             "clientId": c["id"],
+            "materials": _materials(b["id"]),
             "requirements": [
-                _requirement(b["id"], eb1["id"], ["top", "bottom"]),
-                _requirement(b["id"], eb2["id"], ["left", "right"], height=1000),
+                _requirement(eb1["id"], ["top", "bottom"]),
+                _requirement(eb2["id"], ["left", "right"], height=1000),
             ],
         },
     )
@@ -192,13 +201,14 @@ def test_optimize_without_edge_banding_has_empty_summary(client):
         "/api/v1/optimize/",
         json={
             "clientId": c["id"],
+            "materials": _materials(b["id"]),
             "requirements": [
                 {
                     "priority": 0,
                     "height": 400,
                     "width": 600,
                     "quantity": 1,
-                    "productId": b["id"],
+                    "materialKey": "b1",
                     "label": "P",
                     "canRotate": True,
                 }
@@ -220,7 +230,8 @@ def test_edge_banding_unknown_product_returns_404(client):
         "/api/v1/optimize/",
         json={
             "clientId": c["id"],
-            "requirements": [_requirement(b["id"], 99999, ["top"])],
+            "materials": _materials(b["id"]),
+            "requirements": [_requirement(99999, ["top"])],
         },
     )
     assert resp.status_code == 404
@@ -236,7 +247,8 @@ def test_edge_banding_non_edge_banding_product_rejected(client):
         "/api/v1/optimize/",
         json={
             "clientId": c["id"],
-            "requirements": [_requirement(b["id"], other_board["id"], ["top"])],
+            "materials": _materials(b["id"]),
+            "requirements": [_requirement(other_board["id"], ["top"])],
         },
     )
     assert resp.status_code == 422
@@ -251,7 +263,8 @@ def test_edge_banding_rejects_duplicate_sides(client):
         "/api/v1/optimize/",
         json={
             "clientId": c["id"],
-            "requirements": [_requirement(b["id"], eb["id"], ["top", "top"])],
+            "materials": _materials(b["id"]),
+            "requirements": [_requirement(eb["id"], ["top", "top"])],
         },
     )
     assert resp.status_code == 422
@@ -310,10 +323,9 @@ def test_asymmetric_banding_rotates_and_swaps_edges(client):
         "/api/v1/optimize/",
         json={
             "clientId": c["id"],
+            "materials": _materials(b["id"]),
             "requirements": [
-                _requirement(
-                    b["id"], eb["id"], ["top", "left"], height=1000, width=2000
-                )
+                _requirement(eb["id"], ["top", "left"], height=1000, width=2000)
             ],
         },
     )
@@ -331,11 +343,15 @@ def test_placed_piece_notation_includes_band_type(client):
     eb = _create_edge_banding(client, band_type="Soft")
 
     # alto=500, ancho=1000, sin rotar: left+right = 2 largos, top = 1 corto; Soft → CS.
-    req = _requirement(b["id"], eb["id"], ["left", "right", "top"])
+    req = _requirement(eb["id"], ["left", "right", "top"])
     req["canRotate"] = False
     resp = client.post(
         "/api/v1/optimize/",
-        json={"clientId": c["id"], "requirements": [req]},
+        json={
+            "clientId": c["id"],
+            "materials": _materials(b["id"]),
+            "requirements": [req],
+        },
     )
     placed = resp.json()["data"]["layouts"][0]["placedPieces"][0]
     assert placed["rotated"] is False
@@ -354,7 +370,8 @@ def test_order_charges_edge_banding(client):
         "/api/v1/orders/",
         json={
             "clientId": c["id"],
-            "requirements": [_requirement(b["id"], eb["id"], ["top", "bottom"])],
+            "materials": _materials(b["id"]),
+            "requirements": [_requirement(eb["id"], ["top", "bottom"])],
         },
     )
     assert resp.status_code == 201
@@ -392,7 +409,8 @@ def test_order_proforma_with_edge_banding_renders(client):
         "/api/v1/orders/",
         json={
             "clientId": c["id"],
-            "requirements": [_requirement(b["id"], eb["id"], ["top", "bottom"])],
+            "materials": _materials(b["id"]),
+            "requirements": [_requirement(eb["id"], ["top", "bottom"])],
         },
     ).json()["data"]
 

--- a/tests/test_optimizations.py
+++ b/tests/test_optimizations.py
@@ -35,13 +35,14 @@ def _create_board(client, code="MEL18"):
 def _optimize_payload(client_id, product_id):
     return {
         "clientId": client_id,
+        "materials": [{"key": "b1", "source": "catalog", "productId": product_id}],
         "requirements": [
             {
                 "priority": 0,
                 "height": 400,
                 "width": 600,
                 "quantity": 2,
-                "productId": product_id,
+                "materialKey": "b1",
                 "label": "Puerta",
                 "canRotate": True,
             }
@@ -64,7 +65,7 @@ def test_optimize_returns_layouts(client):
     assert len(data["layouts"]) >= 1
     layout = data["layouts"][0]
     assert "placedPieces" in layout
-    assert layout["material"]["materialId"] == created_board["id"]
+    assert layout["material"]["materialKey"] == "b1"
     assert layout["material"]["sheetNumber"] == 1
     assert "efficiency" in layout["statistics"]
     assert layout["placedPieces"][0]["originalWidth"] == 600
@@ -300,13 +301,16 @@ def test_optimize_deduplicates_identical_patterns(client):
     # Una pieza grande (1700×670) entra una sola vez por tablero → 5 hojas idénticas.
     payload = {
         "clientId": created_client["id"],
+        "materials": [
+            {"key": "b1", "source": "catalog", "productId": created_board["id"]}
+        ],
         "requirements": [
             {
                 "priority": 0,
                 "height": 1700,
                 "width": 670,
                 "quantity": 5,
-                "productId": created_board["id"],
+                "materialKey": "b1",
                 "label": "",
                 "canRotate": True,
             }
@@ -328,8 +332,8 @@ def test_optimize_deduplicates_identical_patterns(client):
     assert group["patternId"] == 1
     assert group["count"] == 5
     assert len(group["sheetNumbers"]) == 5
-    assert group["materialId"] == created_board["id"]
-    assert group["layout"]["material"]["materialId"] == created_board["id"]
+    assert group["materialKey"] == "b1"
+    assert group["layout"]["material"]["materialKey"] == "b1"
 
 
 def test_optimize_includes_materials_summary(client):
@@ -348,7 +352,223 @@ def test_optimize_includes_materials_summary(client):
     assert summary is not None and len(summary) == 1
 
     entry = summary[0]
+    assert entry["materialKey"] == "b1"
+    assert entry["source"] == "catalog"
     assert entry["productCode"] == "MEL18"
     assert entry["productName"] == "Melamina MEL18"
     assert entry["count"] == data["totalBoardsUsed"]
     assert entry["totalCost"] == pytest.approx(data["totalBoardsCost"])
+
+
+# --------------------------------------------------------------------------- #
+# Material agnóstico al origen (catálogo / manual / retazo / mixto)
+# --------------------------------------------------------------------------- #
+def _manual_material(key="m1", height=2000, width=1000, thickness=18, cost=30.0):
+    return {
+        "key": key,
+        "source": "manual",
+        "height": height,
+        "width": width,
+        "thickness": thickness,
+        "costPerUnit": cost,
+        "label": "Sobrante taller",
+    }
+
+
+def test_optimize_with_manual_material(client):
+    """Una medida manual (sin catálogo) se optimiza por dimensiones y costo."""
+    c = _create_client(client)
+    payload = {
+        "clientId": c["id"],
+        "materials": [_manual_material(cost=30.0)],
+        "requirements": [
+            {
+                "priority": 0,
+                "height": 400,
+                "width": 600,
+                "quantity": 2,
+                "materialKey": "m1",
+                "label": "Puerta",
+                "canRotate": True,
+            }
+        ],
+    }
+    resp = client.post("/api/v1/optimize/", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+
+    assert data["totalBoardsUsed"] >= 1
+    assert data["layouts"][0]["material"]["materialKey"] == "m1"
+
+    entry = data["materialsSummary"][0]
+    assert entry["materialKey"] == "m1"
+    assert entry["source"] == "manual"
+    assert entry["productId"] is None
+    assert entry["costPerUnit"] == 30.0
+    assert entry["totalCost"] == pytest.approx(data["totalBoardsUsed"] * 30.0)
+
+
+def test_optimize_with_company_offcut_material(client):
+    """Un retazo de empresa se trata igual: dimensiones inline, sin producto."""
+    c = _create_client(client)
+    payload = {
+        "clientId": c["id"],
+        "materials": [
+            {
+                "key": "r1",
+                "source": "companyOffcut",
+                "height": 1200,
+                "width": 600,
+                "thickness": 15,
+                "costPerUnit": 0,
+            }
+        ],
+        "requirements": [
+            {
+                "priority": 0,
+                "height": 400,
+                "width": 300,
+                "quantity": 1,
+                "materialKey": "r1",
+                "canRotate": True,
+            }
+        ],
+    }
+    resp = client.post("/api/v1/optimize/", json=payload)
+    assert resp.status_code == 200
+    entry = resp.json()["data"]["materialsSummary"][0]
+    assert entry["source"] == "companyOffcut"
+    assert entry["productId"] is None
+    # Sin label ni código de catálogo cae a la key / dimensiones legibles.
+    assert entry["productCode"] == "r1"
+    assert entry["productName"] == "600×1200"
+
+
+def test_optimize_mixed_catalog_and_manual(client):
+    """Catálogo y manual conviven en una misma optimización (stock heterogéneo)."""
+    c = _create_client(client)
+    board = _create_board(client)
+    payload = {
+        "clientId": c["id"],
+        "materials": [
+            {"key": "b1", "source": "catalog", "productId": board["id"]},
+            _manual_material(key="m1", cost=20.0),
+        ],
+        "requirements": [
+            {
+                "priority": 0,
+                "height": 400,
+                "width": 600,
+                "quantity": 1,
+                "materialKey": "b1",
+            },
+            {
+                "priority": 0,
+                "height": 300,
+                "width": 300,
+                "quantity": 1,
+                "materialKey": "m1",
+            },
+        ],
+    }
+    resp = client.post("/api/v1/optimize/", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+
+    by_key = {e["materialKey"]: e for e in data["materialsSummary"]}
+    assert set(by_key) == {"b1", "m1"}
+    assert by_key["b1"]["source"] == "catalog"
+    assert by_key["b1"]["productId"] == board["id"]
+    assert by_key["m1"]["source"] == "manual"
+    assert by_key["m1"]["productId"] is None
+
+
+def test_optimize_unknown_material_key_returns_422(client):
+    """Un requerimiento que referencia una key inexistente es 422 (validación)."""
+    c = _create_client(client)
+    board = _create_board(client)
+    payload = {
+        "clientId": c["id"],
+        "materials": [{"key": "b1", "source": "catalog", "productId": board["id"]}],
+        "requirements": [
+            {
+                "priority": 0,
+                "height": 400,
+                "width": 600,
+                "quantity": 1,
+                "materialKey": "zzz",
+            }
+        ],
+    }
+    resp = client.post("/api/v1/optimize/", json=payload)
+    assert resp.status_code == 422
+
+
+def test_optimize_manual_material_hash_is_deterministic(client):
+    """Dos peticiones idénticas con material manual comparten hash (cache-first)."""
+    c = _create_client(client)
+    payload = {
+        "clientId": c["id"],
+        "materials": [_manual_material()],
+        "requirements": [
+            {
+                "priority": 0,
+                "height": 400,
+                "width": 600,
+                "quantity": 1,
+                "materialKey": "m1",
+            }
+        ],
+    }
+    first = client.post("/api/v1/optimize/", json=payload).json()["data"]
+    second = client.post("/api/v1/optimize/", json=payload).json()["data"]
+    assert first["optimizationHash"] == second["optimizationHash"]
+
+
+def test_material_resolver_resolves_each_source(db_session):
+    """El resolver traduce catálogo y fuentes inline a un ResolvedMaterial uniforme."""
+    from src.modules.optimizations.materials import MaterialResolver
+    from src.modules.optimizations.schemas import (
+        CatalogMaterialInput,
+        InlineMaterialInput,
+        MaterialSource,
+    )
+    from src.modules.products.model import ProductModel, ProductType
+
+    board = ProductModel(
+        type=ProductType.BOARD.value,
+        code="MELX",
+        name="Melamina X",
+        price=50.0,
+        attributes={"height": 2440, "width": 1220, "thickness": 18},
+    )
+    db_session.add(board)
+    db_session.commit()
+
+    resolver = MaterialResolver(db_session)
+
+    catalog = resolver.resolve(
+        CatalogMaterialInput(
+            key="b1", source=MaterialSource.catalog, product_id=board.id
+        )
+    )
+    assert catalog.is_catalog
+    assert (catalog.width, catalog.height, catalog.thickness) == (1220, 2440, 18)
+    assert catalog.cost_per_unit == 50.0
+    assert catalog.product_id == board.id and catalog.code == "MELX"
+
+    manual = resolver.resolve(
+        InlineMaterialInput(
+            key="m1",
+            source=MaterialSource.manual,
+            height=2000,
+            width=1000,
+            thickness=15,
+            cost_per_unit=12.5,
+            label="Sobrante",
+        )
+    )
+    assert not manual.is_catalog
+    assert manual.product_id is None and manual.code is None
+    assert manual.name == "Sobrante" and manual.cost_per_unit == 12.5
+    assert manual.to_dict()["source"] == "manual"

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -33,13 +33,14 @@ def _create_board(client, code="MEL18"):
 def _order_payload(client_id, product_id, height=400, width=600, quantity=2):
     return {
         "clientId": client_id,
+        "materials": [{"key": "b1", "source": "catalog", "productId": product_id}],
         "requirements": [
             {
                 "priority": 0,
                 "height": height,
                 "width": width,
                 "quantity": quantity,
-                "productId": product_id,
+                "materialKey": "b1",
                 "label": "Puerta",
                 "canRotate": True,
             }
@@ -361,3 +362,35 @@ def test_expired_order_frees_pending_cap(client, monkeypatch):
         "/api/v1/orders/", json=_order_payload(c["id"], b["id"], width=500)
     )
     assert second.status_code == 201
+
+
+def test_create_order_rejects_non_catalog_material(client):
+    """Fase 1: optimizar/proformar materiales no-catálogo sí; crear orden no (422)."""
+    c = _create_client(client)
+    payload = {
+        "clientId": c["id"],
+        "materials": [
+            {
+                "key": "m1",
+                "source": "manual",
+                "height": 2000,
+                "width": 1000,
+                "thickness": 18,
+                "costPerUnit": 30.0,
+            }
+        ],
+        "requirements": [
+            {
+                "priority": 0,
+                "height": 400,
+                "width": 600,
+                "quantity": 1,
+                "materialKey": "m1",
+            }
+        ],
+    }
+    resp = client.post("/api/v1/orders/", json=payload)
+    assert resp.status_code == 422
+    assert "catálogo" in resp.json()["errors"][0]["message"].lower()
+    # No se persistió ninguna orden.
+    assert client.get("/api/v1/orders/").json()["data"] == []

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -7,10 +7,10 @@ from src.modules.optimizations.patterns import (
 )
 
 
-def _layout(sheet_number, pieces, material_id=18):
+def _layout(sheet_number, pieces, material_key="b1"):
     """Construye un layout mínimo con la forma de ``CuttingLayout.to_dict``."""
     return {
-        "material": {"material_id": material_id, "sheet_number": sheet_number},
+        "material": {"material_key": material_key, "sheet_number": sheet_number},
         "placed_pieces": [
             {
                 "piece_id": pid,
@@ -57,7 +57,7 @@ def test_group_collapses_identical_patterns():
     assert group["pattern_id"] == 1
     assert group["count"] == 3
     assert group["sheet_numbers"] == [1, 2, 3]
-    assert group["material_id"] == 18
+    assert group["material_key"] == "b1"
     assert group["layout"] is layouts[0]
 
 


### PR DESCRIPTION
  Decouple POST /optimize and src/cutting/ from productId so the optimizer
  works on material dimensions, not catalog identity. The request now sends a
  `materials` stock list (each with a `key`) plus `requirements` that reference
  a material by `materialKey`.

  - Add MaterialResolver (optimizations/materials.py): a MaterialInput union discriminated on `source` (MaterialSource: catalog/companyOffcut/ clientOffcut/manual) resolves to a ResolvedMaterial (geometry + cost + origin metadata). It is the only point that touches the products catalog; cutting/ only ever sees geometry. Adding a source = a MaterialSource value
    + its union branch.
  - Identity flows as `materialKey` (string) instead of `materialId` (product int) across layouts, materials_summary, layout_groups and the cutting domain to_dict.
  - Hash is computed over the resolved materials (source, dims, cost) + requirements + cutting params + edge-banding prices; still deterministic.
  - materials_summary carries `source` + nullable `productId`, falling back to the key/label/dimensions so the proforma renders unchanged.
  - Orders stay catalog-only (phase 1): OrderService.create rejects snapshots with non-catalog materials (BusinessRuleError) and maps materialKey back to product_id for order_pieces. orders/model.py is untouched.