### PR TITLE
feat: quoted orders with secure client review links

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,11 @@ CORS_ORIGINS=http://localhost:3000,http://localhost:3001
 ORDER_VALIDITY_DAYS=15
 MAX_PENDING_ORDERS_PER_CLIENT=3
 
+# Frontend de Maderable: base para el enlace de revisión del cliente.
+# El dashboard usa HashRouter: la base debe terminar en "/#" para que
+# {FRONTEND_BASE_URL}/review/{token} resuelva a la ruta del SPA.
+FRONTEND_BASE_URL=http://localhost:3001/#
+
 # Tapacantos: merma sobre el metraje neto antes de redondear al metro cobrado
 EDGE_BANDING_WASTE_FACTOR=0.10
 

--- a/alembic/versions/d2e3f4a5b6c7_add_order_review_links.py
+++ b/alembic/versions/d2e3f4a5b6c7_add_order_review_links.py
@@ -1,0 +1,43 @@
+"""add order review links
+
+Revision ID: d2e3f4a5b6c7
+Revises: c1d2e3f4a5b6
+Create Date: 2026-06-09 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "d2e3f4a5b6c7"
+down_revision: Union[str, None] = "c1d2e3f4a5b6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Enlaces de revisión del cliente: solo se persiste el sha256 del token.
+    op.create_table(
+        "order_review_links",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("order_id", sa.Integer(), nullable=False),
+        sa.Column("token_hash", sa.String(length=64), nullable=False),
+        sa.Column("status", sa.String(length=16), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("expires_at", sa.DateTime(), nullable=True),
+        sa.Column("used_at", sa.DateTime(), nullable=True),
+        sa.Column("used_meta", sa.JSON(), nullable=True),
+        sa.ForeignKeyConstraint(["order_id"], ["orders.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("token_hash"),
+    )
+    op.create_index(
+        "ix_order_review_links_order_id", "order_review_links", ["order_id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_order_review_links_order_id", table_name="order_review_links")
+    op.drop_table("order_review_links")

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ from fastapi.responses import RedirectResponse
 from src.modules.analytics.router import router as analytics_router
 from src.modules.clients.router import router as clients_router
 from src.modules.optimizations.router import router as optimizations_router
+from src.modules.orders.public_router import router as orders_public_router
 from src.modules.orders.router import router as orders_router
 from src.modules.products.router import router as products_router
 from src.modules.system.router import router as system_router
@@ -62,6 +63,7 @@ app.include_router(products_router, prefix="/api/v1")
 app.include_router(clients_router, prefix="/api/v1")
 app.include_router(optimizations_router, prefix="/api/v1")
 app.include_router(orders_router, prefix="/api/v1")
+app.include_router(orders_public_router, prefix="/api/v1")
 app.include_router(analytics_router, prefix="/api/v1")
 
 

--- a/src/modules/orders/model.py
+++ b/src/modules/orders/model.py
@@ -25,8 +25,9 @@ class OrderStatus(str, Enum):
 # Estados sin salida: la orden ya no se transforma.
 TERMINAL_STATUSES = {OrderStatus.completed, OrderStatus.cancelled, OrderStatus.expired}
 
-# Pendientes (abiertas, pre-producción): cuentan para el tope antiabuso por cliente.
-PENDING_STATUSES = {OrderStatus.confirmed, OrderStatus.approved}
+# Pendientes (abiertas, pre-producción): cuentan para el tope antiabuso por cliente
+# y para el barrido perezoso de vigencia (una cotización vence igual que una orden).
+PENDING_STATUSES = {OrderStatus.quoted, OrderStatus.confirmed, OrderStatus.approved}
 
 # Mapa de transiciones válidas de la máquina de estados (ver diseño §7.2).
 TRANSITIONS: dict[OrderStatus, set[OrderStatus]] = {
@@ -44,6 +45,14 @@ TRANSITIONS: dict[OrderStatus, set[OrderStatus]] = {
     OrderStatus.cancelled: set(),
     OrderStatus.expired: set(),
 }
+
+
+class ReviewLinkStatus(str, Enum):
+    """Estados de un enlace de revisión del cliente."""
+
+    active = "active"
+    used = "used"
+    revoked = "revoked"
 
 
 class OrderModel(Base):
@@ -86,6 +95,12 @@ class OrderModel(Base):
         back_populates="order",
         cascade="all, delete-orphan",
         order_by="OrderStatusHistoryModel.id",
+    )
+    review_links: Mapped[list["OrderReviewLinkModel"]] = relationship(
+        "OrderReviewLinkModel",
+        back_populates="order",
+        cascade="all, delete-orphan",
+        order_by="OrderReviewLinkModel.id",
     )
 
 
@@ -137,6 +152,35 @@ class OrderPieceModel(Base):
     edges: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
 
     order: Mapped["OrderModel"] = relationship("OrderModel", back_populates="pieces")
+
+
+class OrderReviewLinkModel(Base):
+    """Enlace seguro de revisión del cliente (el token es la credencial).
+
+    Solo se persiste el sha256 del token; el token crudo se devuelve una única
+    vez al generarlo y es irrecuperable (perderlo = regenerar, lo que revoca el
+    anterior). Un solo enlace ``active`` por orden, garantizado en el servicio.
+    """
+
+    __tablename__ = "order_review_links"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    order_id: Mapped[int] = mapped_column(ForeignKey("orders.id"), index=True)
+    token_hash: Mapped[str] = mapped_column(String(64), unique=True)
+    status: Mapped[str] = mapped_column(
+        String(16), default=ReviewLinkStatus.active.value
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    # Espejo de order.expires_at al generar (defensa en profundidad; la vigencia
+    # de la orden es el mecanismo primario de expiración).
+    expires_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    used_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    # Auditoría de la acción del cliente: {"action", "ip", "user_agent", "note"}.
+    used_meta: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
+
+    order: Mapped["OrderModel"] = relationship(
+        "OrderModel", back_populates="review_links"
+    )
 
 
 class OrderStatusHistoryModel(Base):

--- a/src/modules/orders/public_router.py
+++ b/src/modules/orders/public_router.py
@@ -1,0 +1,133 @@
+"""Rutas públicas de revisión del cliente: el token es la única credencial.
+
+Las consume el frontend de Maderable desde la URL del enlace. No exponen
+identificadores internos ni datos de contacto del cliente (ver
+``ReviewOrderResponse``); los diagramas de corte se entregan vía el PDF de
+proforma, también gateado por el token.
+"""
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query, Request
+
+from src.modules.optimizations.carrier import ProformaCarrier
+from src.modules.optimizations.proforma import ProformaService, pdf_response
+from src.modules.orders.model import OrderModel, OrderStatus
+from src.modules.orders.review_service import ReviewLinkService, review_link_service
+from src.modules.orders.schemas import (
+    ReviewActionRequest,
+    ReviewLineResponse,
+    ReviewOrderResponse,
+    ReviewPieceResponse,
+)
+from src.shared.responses import ERROR_RESPONSES, DataResponse, ok
+
+router = APIRouter(
+    prefix="/public/review", tags=["public-review"], responses=ERROR_RESPONSES
+)
+
+_FORMAT_QUERY = Query(
+    default="pdf",
+    description="Formato de salida: 'pdf' (archivo) o 'base64' (JSON)",
+    pattern="^(pdf|base64)$",
+)
+
+
+def _client_meta(request: Request) -> dict:
+    """IP y user-agent del cliente para auditoría de la acción."""
+    forwarded = request.headers.get("x-forwarded-for")
+    ip = (
+        forwarded.split(",")[0].strip()
+        if forwarded
+        else (request.client.host if request.client else None)
+    )
+    return {"ip": ip, "user_agent": request.headers.get("user-agent")}
+
+
+def _to_review_response(order: OrderModel) -> ReviewOrderResponse:
+    """Proyección sanitizada de la orden para la vista pública del cliente."""
+    client_name = (
+        " ".join(
+            part for part in [order.client.first_name, order.client.last_name] if part
+        )
+        or None
+    )
+    return ReviewOrderResponse(
+        order_code=order.code,
+        status=OrderStatus(order.status),
+        client_name=client_name,
+        currency=order.currency,
+        subtotal=order.subtotal,
+        total=order.total,
+        total_boards_used=order.total_boards_used,
+        created_at=order.created_at,
+        confirmed_at=order.confirmed_at,
+        expires_at=order.expires_at,
+        lines=[
+            ReviewLineResponse(
+                product_code=line.product_code,
+                product_name=line.product_name,
+                quantity=line.quantity,
+                unit_price=line.unit_price_snapshot,
+                line_total=line.line_total,
+                linear_m=line.linear_m,
+            )
+            for line in order.lines
+        ],
+        pieces=[
+            ReviewPieceResponse(
+                label=piece.label,
+                height=piece.height,
+                width=piece.width,
+                quantity=piece.quantity,
+                edges=piece.edges,
+            )
+            for piece in order.pieces
+        ],
+    )
+
+
+@router.get("/{token}", response_model=DataResponse[ReviewOrderResponse])
+def get_review(token: str, svc: ReviewLinkService = Depends(review_link_service)):
+    """Detalle sanitizado de la cotización/orden asociada al token."""
+    return ok(_to_review_response(svc.get_review(token)))
+
+
+@router.post("/{token}/confirm", response_model=DataResponse[ReviewOrderResponse])
+def confirm_review(
+    token: str,
+    request: Request,
+    data: Optional[ReviewActionRequest] = None,
+    svc: ReviewLinkService = Depends(review_link_service),
+):
+    """El cliente confirma la cotización (``quoted → confirmed``); reintento benigno."""
+    note = data.note if data else None
+    order = svc.confirm(token, note=note, meta=_client_meta(request))
+    return ok(_to_review_response(order))
+
+
+@router.post("/{token}/reject", response_model=DataResponse[ReviewOrderResponse])
+def reject_review(
+    token: str,
+    request: Request,
+    data: Optional[ReviewActionRequest] = None,
+    svc: ReviewLinkService = Depends(review_link_service),
+):
+    """El cliente rechaza la cotización (``quoted → cancelled``)."""
+    note = data.note if data else None
+    order = svc.reject(token, note=note, meta=_client_meta(request))
+    return ok(_to_review_response(order))
+
+
+# Exento de la envoltura JSON: transporte de archivo PDF (igual que en orders).
+@router.get("/{token}/proforma")
+def get_review_proforma(
+    token: str,
+    format: str = _FORMAT_QUERY,
+    svc: ReviewLinkService = Depends(review_link_service),
+):
+    """Proforma PDF de la cotización, gateada por el token de revisión."""
+    order = svc.get_review(token)
+    carrier = ProformaCarrier.from_order(order)
+    pdf_buffer = ProformaService.generate_proforma_pdf(carrier)
+    return pdf_response(pdf_buffer, f"proforma_{order.code or order.id}.pdf", format)

--- a/src/modules/orders/review_service.py
+++ b/src/modules/orders/review_service.py
@@ -1,0 +1,209 @@
+"""Enlaces de revisión del cliente: generación, consulta y confirmación/rechazo.
+
+Seguridad del enlace (el token ES la credencial; los endpoints públicos no
+tienen otra autenticación):
+
+- Token de 256 bits CSPRNG (``secrets.token_urlsafe(32)``); adivinarlo es
+  infactible, por lo que actúa como capacidad de acceso a una sola orden.
+- En reposo solo se guarda su sha256 (un dump de la DB o fuga de logs no
+  produce nada reutilizable). Sin salt: un token aleatorio de 256 bits es su
+  propio salt.
+- Token desconocido o revocado → 404 uniforme con mensaje fijo (no se
+  distingue "no existe" de "revocado" ni se hace eco del token), para no dar
+  un oráculo de enumeración.
+- Un solo enlace activo por orden: regenerar revoca el anterior (remedio ante
+  fuga o pérdida; el token es irrecuperable por diseño).
+- Notas de despliegue: el token viaja en la URL, el frontend debe usar
+  ``Referrer-Policy: no-referrer``; rate limiting en el reverse proxy.
+"""
+
+import hashlib
+import secrets
+from datetime import datetime, timedelta
+from typing import Optional, Tuple
+
+from fastapi import Depends
+from sqlalchemy.orm import Session
+
+from src.modules.orders.model import (
+    OrderModel,
+    OrderReviewLinkModel,
+    OrderStatus,
+    ReviewLinkStatus,
+)
+from src.modules.orders.service import OrderService
+from src.shared.config import config
+from src.shared.database import get_db
+from src.shared.exceptions import (
+    AppError,
+    BusinessRuleError,
+    ConflictError,
+    EntityNotFoundError,
+)
+
+
+class ReviewLinkNotFoundError(AppError):
+    """404 uniforme: no distingue token inexistente de revocado."""
+
+    status_code = 404
+    code = "NOT_FOUND"
+
+    def __init__(self):
+        super().__init__("Enlace de revisión no válido")
+
+
+def _hash(token: str) -> str:
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+class ReviewLinkService:
+    """Gestiona el ciclo de vida del enlace y las acciones del cliente."""
+
+    def __init__(self, db: Session):
+        self.db = db
+        self.orders = OrderService(db)
+
+    def generate(self, order_id: int) -> Tuple[OrderReviewLinkModel, str]:
+        """Crea un enlace nuevo (revocando el activo previo) y devuelve el token.
+
+        Solo para cotizaciones (``quoted``): una orden ya confirmada no tiene
+        nada que revisar. Devuelve ``(link, token_crudo)``; el token solo
+        existe en esta respuesta.
+        """
+        order = self.orders.get_or_404(order_id)
+        if order.status != OrderStatus.quoted.value:
+            raise BusinessRuleError(
+                "Solo se puede generar un enlace de revisión para una "
+                "cotización (estado 'quoted')."
+            )
+        for previous in order.review_links:
+            if previous.status == ReviewLinkStatus.active.value:
+                previous.status = ReviewLinkStatus.revoked.value
+        raw_token = secrets.token_urlsafe(32)
+        link = OrderReviewLinkModel(
+            order_id=order.id,
+            token_hash=_hash(raw_token),
+            status=ReviewLinkStatus.active.value,
+            expires_at=order.expires_at,
+        )
+        self.db.add(link)
+        self.db.commit()
+        self.db.refresh(link)
+        return link, raw_token
+
+    def get_latest_info(self, order_id: int) -> OrderReviewLinkModel:
+        """Último enlace de la orden (metadatos; nunca expone el token)."""
+        order = self.orders.get_or_404(order_id)
+        if not order.review_links:
+            raise EntityNotFoundError("ReviewLink de la orden", order_id)
+        return order.review_links[-1]
+
+    def get_review(self, token: str) -> OrderModel:
+        """Orden asociada al token para la vista pública (dispara expiración)."""
+        link = self._get_by_token_or_404(token)
+        return self.orders.get_or_404(link.order_id)
+
+    def confirm(
+        self, token: str, note: Optional[str] = None, meta: Optional[dict] = None
+    ) -> OrderModel:
+        """El cliente confirma la cotización: ``quoted → confirmed``, atómico.
+
+        Idempotente para el cliente: si la orden ya está confirmada (o más
+        adelante en el proceso), un reintento devuelve el estado actual sin
+        error; el doble clic no debe producir fallos fantasma.
+        """
+        link = self._get_by_token_or_404(token)
+        order = self.orders.get_or_404(link.order_id)
+        status = OrderStatus(order.status)
+
+        if status == OrderStatus.expired:
+            raise BusinessRuleError("La cotización expiró; solicita una nueva.")
+        if status == OrderStatus.cancelled:
+            raise BusinessRuleError("La cotización fue retirada; solicita una nueva.")
+        if status != OrderStatus.quoted:
+            return order  # ya confirmada (o en producción): reintento benigno
+
+        now = datetime.utcnow()
+        self.orders._apply_transition(
+            order,
+            OrderStatus.confirmed,
+            actor="client",
+            note=note or "Confirmado por el cliente",
+        )
+        order.confirmed_at = now
+        # La vigencia corre desde la confirmación, igual que una orden directa.
+        order.expires_at = now + timedelta(days=config.ORDER_VALIDITY_DAYS)
+        self._mark_used(link, "confirmed", now, note, meta)
+        self.db.commit()
+        self.db.refresh(order)
+        return order
+
+    def reject(
+        self, token: str, note: Optional[str] = None, meta: Optional[dict] = None
+    ) -> OrderModel:
+        """El cliente rechaza la cotización: ``quoted → cancelled``.
+
+        Libera de inmediato el cupo de pendientes en vez de esperar la
+        expiración. Si ya confirmó, el rechazo contradictorio debe pasar por
+        ventas (409), no cancelar una orden posiblemente en producción.
+        """
+        link = self._get_by_token_or_404(token)
+        order = self.orders.get_or_404(link.order_id)
+        status = OrderStatus(order.status)
+
+        if status == OrderStatus.cancelled:
+            return order  # ya cancelada: reintento benigno
+        if status == OrderStatus.expired:
+            raise BusinessRuleError("La cotización expiró; no hay nada que rechazar.")
+        if status != OrderStatus.quoted:
+            raise ConflictError(
+                "La orden ya fue confirmada; para anularla contacta a ventas."
+            )
+
+        now = datetime.utcnow()
+        self.orders._apply_transition(
+            order,
+            OrderStatus.cancelled,
+            actor="client",
+            note=note or "Rechazado por el cliente",
+        )
+        self._mark_used(link, "rejected", now, note, meta)
+        self.db.commit()
+        self.db.refresh(order)
+        return order
+
+    def build_url(self, raw_token: str) -> str:
+        """URL completa de revisión que abre el cliente (frontend de Maderable)."""
+        return f"{config.FRONTEND_BASE_URL.rstrip('/')}/review/{raw_token}"
+
+    def _mark_used(
+        self,
+        link: OrderReviewLinkModel,
+        action: str,
+        now: datetime,
+        note: Optional[str],
+        meta: Optional[dict],
+    ) -> None:
+        link.status = ReviewLinkStatus.used.value
+        link.used_at = now
+        link.used_meta = {"action": action, "note": note, **(meta or {})}
+
+    def _get_by_token_or_404(self, token: str) -> OrderReviewLinkModel:
+        """Busca por hash del token; 404 uniforme si no existe o fue revocado.
+
+        Un enlace ``used`` sigue siendo legible: el cliente puede volver a la
+        página después de confirmar y ver el estado real de su pedido.
+        """
+        link = (
+            self.db.query(OrderReviewLinkModel)
+            .filter(OrderReviewLinkModel.token_hash == _hash(token))
+            .first()
+        )
+        if link is None or link.status == ReviewLinkStatus.revoked.value:
+            raise ReviewLinkNotFoundError()
+        return link
+
+
+def review_link_service(db: Session = Depends(get_db)) -> ReviewLinkService:
+    """Provider de ``ReviewLinkService`` para inyección en rutas."""
+    return ReviewLinkService(db)

--- a/src/modules/orders/router.py
+++ b/src/modules/orders/router.py
@@ -5,12 +5,15 @@ from fastapi import APIRouter, Depends, Query
 from src.modules.optimizations.carrier import ProformaCarrier
 from src.modules.optimizations.proforma import ProformaService, pdf_response
 from src.modules.orders.model import OrderStatus
+from src.modules.orders.review_service import ReviewLinkService, review_link_service
 from src.modules.orders.schemas import (
     OrderCreate,
     OrderExportResponse,
     OrderInvoiceUpdate,
     OrderResponse,
     OrderStatusUpdate,
+    ReviewLinkInfoResponse,
+    ReviewLinkResponse,
 )
 from src.modules.orders.service import OrderService, order_service
 from src.shared.pagination import PageParams
@@ -66,6 +69,40 @@ def update_order_status(
 ):
     """Transiciona el estado de una orden validando la máquina de estados."""
     return ok(svc.transition(order_id, data.status, actor="sales", note=data.note))
+
+
+@router.post(
+    "/{order_id}/review-link",
+    response_model=DataResponse[ReviewLinkResponse],
+    status_code=201,
+)
+def create_review_link(
+    order_id: int, svc: ReviewLinkService = Depends(review_link_service)
+):
+    """Genera el enlace de revisión del cliente (revoca el anterior si existía).
+
+    El token solo se expone en esta respuesta; si se pierde, se regenera.
+    """
+    link, raw_token = svc.generate(order_id)
+    return ok(
+        ReviewLinkResponse(
+            token=raw_token,
+            url=svc.build_url(raw_token),
+            status=link.status,
+            expires_at=link.expires_at,
+            created_at=link.created_at,
+        )
+    )
+
+
+@router.get(
+    "/{order_id}/review-link", response_model=DataResponse[ReviewLinkInfoResponse]
+)
+def get_review_link_info(
+    order_id: int, svc: ReviewLinkService = Depends(review_link_service)
+):
+    """Metadatos del último enlace de revisión (sin el token, irrecuperable)."""
+    return ok(svc.get_latest_info(order_id))
 
 
 @router.post("/{order_id}/invoice", response_model=DataResponse[OrderResponse])

--- a/src/modules/orders/schemas.py
+++ b/src/modules/orders/schemas.py
@@ -1,11 +1,11 @@
 from datetime import datetime
-from typing import List, Optional
+from typing import List, Literal, Optional
 
 from pydantic import Field
 
 from src.modules.clients.schemas import ClientResponse
 from src.modules.optimizations.schemas import MaterialInput, Requirement
-from src.modules.orders.model import OrderStatus
+from src.modules.orders.model import OrderStatus, ReviewLinkStatus
 from src.shared.schemas import CamelModel
 
 
@@ -23,6 +23,13 @@ class OrderCreate(CamelModel):
     client_id: int = Field(..., description="Client ID placing the order")
     notes: Optional[str] = Field(default=None, max_length=512)
     source: Optional[str] = Field(default="telegram", max_length=32)
+    status: Literal[OrderStatus.quoted, OrderStatus.confirmed] = Field(
+        default=OrderStatus.confirmed,
+        description=(
+            "Born status: 'quoted' (cotización para revisión del cliente) o "
+            "'confirmed' (orden directa, default retrocompatible)"
+        ),
+    )
 
 
 class OrderStatusUpdate(CamelModel):
@@ -127,3 +134,71 @@ class OrderResponse(CamelModel):
     lines: List[OrderLineResponse] = Field(default_factory=list)
     pieces: List[OrderPieceResponse] = Field(default_factory=list)
     history: List[OrderStatusHistoryResponse] = Field(default_factory=list)
+
+
+class ReviewLinkResponse(CamelModel):
+    """Enlace de revisión recién generado: única respuesta que expone el token."""
+
+    token: str = Field(..., description="Raw token, returned only at generation time")
+    url: str = Field(..., description="Full review URL for the Maderable frontend")
+    status: ReviewLinkStatus
+    expires_at: Optional[datetime] = None
+    created_at: datetime
+
+
+class ReviewLinkInfoResponse(CamelModel):
+    """Metadatos del enlace vigente, sin el token (irrecuperable por diseño)."""
+
+    status: ReviewLinkStatus
+    created_at: datetime
+    expires_at: Optional[datetime] = None
+    used_at: Optional[datetime] = None
+
+
+class ReviewActionRequest(CamelModel):
+    """Acción del cliente sobre la cotización (confirmar/rechazar)."""
+
+    note: Optional[str] = Field(default=None, max_length=512)
+
+
+class ReviewLineResponse(CamelModel):
+    """Línea de cobro proyectada para la revisión pública del cliente."""
+
+    product_code: Optional[str] = None
+    product_name: Optional[str] = None
+    quantity: int
+    unit_price: float
+    line_total: float
+    linear_m: Optional[float] = None
+
+
+class ReviewPieceResponse(CamelModel):
+    """Pieza de la lista de corte proyectada para la revisión pública."""
+
+    label: Optional[str] = None
+    height: int
+    width: int
+    quantity: int
+    edges: Optional[dict] = None
+
+
+class ReviewOrderResponse(CamelModel):
+    """Vista pública sanitizada de la orden: lo que ve el cliente en el enlace.
+
+    Excluye a propósito identificadores internos (id numérico, client_id),
+    datos de contacto (identifier/phone/email), el snapshot/hash de optimización
+    y metadatos comerciales internos (notes, source, factura externa).
+    """
+
+    order_code: Optional[str] = None
+    status: OrderStatus
+    client_name: Optional[str] = None
+    currency: str
+    subtotal: float
+    total: float
+    total_boards_used: int
+    created_at: datetime
+    confirmed_at: Optional[datetime] = None
+    expires_at: Optional[datetime] = None
+    lines: List[ReviewLineResponse] = Field(default_factory=list)
+    pieces: List[ReviewPieceResponse] = Field(default_factory=list)

--- a/src/modules/orders/service.py
+++ b/src/modules/orders/service.py
@@ -104,10 +104,15 @@ class OrderService:
         total_edge_banding_cost = payload.get("total_edge_banding_cost", 0.0)
         grand_total = round(total_boards_cost + total_edge_banding_cost, 2)
 
+        # Estado de nacimiento: 'confirmed' (flujo directo, default) congela la
+        # confirmación ya; 'quoted' deja la cotización abierta a revisión del
+        # cliente (expires_at = vigencia de la cotización).
+        born_quoted = data.status == OrderStatus.quoted
+
         now = datetime.utcnow()
         order = OrderModel(
             client_id=data.client_id,
-            status=OrderStatus.confirmed.value,
+            status=data.status.value,
             optimization_snapshot=payload,
             optimization_hash=optimization_hash,
             currency="USD",
@@ -117,7 +122,7 @@ class OrderService:
             source=data.source,
             notes=data.notes,
             created_at=now,
-            confirmed_at=now,
+            confirmed_at=None if born_quoted else now,
             expires_at=now + timedelta(days=config.ORDER_VALIDITY_DAYS),
         )
         # Líneas de cobro = tableros usados + tapacantos (productos consumidos).
@@ -166,9 +171,9 @@ class OrderService:
         order.history = [
             OrderStatusHistoryModel(
                 from_status=None,
-                to_status=OrderStatus.confirmed.value,
-                actor="system",
-                note="Orden creada",
+                to_status=data.status.value,
+                actor="sales" if born_quoted else "system",
+                note="Cotización creada" if born_quoted else "Orden creada",
             )
         ]
 
@@ -188,6 +193,23 @@ class OrderService:
     ) -> OrderModel:
         """Valida y aplica una transición de estado, registrando el historial."""
         order = self.get_or_404(order_id)
+        self._apply_transition(order, to_status, actor=actor, note=note)
+        self.db.commit()
+        self.db.refresh(order)
+        return order
+
+    def _apply_transition(
+        self,
+        order: OrderModel,
+        to_status: OrderStatus,
+        actor: str = "system",
+        note: Optional[str] = None,
+    ) -> None:
+        """Valida y aplica la transición sin commit (el llamador persiste).
+
+        Permite componer la transición con otros cambios (p. ej. marcar el
+        enlace de revisión como usado) en una sola transacción atómica.
+        """
         current = OrderStatus(order.status)
         if to_status not in TRANSITIONS.get(current, set()):
             raise BusinessRuleError(
@@ -202,9 +224,6 @@ class OrderService:
             )
         )
         order.status = to_status.value
-        self.db.commit()
-        self.db.refresh(order)
-        return order
 
     def set_external_invoice_id(
         self, order_id: int, external_invoice_id: str

--- a/src/shared/config.py
+++ b/src/shared/config.py
@@ -78,6 +78,11 @@ class Config:
     ORDER_VALIDITY_DAYS = env.int("ORDER_VALIDITY_DAYS", 15)
     MAX_PENDING_ORDERS_PER_CLIENT = env.int("MAX_PENDING_ORDERS_PER_CLIENT", 3)
 
+    # Base del frontend de Maderable: compone la URL del enlace de revisión que
+    # abre el cliente (el origen debe estar también en CORS_ORIGINS). El dashboard
+    # usa HashRouter, por eso la base termina en "/#" (ruta = {base}/review/{token}).
+    FRONTEND_BASE_URL = env("FRONTEND_BASE_URL", "http://localhost:3001/#")
+
     # Datos de la empresa (membrete de la proforma). Valores dummy por defecto;
     # los reales se definen en el .env.
     COMPANY_NAME = env("COMPANY_NAME", "Mi Empresa")

--- a/tests/test_order_review.py
+++ b/tests/test_order_review.py
@@ -1,0 +1,312 @@
+"""Tests del flujo de revisión del cliente: cotización, enlace seguro y públicos."""
+
+from datetime import datetime, timedelta
+
+from src.modules.orders.model import OrderModel
+from src.shared.config import config
+
+from .test_orders import _create_board, _create_client, _order_payload
+
+
+def _quoted_payload(client_id, product_id, **kwargs):
+    payload = _order_payload(client_id, product_id, **kwargs)
+    payload["status"] = "quoted"
+    return payload
+
+
+def _create_quoted_order(client, **kwargs):
+    c = _create_client(client)
+    b = _create_board(client)
+    order = client.post(
+        "/api/v1/orders/", json=_quoted_payload(c["id"], b["id"], **kwargs)
+    ).json()["data"]
+    return order
+
+
+def _generate_link(client, order_id):
+    resp = client.post(f"/api/v1/orders/{order_id}/review-link")
+    assert resp.status_code == 201
+    return resp.json()["data"]
+
+
+# ---------------------------------------------------------------------------
+# Ciclo de vida de la cotización (orden nacida en quoted)
+# ---------------------------------------------------------------------------
+
+
+def test_create_quoted_order(client):
+    order = _create_quoted_order(client)
+
+    assert order["status"] == "quoted"
+    assert order["confirmedAt"] is None
+    assert order["expiresAt"] is not None
+    assert order["code"].startswith("ORD-")
+    # Historial inicial: creación de la cotización por ventas.
+    assert order["history"][0]["fromStatus"] is None
+    assert order["history"][0]["toStatus"] == "quoted"
+    assert order["history"][0]["actor"] == "sales"
+
+
+def test_create_order_default_status_remains_confirmed(client):
+    """Retrocompatibilidad: sin ``status`` la orden nace confirmed (flujo bot)."""
+    c = _create_client(client)
+    b = _create_board(client)
+    order = client.post(
+        "/api/v1/orders/", json=_order_payload(c["id"], b["id"])
+    ).json()["data"]
+    assert order["status"] == "confirmed"
+    assert order["confirmedAt"] is not None
+
+
+def test_quoted_order_expires_lazily(client, monkeypatch):
+    monkeypatch.setattr(config, "ORDER_VALIDITY_DAYS", -1)
+    order = _create_quoted_order(client)
+    fetched = client.get(f"/api/v1/orders/{order['id']}").json()["data"]
+    assert fetched["status"] == "expired"
+    assert fetched["history"][-1]["fromStatus"] == "quoted"
+
+
+def test_quoted_order_counts_towards_pending_cap(client, monkeypatch):
+    monkeypatch.setattr(config, "MAX_PENDING_ORDERS_PER_CLIENT", 1)
+    c = _create_client(client)
+    b = _create_board(client)
+    assert (
+        client.post(
+            "/api/v1/orders/", json=_quoted_payload(c["id"], b["id"], width=600)
+        ).status_code
+        == 201
+    )
+    blocked = client.post(
+        "/api/v1/orders/", json=_quoted_payload(c["id"], b["id"], width=500)
+    )
+    assert blocked.status_code == 422
+    assert "pendiente" in blocked.json()["errors"][0]["message"]
+
+
+# ---------------------------------------------------------------------------
+# Generación del enlace de revisión
+# ---------------------------------------------------------------------------
+
+
+def test_generate_review_link(client, monkeypatch):
+    monkeypatch.setattr(config, "FRONTEND_BASE_URL", "https://maderable.ec")
+    order = _create_quoted_order(client)
+    link = _generate_link(client, order["id"])
+
+    assert link["status"] == "active"
+    assert len(link["token"]) >= 40
+    assert link["url"] == f"https://maderable.ec/review/{link['token']}"
+    assert link["expiresAt"] is not None
+
+    # GET de metadatos no expone el token.
+    info = client.get(f"/api/v1/orders/{order['id']}/review-link")
+    assert info.status_code == 200
+    body = info.json()["data"]
+    assert body["status"] == "active"
+    assert "token" not in body
+    assert link["token"] not in info.text
+
+
+def test_review_link_url_supports_hash_router_base(client, monkeypatch):
+    """El dashboard usa HashRouter: una base terminada en ``/#`` (con o sin
+    slash final) compone ``{base}/review/{token}`` sin romper el fragmento."""
+    monkeypatch.setattr(config, "FRONTEND_BASE_URL", "https://maderable.ec/#/")
+    order = _create_quoted_order(client)
+    link = _generate_link(client, order["id"])
+    assert link["url"] == f"https://maderable.ec/#/review/{link['token']}"
+
+
+def test_generate_review_link_requires_quoted_status(client):
+    c = _create_client(client)
+    b = _create_board(client)
+    confirmed = client.post(
+        "/api/v1/orders/", json=_order_payload(c["id"], b["id"])
+    ).json()["data"]
+
+    resp = client.post(f"/api/v1/orders/{confirmed['id']}/review-link")
+    assert resp.status_code == 422
+    assert "quoted" in resp.json()["errors"][0]["message"]
+
+
+def test_review_link_endpoints_404(client):
+    assert client.post("/api/v1/orders/999999/review-link").status_code == 404
+    assert client.get("/api/v1/orders/999999/review-link").status_code == 404
+    # Orden sin enlace generado aún.
+    order = _create_quoted_order(client)
+    assert client.get(f"/api/v1/orders/{order['id']}/review-link").status_code == 404
+
+
+def test_regenerate_revokes_previous_link(client):
+    order = _create_quoted_order(client)
+    first = _generate_link(client, order["id"])
+    second = _generate_link(client, order["id"])
+
+    # El token anterior queda revocado → 404 uniforme.
+    old = client.get(f"/api/v1/public/review/{first['token']}")
+    assert old.status_code == 404
+    # El nuevo funciona.
+    fresh = client.get(f"/api/v1/public/review/{second['token']}")
+    assert fresh.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Endpoints públicos (token como credencial)
+# ---------------------------------------------------------------------------
+
+
+def test_public_review_detail_is_sanitized(client):
+    order = _create_quoted_order(client)
+    link = _generate_link(client, order["id"])
+
+    resp = client.get(f"/api/v1/public/review/{link['token']}")
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+
+    assert data["orderCode"] == order["code"]
+    assert data["status"] == "quoted"
+    assert data["clientName"] == "Ada Lovelace"
+    assert data["total"] == order["total"]
+    assert len(data["lines"]) == 1
+    assert data["lines"][0]["productCode"] == "MEL18"
+    assert len(data["pieces"]) == 1
+    assert data["pieces"][0]["height"] == 400
+
+    # Sanitización: nada de contacto, identificadores internos ni snapshot.
+    body = resp.text
+    assert "0991112233" not in body  # identifier/phone del cliente
+    for leaked in ("identifier", "phone", "email", "optimizationHash", "history"):
+        assert leaked not in data
+
+
+def test_public_review_unknown_token_404(client):
+    resp = client.get("/api/v1/public/review/un-token-que-no-existe")
+    assert resp.status_code == 404
+    assert resp.json()["errors"][0]["message"] == "Enlace de revisión no válido"
+
+
+def test_confirm_via_token(client):
+    order = _create_quoted_order(client)
+    link = _generate_link(client, order["id"])
+
+    resp = client.post(f"/api/v1/public/review/{link['token']}/confirm")
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["status"] == "confirmed"
+    assert data["confirmedAt"] is not None
+
+    # Historial: la transición la hizo el cliente; el enlace quedó usado.
+    fetched = client.get(f"/api/v1/orders/{order['id']}").json()["data"]
+    assert fetched["history"][-1]["actor"] == "client"
+    assert fetched["history"][-1]["toStatus"] == "confirmed"
+    info = client.get(f"/api/v1/orders/{order['id']}/review-link").json()["data"]
+    assert info["status"] == "used"
+    assert info["usedAt"] is not None
+
+
+def test_confirm_extends_validity(client):
+    order = _create_quoted_order(client)
+    link = _generate_link(client, order["id"])
+    confirmed = client.post(f"/api/v1/public/review/{link['token']}/confirm").json()[
+        "data"
+    ]
+    # La vigencia corre desde la confirmación (≥ que la de la cotización).
+    assert confirmed["expiresAt"] >= order["expiresAt"]
+
+
+def test_reconfirm_is_benign(client):
+    order = _create_quoted_order(client)
+    link = _generate_link(client, order["id"])
+    client.post(f"/api/v1/public/review/{link['token']}/confirm")
+
+    again = client.post(f"/api/v1/public/review/{link['token']}/confirm")
+    assert again.status_code == 200
+    assert again.json()["data"]["status"] == "confirmed"
+
+    # Sin doble transición en el historial.
+    fetched = client.get(f"/api/v1/orders/{order['id']}").json()["data"]
+    confirms = [h for h in fetched["history"] if h["toStatus"] == "confirmed"]
+    assert len(confirms) == 1
+
+
+def test_reject_via_token(client):
+    order = _create_quoted_order(client)
+    link = _generate_link(client, order["id"])
+
+    resp = client.post(
+        f"/api/v1/public/review/{link['token']}/reject",
+        json={"note": "Muy caro"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["data"]["status"] == "cancelled"
+
+    fetched = client.get(f"/api/v1/orders/{order['id']}").json()["data"]
+    assert fetched["history"][-1]["actor"] == "client"
+    assert fetched["history"][-1]["note"] == "Muy caro"
+
+    # Rechazo repetido: benigno.
+    again = client.post(f"/api/v1/public/review/{link['token']}/reject")
+    assert again.status_code == 200
+
+
+def test_reject_after_confirm_conflicts(client):
+    order = _create_quoted_order(client)
+    link = _generate_link(client, order["id"])
+    client.post(f"/api/v1/public/review/{link['token']}/confirm")
+
+    resp = client.post(f"/api/v1/public/review/{link['token']}/reject")
+    assert resp.status_code == 409
+    assert "ventas" in resp.json()["errors"][0]["message"]
+
+
+def test_confirm_expired_quote_fails(client, db_session):
+    order = _create_quoted_order(client)
+    link = _generate_link(client, order["id"])
+
+    # Vence la cotización: el enlace se generó cuando aún estaba vigente.
+    db_order = db_session.get(OrderModel, order["id"])
+    db_order.expires_at = datetime.utcnow() - timedelta(days=1)
+    db_session.commit()
+
+    resp = client.post(f"/api/v1/public/review/{link['token']}/confirm")
+    assert resp.status_code == 422
+    assert "expiró" in resp.json()["errors"][0]["message"]
+    # GET con token válido sobre cotización vencida NO es 404: página amigable.
+    detail = client.get(f"/api/v1/public/review/{link['token']}")
+    assert detail.status_code == 200
+    assert detail.json()["data"]["status"] == "expired"
+
+
+def test_confirm_cancelled_quote_fails(client):
+    order = _create_quoted_order(client)
+    link = _generate_link(client, order["id"])
+    # Ventas retira la cotización.
+    client.patch(f"/api/v1/orders/{order['id']}/status", json={"status": "cancelled"})
+
+    resp = client.post(f"/api/v1/public/review/{link['token']}/confirm")
+    assert resp.status_code == 422
+    assert "retirada" in resp.json()["errors"][0]["message"]
+
+
+def test_public_proforma_by_token(client):
+    order = _create_quoted_order(client)
+    link = _generate_link(client, order["id"])
+
+    pdf = client.get(f"/api/v1/public/review/{link['token']}/proforma")
+    assert pdf.status_code == 200
+    assert pdf.headers["content-type"] == "application/pdf"
+    assert len(pdf.content) > 1000
+
+    assert client.get("/api/v1/public/review/token-falso/proforma").status_code == 404
+
+
+def test_confirmed_order_continues_existing_state_machine(client):
+    """Tras la confirmación del cliente, la orden sigue el flujo operativo normal."""
+    order = _create_quoted_order(client)
+    link = _generate_link(client, order["id"])
+    client.post(f"/api/v1/public/review/{link['token']}/confirm")
+
+    ok = client.patch(
+        f"/api/v1/orders/{order['id']}/status", json={"status": "approved"}
+    )
+    assert ok.status_code == 200
+    assert ok.json()["data"]["status"] == "approved"


### PR DESCRIPTION
    Orders can now be born as quotes (OrderCreate.status, default confirmed
    keeps the bot flow intact). A quoted order issues a 256-bit review link
    (sha256 at rest, one active per order) that the client uses on public
    token-gated endpoints to view, confirm or reject the quote.