### PR TITLE
feat: allow non-catalog orders and fix edge-banding metrics for unlabeled pieces

### DIFF
--- a/alembic/versions/e1f2a3b4c5d6_order_product_id_nullable.py
+++ b/alembic/versions/e1f2a3b4c5d6_order_product_id_nullable.py
@@ -1,0 +1,37 @@
+"""make order_lines/order_pieces product_id nullable
+
+Permite órdenes con materiales fuera del catálogo (retazos/manual), que se
+resuelven a ``product_id = NULL`` y se identifican por ``product_code``/``product_name``.
+
+Revision ID: e1f2a3b4c5d6
+Revises: d2e3f4a5b6c7
+Create Date: 2026-06-11 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "e1f2a3b4c5d6"
+down_revision: Union[str, None] = "d2e3f4a5b6c7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ``batch_alter_table`` es obligatorio para SQLite (dev), que no soporta
+    # ALTER COLUMN directo; en Postgres (prod) se traduce a un ALTER nativo.
+    with op.batch_alter_table("order_lines") as batch_op:
+        batch_op.alter_column("product_id", existing_type=sa.Integer(), nullable=True)
+    with op.batch_alter_table("order_pieces") as batch_op:
+        batch_op.alter_column("product_id", existing_type=sa.Integer(), nullable=True)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("order_pieces") as batch_op:
+        batch_op.alter_column("product_id", existing_type=sa.Integer(), nullable=False)
+    with op.batch_alter_table("order_lines") as batch_op:
+        batch_op.alter_column("product_id", existing_type=sa.Integer(), nullable=False)

--- a/src/cutting/optimizer.py
+++ b/src/cutting/optimizer.py
@@ -63,7 +63,9 @@ class GuillotineOptimizer:
         for piece in pieces:
             for i in range(piece.quantity):
                 piece_copy = Piece(
-                    id=f"{piece.id}_{i+1}" if piece.quantity > 1 else piece.id,
+                    # ``#`` es un separador reservado para la instancia: no colisiona
+                    # con etiquetas que terminan en ``_<n>`` (ver ``base_label``).
+                    id=f"{piece.id}#{i+1}" if piece.quantity > 1 else piece.id,
                     width=piece.width,
                     height=piece.height,
                     quantity=1,
@@ -411,7 +413,9 @@ class MultiSheetGuillotineOptimizer:
         for piece in pieces:
             for i in range(piece.quantity):
                 piece_copy = Piece(
-                    id=f"{piece.id}_{i+1}" if piece.quantity > 1 else piece.id,
+                    # ``#`` es un separador reservado para la instancia: no colisiona
+                    # con etiquetas que terminan en ``_<n>`` (ver ``base_label``).
+                    id=f"{piece.id}#{i+1}" if piece.quantity > 1 else piece.id,
                     width=piece.width,
                     height=piece.height,
                     quantity=1,

--- a/src/modules/optimizations/patterns.py
+++ b/src/modules/optimizations/patterns.py
@@ -9,14 +9,16 @@ conteo físico de tableros.
 import re
 from typing import List, Tuple
 
-# El optimizador expande las piezas con sufijo de instancia ``_{i+1}`` cuando
+# El optimizador expande las piezas con sufijo de instancia ``#{i+1}`` cuando
 # ``quantity > 1`` (ver ``src/cutting/optimizer.py``). Para comparar patrones nos
-# interesa la etiqueta base, no la instancia concreta.
-_INSTANCE_SUFFIX = re.compile(r"_\d+$")
+# interesa la etiqueta base, no la instancia concreta. Se usa ``#`` (no ``_``) para
+# no mutilar etiquetas que ya terminan en ``_<n>`` (p. ej. el auto-label ``piece_1``
+# o una etiqueta de usuario ``estante_2``).
+_INSTANCE_SUFFIX = re.compile(r"#\d+$")
 
 
 def base_label(piece_id: str) -> str:
-    """Devuelve la etiqueta base quitando un único sufijo de instancia ``_N``."""
+    """Devuelve la etiqueta base quitando un único sufijo de instancia ``#N``."""
     return _INSTANCE_SUFFIX.sub("", piece_id or "")
 
 

--- a/src/modules/orders/model.py
+++ b/src/modules/orders/model.py
@@ -109,13 +109,18 @@ class OrderLineModel(Base):
 
     Hoy el cobro es por tableros usados; el modelo admite cualquier producto
     (tablero, tapacanto, herraje) para órdenes mixtas futuras.
+
+    ``product_id`` es nulo para materiales fuera del catálogo (retazos o medidas
+    manuales): esos se identifican por ``product_code``/``product_name``.
     """
 
     __tablename__ = "order_lines"
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     order_id: Mapped[int] = mapped_column(ForeignKey("orders.id"))
-    product_id: Mapped[int] = mapped_column(ForeignKey("products.id"))
+    product_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("products.id"), nullable=True
+    )
     product_code: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
     product_name: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
     quantity: Mapped[int] = mapped_column(Integer)
@@ -133,14 +138,17 @@ class OrderLineModel(Base):
 class OrderPieceModel(Base):
     """Pieza de la LISTA DE CORTE (insumo de producción; no se cobra).
 
-    ``product_id`` referencia el tablero (producto tipo ``board``) del que se corta.
+    ``product_id`` referencia el tablero (producto tipo ``board``) del que se corta;
+    es nulo cuando el material está fuera del catálogo (retazo o medida manual).
     """
 
     __tablename__ = "order_pieces"
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     order_id: Mapped[int] = mapped_column(ForeignKey("orders.id"))
-    product_id: Mapped[int] = mapped_column(ForeignKey("products.id"))
+    product_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("products.id"), nullable=True
+    )
     label: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
     height: Mapped[int] = mapped_column(Integer)
     width: Mapped[int] = mapped_column(Integer)

--- a/src/modules/orders/schemas.py
+++ b/src/modules/orders/schemas.py
@@ -76,7 +76,7 @@ class OrderExportResponse(CamelModel):
 
 class OrderLineResponse(CamelModel):
     id: int
-    product_id: int
+    product_id: Optional[int] = None  # nulo si el material no es de catálogo
     product_code: Optional[str] = None
     product_name: Optional[str] = None
     quantity: int = Field(
@@ -94,7 +94,7 @@ class OrderLineResponse(CamelModel):
 
 class OrderPieceResponse(CamelModel):
     id: int
-    product_id: int
+    product_id: Optional[int] = None  # nulo si el material no es de catálogo
     label: Optional[str] = None
     height: int
     width: int

--- a/src/modules/orders/service.py
+++ b/src/modules/orders/service.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 from src.modules.clients.model import ClientModel
 from src.modules.clients.service import require_phone
-from src.modules.optimizations.schemas import MaterialSource, OptimizeRequest
+from src.modules.optimizations.schemas import OptimizeRequest
 from src.modules.optimizations.service import OptimizationService
 from src.modules.orders.model import (
     PENDING_STATUSES,
@@ -79,20 +79,9 @@ class OrderService:
         )
         payload, optimization_hash = self.optimization_service.compute(opt_request)
 
-        # Fase 1: el cobro de órdenes solo soporta materiales de catálogo (los
-        # ``order_lines``/``order_pieces`` exigen ``product_id``). Optimizar y
-        # proformar materiales fuera del catálogo sí se permite; convertirlos en
-        # orden se aborda en una iteración posterior.
-        non_catalog = [
-            m
-            for m in payload.get("materials", [])
-            if m.get("source") != MaterialSource.catalog.value
-        ]
-        if non_catalog:
-            raise BusinessRuleError(
-                "Aún no se pueden crear órdenes con materiales fuera del catálogo "
-                "(retazos o medidas manuales); usa tableros del catálogo."
-            )
+        # Las órdenes admiten materiales fuera del catálogo (retazos/manual): se
+        # congelan tal cual el snapshot. Sus líneas/piezas quedan con ``product_id``
+        # nulo y se identifican por ``product_code``/``product_name``.
 
         existing = self._find_active_duplicate(data.client_id, optimization_hash)
         if existing is not None:
@@ -151,7 +140,7 @@ class OrderService:
             for e in payload.get("edge_bandings_summary", [])
         ]
         # Lista de corte = piezas (insumo de producción; no se cobra). El producto
-        # se resuelve por la key del material (garantizado de catálogo por el guard).
+        # se resuelve por la key del material (nulo si el material no es de catálogo).
         product_id_by_key = {
             m["material_key"]: m["product_id"] for m in payload.get("materials", [])
         }

--- a/tests/test_edge_banding.py
+++ b/tests/test_edge_banding.py
@@ -151,6 +151,43 @@ def test_optimize_reports_edge_banding_linear_m_per_sheet(client):
     assert stats["edgeBandingLinearM"] == pytest.approx(2.0)
 
 
+def test_unlabeled_piece_still_reports_edge_banding_per_sheet(client):
+    """Regresión: una pieza SIN etiqueta y ``quantity=1`` usa el auto-label
+    ``piece_1``; el metraje por plancha y los ``edges`` de la pieza no deben
+    perderse (antes ``base_label`` mutilaba el ``_1`` y daba 0)."""
+    c = _create_client(client)
+    b = _create_board(client)
+    eb = _create_edge_banding(client, price=2.0)
+
+    resp = client.post(
+        "/api/v1/optimize/",
+        json={
+            "clientId": c["id"],
+            "materials": _materials(b["id"]),
+            "requirements": [
+                {
+                    "priority": 0,
+                    "height": 500,
+                    "width": 1000,
+                    "quantity": 1,
+                    "materialKey": "b1",
+                    "canRotate": True,
+                    "edgeBanding": {"productId": eb["id"], "sides": ["top", "bottom"]},
+                }
+            ],
+        },
+    )
+    data = resp.json()["data"]
+    # top+bottom con width=1000 → 2×1000 = 2000 mm = 2.0 m neto.
+    assert data["totalEdgeBandingLinearM"] == pytest.approx(2.0)
+    layout = data["layouts"][0]
+    assert layout["statistics"]["edgeBandingLinearM"] == pytest.approx(2.0)
+    # El canto se propaga a la pieza colocada (para el diagrama / hoja de taller).
+    placed = layout["placedPieces"][0]
+    assert placed["edges"] is not None
+    assert placed["edges"]["sides"] == ["top", "bottom"]
+
+
 def test_optimize_uses_height_for_left_right_sides(client):
     """left/right miden el alto; top/bottom el ancho."""
     c = _create_client(client)

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -364,11 +364,10 @@ def test_expired_order_frees_pending_cap(client, monkeypatch):
     assert second.status_code == 201
 
 
-def test_create_order_rejects_non_catalog_material(client):
-    """Fase 1: optimizar/proformar materiales no-catálogo sí; crear orden no (422)."""
-    c = _create_client(client)
-    payload = {
-        "clientId": c["id"],
+def _manual_material_payload(client_id):
+    """Orden con un único material 'manual' (fuera del catálogo)."""
+    return {
+        "clientId": client_id,
         "materials": [
             {
                 "key": "m1",
@@ -377,6 +376,7 @@ def test_create_order_rejects_non_catalog_material(client):
                 "width": 1000,
                 "thickness": 18,
                 "costPerUnit": 30.0,
+                "label": "Sobrante taller",
             }
         ],
         "requirements": [
@@ -389,8 +389,101 @@ def test_create_order_rejects_non_catalog_material(client):
             }
         ],
     }
+
+
+def test_create_order_with_non_catalog_material(client):
+    """Un material 'manual' se congela tal cual el snapshot: línea sin productId."""
+    c = _create_client(client)
+
+    resp = client.post("/api/v1/orders/", json=_manual_material_payload(c["id"]))
+    assert resp.status_code == 201
+    data = resp.json()["data"]
+
+    # Cobro = el material manual, identificado por code/name (sin productId).
+    assert len(data["lines"]) == 1
+    line = data["lines"][0]
+    assert line["productId"] is None
+    assert line["productCode"] == "m1"
+    assert line["productName"] == "Sobrante taller"
+    assert line["unitPriceSnapshot"] == 30.0
+    assert line["lineTotal"] == 30.0 * line["quantity"]
+    assert data["total"] == data["subtotal"] == 30.0 * data["totalBoardsUsed"]
+
+    # La pieza cortada del material manual también queda sin productId.
+    assert len(data["pieces"]) == 1
+    assert data["pieces"][0]["productId"] is None
+
+    # Se persistió la orden.
+    assert len(client.get("/api/v1/orders/").json()["data"]) == 1
+
+
+def test_create_mixed_catalog_and_offcut_order(client):
+    """Orden mixta: tablero de catálogo + retazo de empresa (costo 0)."""
+    c = _create_client(client)
+    b = _create_board(client)
+
+    payload = {
+        "clientId": c["id"],
+        "materials": [
+            {"key": "b1", "source": "catalog", "productId": b["id"]},
+            {
+                "key": "r1",
+                "source": "companyOffcut",
+                "height": 1200,
+                "width": 600,
+                "thickness": 15,
+                "costPerUnit": 0,
+            },
+        ],
+        "requirements": [
+            {
+                "priority": 0,
+                "height": 400,
+                "width": 600,
+                "quantity": 1,
+                "materialKey": "b1",
+            },
+            {
+                "priority": 0,
+                "height": 300,
+                "width": 400,
+                "quantity": 1,
+                "materialKey": "r1",
+            },
+        ],
+    }
     resp = client.post("/api/v1/orders/", json=payload)
-    assert resp.status_code == 422
-    assert "catálogo" in resp.json()["errors"][0]["message"].lower()
-    # No se persistió ninguna orden.
-    assert client.get("/api/v1/orders/").json()["data"] == []
+    assert resp.status_code == 201
+    data = resp.json()["data"]
+
+    assert len(data["lines"]) == 2
+    catalog_line = next(line for line in data["lines"] if line["productId"] is not None)
+    offcut_line = next(line for line in data["lines"] if line["productId"] is None)
+    assert catalog_line["productId"] == b["id"]
+    assert catalog_line["productCode"] == "MEL18"
+    assert offcut_line["productCode"] == "r1"
+    # El retazo a costo 0 no suma al total; este = solo el tablero de catálogo.
+    assert offcut_line["lineTotal"] == 0
+    assert data["total"] == catalog_line["lineTotal"]
+
+    # Cada pieza referencia su material: catálogo → productId, retazo → None.
+    piece_product_ids = {p["productId"] for p in data["pieces"]}
+    assert piece_product_ids == {b["id"], None}
+
+
+def test_non_catalog_order_renders_proforma_and_production_sheet(client):
+    """Proforma y hoja de producción se renderizan del snapshot, sin catálogo."""
+    c = _create_client(client)
+    order = client.post(
+        "/api/v1/orders/", json=_manual_material_payload(c["id"])
+    ).json()["data"]
+
+    proforma = client.get(f"/api/v1/orders/{order['id']}/proforma")
+    assert proforma.status_code == 200
+    assert proforma.headers["content-type"] == "application/pdf"
+    assert len(proforma.content) > 1000
+
+    sheet = client.get(f"/api/v1/orders/{order['id']}/production-sheet")
+    assert sheet.status_code == 200
+    assert sheet.headers["content-type"] == "application/pdf"
+    assert len(sheet.content) > 1000

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -27,15 +27,23 @@ def _layout(sheet_number, pieces, material_key="b1"):
 
 
 def test_base_label_strips_single_instance_suffix():
-    assert base_label("piece_1_5") == "piece_1"
-    assert base_label("Puerta_2") == "Puerta"
+    assert base_label("piece_1#5") == "piece_1"
+    assert base_label("Puerta#2") == "Puerta"
     assert base_label("Puerta") == "Puerta"
     assert base_label("") == ""
 
 
+def test_base_label_preserves_labels_ending_in_underscore_number():
+    """``#`` separa la instancia: las etiquetas que terminan en ``_<n>`` (auto-label
+    ``piece_1`` o de usuario ``estante_2``) no se mutilan."""
+    assert base_label("piece_1") == "piece_1"
+    assert base_label("estante_2") == "estante_2"
+    assert base_label("estante_2#3") == "estante_2"
+
+
 def test_signature_ignores_instance_suffix_and_sheet_number():
-    a = _layout(1, [("Puerta_1", 0, 0, 670, 1700, False)])
-    b = _layout(7, [("Puerta_9", 0, 0, 670, 1700, False)])
+    a = _layout(1, [("Puerta#1", 0, 0, 670, 1700, False)])
+    b = _layout(7, [("Puerta#9", 0, 0, 670, 1700, False)])
     assert layout_signature(a) == layout_signature(b)
 
 
@@ -47,9 +55,9 @@ def test_signature_ignores_piece_order():
 
 def test_group_collapses_identical_patterns():
     layouts = [
-        _layout(1, [("piece_1_1", 0, 0, 670, 1700, False)]),
-        _layout(2, [("piece_1_2", 0, 0, 670, 1700, False)]),
-        _layout(3, [("piece_1_3", 0, 0, 670, 1700, False)]),
+        _layout(1, [("piece_1#1", 0, 0, 670, 1700, False)]),
+        _layout(2, [("piece_1#2", 0, 0, 670, 1700, False)]),
+        _layout(3, [("piece_1#3", 0, 0, 670, 1700, False)]),
     ]
     groups = group_layouts(layouts)
     assert len(groups) == 1


### PR DESCRIPTION
- Orders accept offcut/manual materials: order_lines/order_pieces.product_id is now nullable and the catalog-only guard is removed; non-catalog lines/pieces persist with NULL product_id and bill exactly as the frozen snapshot.
    - Edge-banding linear meters and per-piece edges were lost for auto-labeled pieces; the instance suffix now uses '#' so base_label keeps a trailing '_N' (e.g. 'piece_1', 'estante_2').