### PR TITLE
feat: per-piece cutting plan for the workshop view

### DIFF
--- a/alembic/versions/a3b4c5d6e7f8_add_remainders_cuts_to_order_boards.py
+++ b/alembic/versions/a3b4c5d6e7f8_add_remainders_cuts_to_order_boards.py
@@ -1,0 +1,32 @@
+"""add remainders and cuts to order boards
+
+Revision ID: a3b4c5d6e7f8
+Revises: f2a3b4c5d6e7
+Create Date: 2026-06-12 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "a3b4c5d6e7f8"
+down_revision: Union[str, None] = "f2a3b4c5d6e7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Sobrantes (display + futuro inventario de retazos) y cortes de guillotina
+    # (líneas de sierra para la vista de taller), copiados del snapshot al
+    # materializar el plan de corte. Nulos en tableros previos a esta feature.
+    op.add_column(
+        "order_boards", sa.Column("remainders", sa.JSON(), nullable=True)
+    )
+    op.add_column("order_boards", sa.Column("cuts", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("order_boards", "cuts")
+    op.drop_column("order_boards", "remainders")

--- a/alembic/versions/f2a3b4c5d6e7_add_cutting_plan_tables.py
+++ b/alembic/versions/f2a3b4c5d6e7_add_cutting_plan_tables.py
@@ -1,0 +1,78 @@
+"""add cutting plan tables
+
+Revision ID: f2a3b4c5d6e7
+Revises: e1f2a3b4c5d6
+Create Date: 2026-06-12 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "f2a3b4c5d6e7"
+down_revision: Union[str, None] = "e1f2a3b4c5d6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Plan de corte materializado: un tablero físico por layout del snapshot.
+    op.create_table(
+        "order_boards",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("order_id", sa.Integer(), nullable=False),
+        sa.Column("sheet_number", sa.Integer(), nullable=False),
+        sa.Column("material_key", sa.String(length=64), nullable=False),
+        sa.Column("product_id", sa.Integer(), nullable=True),
+        sa.Column("product_code", sa.String(length=64), nullable=True),
+        sa.Column("product_name", sa.String(length=128), nullable=True),
+        sa.Column("width", sa.Float(), nullable=False),
+        sa.Column("height", sa.Float(), nullable=False),
+        sa.Column("thickness", sa.Float(), nullable=False),
+        sa.ForeignKeyConstraint(["order_id"], ["orders.id"]),
+        sa.ForeignKeyConstraint(["product_id"], ["products.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_order_boards_order_id", "order_boards", ["order_id"])
+
+    # Piezas colocadas: la unidad que el operario marca como cortada (cut_at).
+    op.create_table(
+        "order_placed_pieces",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("order_id", sa.Integer(), nullable=False),
+        sa.Column("board_id", sa.Integer(), nullable=False),
+        sa.Column("piece_id", sa.String(length=160), nullable=False),
+        sa.Column("label", sa.String(length=128), nullable=False),
+        sa.Column("x", sa.Float(), nullable=False),
+        sa.Column("y", sa.Float(), nullable=False),
+        sa.Column("width", sa.Float(), nullable=False),
+        sa.Column("height", sa.Float(), nullable=False),
+        sa.Column("original_width", sa.Float(), nullable=False),
+        sa.Column("original_height", sa.Float(), nullable=False),
+        sa.Column("rotated", sa.Boolean(), nullable=False),
+        sa.Column("edges", sa.JSON(), nullable=True),
+        sa.Column("cut_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["order_id"], ["orders.id"]),
+        sa.ForeignKeyConstraint(["board_id"], ["order_boards.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_order_placed_pieces_order_id", "order_placed_pieces", ["order_id"]
+    )
+    op.create_index(
+        "ix_order_placed_pieces_board_id", "order_placed_pieces", ["board_id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_order_placed_pieces_board_id", table_name="order_placed_pieces"
+    )
+    op.drop_index(
+        "ix_order_placed_pieces_order_id", table_name="order_placed_pieces"
+    )
+    op.drop_table("order_placed_pieces")
+    op.drop_index("ix_order_boards_order_id", table_name="order_boards")
+    op.drop_table("order_boards")

--- a/src/cutting/models.py
+++ b/src/cutting/models.py
@@ -187,4 +187,13 @@ class CuttingLayout:
                 {"x": r.x, "y": r.y, "width": r.width, "height": r.height}
                 for r in self.remainders
             ],
+            "cuts": [
+                {
+                    "x": c.x,
+                    "y": c.y,
+                    "length": c.length,
+                    "is_horizontal": c.is_horizontal,
+                }
+                for c in self.cuts
+            ],
         }

--- a/src/modules/optimizations/schemas.py
+++ b/src/modules/optimizations/schemas.py
@@ -254,6 +254,17 @@ class Remainder(CamelModel):
     width: float = Field(..., description="Width of the remainder (ancho)")
 
 
+class CutSegment(CamelModel):
+    """Segmento de corte de guillotina (recorrido de la sierra) sobre la plancha."""
+
+    x: float = Field(..., description="X where the saw cut starts")
+    y: float = Field(..., description="Y where the saw cut starts")
+    length: float = Field(..., description="Length of the saw travel along its axis")
+    is_horizontal: bool = Field(
+        ..., description="True if the cut runs horizontally (along X)"
+    )
+
+
 class LayoutStatistics(CamelModel):
     used_area: float = Field(..., description="Total area occupied by placed pieces")
     waste_area: float = Field(..., description="Unused area of the sheet")
@@ -278,6 +289,11 @@ class Layout(CamelModel):
     )
     remainders: List[Remainder] = Field(
         ..., description="Leftover rectangles on this sheet"
+    )
+    # Default vacío: payloads cacheados/snapshots previos a esta clave validan igual.
+    cuts: List[CutSegment] = Field(
+        default_factory=list,
+        description="Guillotine saw cuts on this sheet (for drawing cut lines)",
     )
 
 

--- a/src/modules/orders/model.py
+++ b/src/modules/orders/model.py
@@ -102,6 +102,12 @@ class OrderModel(Base):
         cascade="all, delete-orphan",
         order_by="OrderReviewLinkModel.id",
     )
+    boards: Mapped[list["OrderBoardModel"]] = relationship(
+        "OrderBoardModel",
+        back_populates="order",
+        cascade="all, delete-orphan",
+        order_by="OrderBoardModel.id",
+    )
 
 
 class OrderLineModel(Base):
@@ -160,6 +166,77 @@ class OrderPieceModel(Base):
     edges: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
 
     order: Mapped["OrderModel"] = relationship("OrderModel", back_populates="pieces")
+
+
+class OrderBoardModel(Base):
+    """Tablero FÍSICO del plan de corte, materializado desde el snapshot.
+
+    Cada fila es una hoja real a cortar (los ``layout_groups`` del snapshot solo
+    deduplican la vista). ``sheet_number`` es la secuencia global 1..N dentro de
+    la orden (el ``sheet_number`` del snapshot se reinicia por material).
+    ``product_id`` es nulo para materiales fuera del catálogo (retazo/manual).
+    """
+
+    __tablename__ = "order_boards"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    order_id: Mapped[int] = mapped_column(ForeignKey("orders.id"), index=True)
+    sheet_number: Mapped[int] = mapped_column(Integer)
+    material_key: Mapped[str] = mapped_column(String(64))
+    product_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("products.id"), nullable=True
+    )
+    product_code: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    product_name: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
+    width: Mapped[float] = mapped_column(Float)
+    height: Mapped[float] = mapped_column(Float)
+    thickness: Mapped[float] = mapped_column(Float)
+    # Rectángulos sobrantes del snapshot (display + futuro inventario de retazos).
+    remainders: Mapped[Optional[list]] = mapped_column(JSON, nullable=True)
+    # Cortes de guillotina (recorridos de sierra) para dibujar las líneas de corte.
+    # Nulo en órdenes cuyo snapshot es previo a la serialización de ``cuts``.
+    cuts: Mapped[Optional[list]] = mapped_column(JSON, nullable=True)
+
+    order: Mapped["OrderModel"] = relationship("OrderModel", back_populates="boards")
+    pieces: Mapped[list["OrderPlacedPieceModel"]] = relationship(
+        "OrderPlacedPieceModel",
+        back_populates="board",
+        cascade="all, delete-orphan",
+        order_by="OrderPlacedPieceModel.id",
+    )
+
+
+class OrderPlacedPieceModel(Base):
+    """Pieza COLOCADA en un tablero físico: la unidad que el operario marca.
+
+    Geometría ya rotada (x, y, width, height) lista para dibujar; las dims
+    nominales (``original_*``) sirven para agrupar piezas iguales en el front.
+    ``piece_id`` conserva la identidad de instancia del snapshot (``label#N``).
+    ``cut_at`` nulo = pendiente de corte; con fecha = cortada.
+    """
+
+    __tablename__ = "order_placed_pieces"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    order_id: Mapped[int] = mapped_column(ForeignKey("orders.id"), index=True)
+    board_id: Mapped[int] = mapped_column(ForeignKey("order_boards.id"), index=True)
+    piece_id: Mapped[str] = mapped_column(String(160))
+    label: Mapped[str] = mapped_column(String(128))
+    x: Mapped[float] = mapped_column(Float)
+    y: Mapped[float] = mapped_column(Float)
+    width: Mapped[float] = mapped_column(Float)
+    height: Mapped[float] = mapped_column(Float)
+    original_width: Mapped[float] = mapped_column(Float)
+    original_height: Mapped[float] = mapped_column(Float)
+    rotated: Mapped[bool] = mapped_column(Boolean, default=False)
+    # Lados canteados geométricos, tal cual el snapshot (nulo si no lleva canto).
+    edges: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
+    cut_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+
+    order: Mapped["OrderModel"] = relationship("OrderModel")
+    board: Mapped["OrderBoardModel"] = relationship(
+        "OrderBoardModel", back_populates="pieces"
+    )
 
 
 class OrderReviewLinkModel(Base):

--- a/src/modules/orders/router.py
+++ b/src/modules/orders/router.py
@@ -7,11 +7,14 @@ from src.modules.optimizations.proforma import ProformaService, pdf_response
 from src.modules.orders.model import OrderStatus
 from src.modules.orders.review_service import ReviewLinkService, review_link_service
 from src.modules.orders.schemas import (
+    CuttingPlanResponse,
     OrderCreate,
     OrderExportResponse,
     OrderInvoiceUpdate,
     OrderResponse,
     OrderStatusUpdate,
+    PieceCutResponse,
+    PieceCutUpdate,
     ReviewLinkInfoResponse,
     ReviewLinkResponse,
 )
@@ -69,6 +72,31 @@ def update_order_status(
 ):
     """Transiciona el estado de una orden validando la máquina de estados."""
     return ok(svc.transition(order_id, data.status, actor="sales", note=data.note))
+
+
+@router.get(
+    "/{order_id}/cutting-plan", response_model=DataResponse[CuttingPlanResponse]
+)
+def get_cutting_plan(order_id: int, svc: OrderService = Depends(order_service)):
+    """Plan de corte para la vista de taller: tableros físicos, piezas y avance."""
+    return ok(svc.get_cutting_plan(order_id))
+
+
+@router.patch(
+    "/{order_id}/cutting-plan/pieces/{piece_id}",
+    response_model=DataResponse[PieceCutResponse],
+)
+def mark_piece_cut(
+    order_id: int,
+    piece_id: int,
+    data: PieceCutUpdate,
+    svc: OrderService = Depends(order_service),
+):
+    """Marca (o desmarca, ``cut=false``) una pieza colocada como cortada.
+
+    Solo con la orden ``in_production``. Idempotente: re-marcar no cambia nada.
+    """
+    return ok(svc.mark_piece_cut(order_id, piece_id, data.cut))
 
 
 @router.post(

--- a/src/modules/orders/schemas.py
+++ b/src/modules/orders/schemas.py
@@ -4,7 +4,12 @@ from typing import List, Literal, Optional
 from pydantic import Field
 
 from src.modules.clients.schemas import ClientResponse
-from src.modules.optimizations.schemas import MaterialInput, Requirement
+from src.modules.optimizations.schemas import (
+    CutSegment,
+    MaterialInput,
+    Remainder,
+    Requirement,
+)
 from src.modules.orders.model import OrderStatus, ReviewLinkStatus
 from src.shared.schemas import CamelModel
 
@@ -134,6 +139,79 @@ class OrderResponse(CamelModel):
     lines: List[OrderLineResponse] = Field(default_factory=list)
     pieces: List[OrderPieceResponse] = Field(default_factory=list)
     history: List[OrderStatusHistoryResponse] = Field(default_factory=list)
+
+
+class PlacedPieceResponse(CamelModel):
+    """Pieza colocada en un tablero físico, con su estado de corte."""
+
+    id: int
+    piece_id: str = Field(..., description="Instance identity from snapshot (label#N)")
+    label: str
+    x: float
+    y: float
+    width: float
+    height: float
+    original_width: float
+    original_height: float
+    rotated: bool
+    edges: Optional[dict] = Field(
+        default=None, description="Geometric edge-banded sides (as drawn)"
+    )
+    cut: bool = Field(..., description="Whether the piece was already cut")
+    cut_at: Optional[datetime] = None
+
+
+class CuttingProgress(CamelModel):
+    """Avance de corte: piezas cortadas sobre el total."""
+
+    cut_pieces: int
+    total_pieces: int
+
+
+class OrderBoardResponse(CamelModel):
+    """Tablero físico del plan de corte con sus piezas y avance."""
+
+    id: int
+    sheet_number: int = Field(..., description="Global sheet sequence within the order")
+    material_key: str
+    product_code: Optional[str] = None
+    product_name: Optional[str] = None
+    width: float
+    height: float
+    thickness: float
+    progress: CuttingProgress
+    pieces: List[PlacedPieceResponse] = Field(default_factory=list)
+    remainders: List[Remainder] = Field(
+        default_factory=list, description="Leftover rectangles (waste/offcuts)"
+    )
+    cuts: List[CutSegment] = Field(
+        default_factory=list,
+        description="Guillotine saw cuts; empty for orders frozen before this field",
+    )
+
+
+class CuttingPlanResponse(CamelModel):
+    """Plan de corte de la orden: tableros físicos para la vista de taller."""
+
+    order_id: int
+    order_code: Optional[str] = None
+    status: OrderStatus
+    progress: CuttingProgress
+    boards: List[OrderBoardResponse] = Field(default_factory=list)
+
+
+class PieceCutUpdate(CamelModel):
+    """Marca (o desmarca, con ``cut=false``) una pieza colocada como cortada."""
+
+    cut: bool = Field(default=True, description="True = cut, False = undo")
+
+
+class PieceCutResponse(CamelModel):
+    """Resultado de marcar una pieza: estado de la pieza + avance actualizado."""
+
+    piece: PlacedPieceResponse
+    progress: CuttingProgress = Field(..., description="Order-level progress")
+    board_progress: CuttingProgress = Field(..., description="Affected board progress")
 
 
 class ReviewLinkResponse(CamelModel):

--- a/src/modules/orders/service.py
+++ b/src/modules/orders/service.py
@@ -6,19 +6,31 @@ from sqlalchemy.orm import Session
 
 from src.modules.clients.model import ClientModel
 from src.modules.clients.service import require_phone
+from src.modules.optimizations.patterns import base_label
 from src.modules.optimizations.schemas import OptimizeRequest
 from src.modules.optimizations.service import OptimizationService
 from src.modules.orders.model import (
     PENDING_STATUSES,
     TERMINAL_STATUSES,
     TRANSITIONS,
+    OrderBoardModel,
     OrderLineModel,
     OrderModel,
     OrderPieceModel,
+    OrderPlacedPieceModel,
     OrderStatus,
     OrderStatusHistoryModel,
 )
-from src.modules.orders.schemas import OrderCreate, OrderExportLine, OrderExportResponse
+from src.modules.orders.schemas import (
+    CuttingPlanResponse,
+    CuttingProgress,
+    OrderBoardResponse,
+    OrderCreate,
+    OrderExportLine,
+    OrderExportResponse,
+    PieceCutResponse,
+    PlacedPieceResponse,
+)
 from src.shared.config import config
 from src.shared.database import get_db
 from src.shared.exceptions import BusinessRuleError, ConflictError, EntityNotFoundError
@@ -157,6 +169,9 @@ class OrderService:
             )
             for r in payload["requirements"]
         ]
+        # Plan de corte = tableros físicos con cada pieza colocada (la unidad que
+        # el operario marca en el taller; estado mutable fuera del snapshot).
+        _attach_cutting_plan(order, payload)
         order.history = [
             OrderStatusHistoryModel(
                 from_status=None,
@@ -180,12 +195,104 @@ class OrderService:
         actor: str = "system",
         note: Optional[str] = None,
     ) -> OrderModel:
-        """Valida y aplica una transición de estado, registrando el historial."""
+        """Valida y aplica una transición de estado, registrando el historial.
+
+        Gate de producción: pasar a ``cut`` exige que todas las piezas del plan
+        de corte estén marcadas como cortadas.
+        """
         order = self.get_or_404(order_id)
+        if (
+            to_status == OrderStatus.cut
+            and order.status == OrderStatus.in_production.value
+        ):
+            self._ensure_cutting_plan(order)
+            pending = (
+                self.db.query(OrderPlacedPieceModel)
+                .filter(
+                    OrderPlacedPieceModel.order_id == order.id,
+                    OrderPlacedPieceModel.cut_at.is_(None),
+                )
+                .count()
+            )
+            if pending:
+                raise BusinessRuleError(f"Faltan {pending} pieza(s) por cortar")
         self._apply_transition(order, to_status, actor=actor, note=note)
         self.db.commit()
         self.db.refresh(order)
         return order
+
+    def get_cutting_plan(self, order_id: int) -> CuttingPlanResponse:
+        """Plan de corte para la vista de taller: tableros físicos + avance."""
+        order = self.get_or_404(order_id)
+        self._ensure_cutting_plan(order)
+        boards = [
+            OrderBoardResponse(
+                id=board.id,
+                sheet_number=board.sheet_number,
+                material_key=board.material_key,
+                product_code=board.product_code,
+                product_name=board.product_name,
+                width=board.width,
+                height=board.height,
+                thickness=board.thickness,
+                progress=_progress(board.pieces),
+                pieces=[_piece_response(p) for p in board.pieces],
+                remainders=board.remainders or [],
+                cuts=board.cuts or [],
+            )
+            for board in order.boards
+        ]
+        all_pieces = [p for board in order.boards for p in board.pieces]
+        return CuttingPlanResponse(
+            order_id=order.id,
+            order_code=order.code,
+            status=OrderStatus(order.status),
+            progress=_progress(all_pieces),
+            boards=boards,
+        )
+
+    def mark_piece_cut(
+        self, order_id: int, placed_piece_id: int, cut: bool
+    ) -> PieceCutResponse:
+        """Marca (o desmarca) una pieza colocada como cortada, idempotente.
+
+        Solo con la orden ``in_production``: antes no hay nada que cortar y
+        después el corte ya quedó cerrado por la transición.
+        """
+        order = self.get_or_404(order_id)
+        self._ensure_cutting_plan(order)
+        if order.status != OrderStatus.in_production.value:
+            raise BusinessRuleError(
+                "Solo se pueden marcar piezas con la orden en producción"
+            )
+        piece = self.db.get(OrderPlacedPieceModel, placed_piece_id)
+        if piece is None or piece.order_id != order.id:
+            raise EntityNotFoundError("OrderPlacedPiece", placed_piece_id)
+        if cut and piece.cut_at is None:
+            piece.cut_at = datetime.utcnow()
+        elif not cut:
+            piece.cut_at = None
+        self.db.commit()
+        self.db.refresh(piece)
+        all_pieces = [p for board in order.boards for p in board.pieces]
+        return PieceCutResponse(
+            piece=_piece_response(piece),
+            progress=_progress(all_pieces),
+            board_progress=_progress(piece.board.pieces),
+        )
+
+    def _ensure_cutting_plan(self, order: OrderModel) -> None:
+        """Materializa el plan de corte desde el snapshot si aún no existe.
+
+        Cubre las órdenes creadas antes de esta funcionalidad sin backfill: la
+        primera lectura/marcado reconstruye las filas desde ``layouts``.
+        """
+        if order.boards:
+            return
+        _attach_cutting_plan(order, order.optimization_snapshot or {})
+        if order.boards:
+            self.db.commit()
+            self.db.refresh(order)
 
     def _apply_transition(
         self,
@@ -344,6 +451,77 @@ class OrderService:
                 f"El cliente ya tiene {active} pedido(s) pendiente(s); "
                 "resuélvalos o espere a que expiren antes de crear otro."
             )
+
+
+def _attach_cutting_plan(order: OrderModel, payload: dict) -> None:
+    """Expande ``payload["layouts"]`` en tableros físicos + piezas colocadas.
+
+    Cada layout del snapshot es una hoja real; ``sheet_number`` se reasigna como
+    secuencia global (el del snapshot se reinicia por material). Las piezas
+    quedan ligadas también a la orden para contar avance sin joins.
+    """
+    materials_by_key = {m["material_key"]: m for m in payload.get("materials", [])}
+    for seq, layout in enumerate(payload.get("layouts", []), start=1):
+        material = layout.get("material", {})
+        resolved = materials_by_key.get(material.get("material_key"), {})
+        board = OrderBoardModel(
+            sheet_number=seq,
+            material_key=material.get("material_key", ""),
+            product_id=resolved.get("product_id"),
+            product_code=resolved.get("product_code"),
+            product_name=resolved.get("product_name"),
+            width=material.get("width", 0.0),
+            height=material.get("height", 0.0),
+            thickness=material.get("thickness", 0.0),
+            remainders=layout.get("remainders") or None,
+            # Snapshots previos a la serialización de ``cuts`` no traen la clave.
+            cuts=layout.get("cuts") or None,
+        )
+        for placed in layout.get("placed_pieces", []):
+            piece_id = str(placed.get("piece_id", ""))
+            board.pieces.append(
+                OrderPlacedPieceModel(
+                    order=order,
+                    piece_id=piece_id,
+                    label=base_label(piece_id),
+                    x=placed["x"],
+                    y=placed["y"],
+                    width=placed["width"],
+                    height=placed["height"],
+                    original_width=placed.get("original_width", placed["width"]),
+                    original_height=placed.get("original_height", placed["height"]),
+                    rotated=bool(placed.get("rotated", False)),
+                    edges=placed.get("edges"),
+                )
+            )
+        order.boards.append(board)
+
+
+def _progress(pieces: List[OrderPlacedPieceModel]) -> CuttingProgress:
+    """Avance de corte sobre un conjunto de piezas colocadas."""
+    return CuttingProgress(
+        cut_pieces=sum(1 for p in pieces if p.cut_at is not None),
+        total_pieces=len(pieces),
+    )
+
+
+def _piece_response(piece: OrderPlacedPieceModel) -> PlacedPieceResponse:
+    """Proyección API de una pieza colocada (``cut`` derivado de ``cut_at``)."""
+    return PlacedPieceResponse(
+        id=piece.id,
+        piece_id=piece.piece_id,
+        label=piece.label,
+        x=piece.x,
+        y=piece.y,
+        width=piece.width,
+        height=piece.height,
+        original_width=piece.original_width,
+        original_height=piece.original_height,
+        rotated=piece.rotated,
+        edges=piece.edges,
+        cut=piece.cut_at is not None,
+        cut_at=piece.cut_at,
+    )
 
 
 def _line_description(line: OrderLineModel) -> str:

--- a/tests/test_cutting.py
+++ b/tests/test_cutting.py
@@ -82,6 +82,11 @@ def test_guillotine_places_pieces_and_reports_efficiency():
     assert as_dict["statistics"]["pieces_count"] == 1
     assert as_dict["material"]["material_key"] == "m1"
     assert as_dict["material"]["sheet_number"] == 1
+    # Los cortes de sierra se serializan (los consume la vista de taller).
+    assert as_dict["cuts"] == [
+        {"x": c.x, "y": c.y, "length": c.length, "is_horizontal": c.is_horizontal}
+        for c in layout.cuts
+    ]
 
 
 def test_guillotine_empty_pieces_returns_empty():

--- a/tests/test_optimizations.py
+++ b/tests/test_optimizations.py
@@ -69,6 +69,9 @@ def test_optimize_returns_layouts(client):
     assert layout["material"]["sheetNumber"] == 1
     assert "efficiency" in layout["statistics"]
     assert layout["placedPieces"][0]["originalWidth"] == 600
+    # Cortes de guillotina expuestos para dibujar las líneas de sierra.
+    assert layout["cuts"], "colocar piezas genera recorridos de sierra"
+    assert set(layout["cuts"][0]) == {"x", "y", "length", "isHorizontal"}
 
 
 def test_optimize_reports_cut_linear_meters(client):

--- a/tests/test_order_cutting_plan.py
+++ b/tests/test_order_cutting_plan.py
@@ -1,0 +1,218 @@
+"""Tests del plan de corte por orden: materialización, marcado táctil y gate."""
+
+from src.modules.orders.model import OrderBoardModel, OrderPlacedPieceModel
+
+
+def _create_client(client, identifier="0991112233", phone="0991112233"):
+    return client.post(
+        "/api/v1/clients/",
+        json={
+            "identifier": identifier,
+            "firstName": "Ada",
+            "lastName": "Lovelace",
+            "phone": phone,
+        },
+    ).json()["data"]
+
+
+def _create_board(client, code="MEL18"):
+    return client.post(
+        "/api/v1/products/",
+        json={
+            "type": "board",
+            "code": code,
+            "name": f"Melamina {code}",
+            "price": 45.5,
+            "attributes": {"height": 2440, "width": 1220, "thickness": 18},
+        },
+    ).json()["data"]
+
+
+def _order_payload(client_id, product_id, height=400, width=600, quantity=3):
+    return {
+        "clientId": client_id,
+        "materials": [{"key": "b1", "source": "catalog", "productId": product_id}],
+        "requirements": [
+            {
+                "priority": 0,
+                "height": height,
+                "width": width,
+                "quantity": quantity,
+                "materialKey": "b1",
+                "label": "Puerta",
+                "canRotate": True,
+            }
+        ],
+    }
+
+
+def _create_order(client, quantity=3, width=600):
+    c = _create_client(client)
+    b = _create_board(client)
+    payload = _order_payload(c["id"], b["id"], quantity=quantity, width=width)
+    return client.post("/api/v1/orders/", json=payload).json()["data"]
+
+
+def _to_production(client, order_id):
+    """Avanza la orden recién creada (confirmed) hasta in_production."""
+    for status in ("approved", "in_production"):
+        resp = client.patch(
+            f"/api/v1/orders/{order_id}/status", json={"status": status}
+        )
+        assert resp.status_code == 200
+    return resp.json()["data"]
+
+
+def _get_plan(client, order_id):
+    resp = client.get(f"/api/v1/orders/{order_id}/cutting-plan")
+    assert resp.status_code == 200
+    return resp.json()["data"]
+
+
+def test_create_order_materializes_cutting_plan(client):
+    """Crear la orden expande el snapshot en tableros físicos y piezas colocadas."""
+    order = _create_order(client, quantity=3)
+    plan = _get_plan(client, order["id"])
+
+    assert plan["orderId"] == order["id"]
+    assert plan["orderCode"] == order["code"]
+    assert plan["status"] == "confirmed"
+    assert plan["progress"] == {"cutPieces": 0, "totalPieces": 3}
+
+    # 3 piezas de 400×600 caben en un solo tablero de 2440×1220.
+    assert len(plan["boards"]) == 1
+    board = plan["boards"][0]
+    assert board["sheetNumber"] == 1
+    assert board["materialKey"] == "b1"
+    assert board["productCode"] == "MEL18"
+    assert board["width"] == 1220 and board["height"] == 2440
+    assert board["progress"] == {"cutPieces": 0, "totalPieces": 3}
+
+    # quantity=3 → 3 instancias individuales con identidad propia (label#N).
+    assert len(board["pieces"]) == 3
+    assert {p["pieceId"] for p in board["pieces"]} == {
+        "Puerta#1",
+        "Puerta#2",
+        "Puerta#3",
+    }
+    for piece in board["pieces"]:
+        assert piece["label"] == "Puerta"
+        assert piece["cut"] is False and piece["cutAt"] is None
+        # Geometría lista para dibujar + dims nominales para agrupar.
+        assert {piece["originalWidth"], piece["originalHeight"]} == {400, 600}
+
+    # Sobrantes y cortes de guillotina del snapshot, para dibujar el tablero
+    # completo en el taller (zonas libres + líneas de sierra).
+    assert board["remainders"], "3 piezas chicas en 2440×1220 dejan sobrantes"
+    for rem in board["remainders"]:
+        assert set(rem) == {"x", "y", "width", "height"}
+    assert board["cuts"], "colocar piezas genera recorridos de sierra"
+    for cut in board["cuts"]:
+        assert set(cut) == {"x", "y", "length", "isHorizontal"}
+
+
+def test_cutting_plan_unknown_order_returns_404(client):
+    resp = client.get("/api/v1/orders/99999/cutting-plan")
+    assert resp.status_code == 404
+
+
+def test_mark_piece_requires_in_production(client):
+    """Antes de producción no hay nada que cortar: marcar da 422."""
+    order = _create_order(client)
+    piece_id = _get_plan(client, order["id"])["boards"][0]["pieces"][0]["id"]
+
+    resp = client.patch(
+        f"/api/v1/orders/{order['id']}/cutting-plan/pieces/{piece_id}",
+        json={"cut": True},
+    )
+    assert resp.status_code == 422
+    assert "producción" in resp.json()["errors"][0]["message"]
+
+
+def test_mark_and_unmark_piece_updates_progress(client):
+    order = _create_order(client, quantity=3)
+    _to_production(client, order["id"])
+    piece_id = _get_plan(client, order["id"])["boards"][0]["pieces"][0]["id"]
+    url = f"/api/v1/orders/{order['id']}/cutting-plan/pieces/{piece_id}"
+
+    marked = client.patch(url, json={"cut": True}).json()["data"]
+    assert marked["piece"]["cut"] is True
+    assert marked["piece"]["cutAt"] is not None
+    assert marked["progress"] == {"cutPieces": 1, "totalPieces": 3}
+    assert marked["boardProgress"] == {"cutPieces": 1, "totalPieces": 3}
+
+    # Idempotente: re-marcar no cambia el momento del corte.
+    again = client.patch(url, json={"cut": True}).json()["data"]
+    assert again["piece"]["cutAt"] == marked["piece"]["cutAt"]
+    assert again["progress"] == {"cutPieces": 1, "totalPieces": 3}
+
+    # Deshacer: la pieza vuelve a pendiente.
+    undone = client.patch(url, json={"cut": False}).json()["data"]
+    assert undone["piece"]["cut"] is False and undone["piece"]["cutAt"] is None
+    assert undone["progress"] == {"cutPieces": 0, "totalPieces": 3}
+
+
+def test_mark_piece_of_another_order_returns_404(client):
+    """Una pieza ajena a la orden no existe para ella (404, sin filtrar datos)."""
+    c = _create_client(client)
+    b = _create_board(client)
+    first = client.post(
+        "/api/v1/orders/", json=_order_payload(c["id"], b["id"], width=600)
+    ).json()["data"]
+    second = client.post(
+        "/api/v1/orders/", json=_order_payload(c["id"], b["id"], width=500)
+    ).json()["data"]
+    _to_production(client, first["id"])
+    foreign_piece = _get_plan(client, second["id"])["boards"][0]["pieces"][0]["id"]
+
+    resp = client.patch(
+        f"/api/v1/orders/{first['id']}/cutting-plan/pieces/{foreign_piece}",
+        json={"cut": True},
+    )
+    assert resp.status_code == 404
+
+
+def test_transition_to_cut_blocked_until_all_pieces_marked(client):
+    """Gate de producción: in_production → cut exige el plan de corte completo."""
+    order = _create_order(client, quantity=3)
+    _to_production(client, order["id"])
+    pieces = _get_plan(client, order["id"])["boards"][0]["pieces"]
+
+    # Con 1 de 3 cortadas, la transición se rechaza informando lo pendiente.
+    client.patch(
+        f"/api/v1/orders/{order['id']}/cutting-plan/pieces/{pieces[0]['id']}",
+        json={"cut": True},
+    )
+    blocked = client.patch(
+        f"/api/v1/orders/{order['id']}/status", json={"status": "cut"}
+    )
+    assert blocked.status_code == 422
+    assert "Faltan 2 pieza(s) por cortar" in blocked.json()["errors"][0]["message"]
+
+    # Con todo cortado, la transición pasa.
+    for piece in pieces[1:]:
+        client.patch(
+            f"/api/v1/orders/{order['id']}/cutting-plan/pieces/{piece['id']}",
+            json={"cut": True},
+        )
+    done = client.patch(f"/api/v1/orders/{order['id']}/status", json={"status": "cut"})
+    assert done.status_code == 200
+    assert done.json()["data"]["status"] == "cut"
+
+
+def test_lazy_materialization_for_legacy_orders(client, db_session):
+    """Órdenes previas a la feature reconstruyen el plan desde el snapshot."""
+    order = _create_order(client, quantity=2)
+
+    # Simula una orden creada antes de la feature: sin filas de plan de corte.
+    db_session.query(OrderPlacedPieceModel).delete()
+    db_session.query(OrderBoardModel).delete()
+    db_session.commit()
+
+    plan = _get_plan(client, order["id"])
+    assert plan["progress"]["totalPieces"] == 2
+    assert len(plan["boards"]) == 1
+    assert len(plan["boards"][0]["pieces"]) == 2
+    # El snapshot conserva sobrantes y cortes: la reconstrucción los trae.
+    assert plan["boards"][0]["remainders"]
+    assert plan["boards"][0]["cuts"]


### PR DESCRIPTION
    Materialize each order's snapshot layouts into physical boards
    (order_boards) and placed pieces (order_placed_pieces), with lazy
    materialization for pre-feature orders. Add GET /orders/{id}/cutting-plan
    and PATCH .../pieces/{piece_id} to track cut progress, and gate the
    in_production -> cut transition until every piece is cut. Serialize
    guillotine cuts in layouts so the view can draw the saw lines.