### PR TITLE
feat: settings module — editable cutting params and company letterhead via DB

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -15,6 +15,7 @@ from src.modules.optimization_drafts.model import (  # noqa: F401
 from src.modules.optimizations.model import OptimizationModel  # noqa: F401
 from src.modules.orders import model as orders_model  # noqa: F401
 from src.modules.products.model import ProductModel  # noqa: F401
+from src.modules.settings.model import SettingsModel  # noqa: F401
 from src.shared.config import config as app_config
 from src.shared.database import Base
 

--- a/alembic/versions/d3e4f5a6b7c8_add_settings_singleton_table.py
+++ b/alembic/versions/d3e4f5a6b7c8_add_settings_singleton_table.py
@@ -1,0 +1,46 @@
+"""add settings singleton table
+
+Revision ID: d3e4f5a6b7c8
+Revises: c2d3e4f5a6b7
+Create Date: 2026-06-15 19:00:00.000000
+
+Persiste la configuración única de la aplicación (parámetros de corte + datos de
+empresa) que antes vivía solo en variables de entorno. Es una tabla singleton: la
+fila ``id=1`` se siembra perezosamente desde ``config`` en la primera lectura, así
+que la migración crea únicamente la tabla.
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d3e4f5a6b7c8"
+down_revision: Union[str, None] = "c2d3e4f5a6b7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "settings",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("kerf", sa.Float(), nullable=False),
+        sa.Column("top_trim", sa.Float(), nullable=False),
+        sa.Column("bottom_trim", sa.Float(), nullable=False),
+        sa.Column("left_trim", sa.Float(), nullable=False),
+        sa.Column("right_trim", sa.Float(), nullable=False),
+        sa.Column("edge_banding_waste_factor", sa.Float(), nullable=False),
+        sa.Column("company_name", sa.String(length=128), nullable=False),
+        sa.Column("company_tagline", sa.String(length=256), nullable=False),
+        sa.Column("company_email", sa.String(length=128), nullable=False),
+        sa.Column("company_phone", sa.String(length=128), nullable=False),
+        sa.Column("company_branches", sa.JSON(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("settings")

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ from src.modules.orders.router import router as orders_router
 from src.modules.preorders.public_router import router as preorders_public_router
 from src.modules.preorders.router import router as preorders_router
 from src.modules.products.router import router as products_router
+from src.modules.settings.router import router as settings_router
 from src.modules.system.router import router as system_router
 from src.shared.config import config
 from src.shared.errors import register_exception_handlers
@@ -69,6 +70,7 @@ app.include_router(orders_router, prefix="/api/v1")
 app.include_router(preorders_router, prefix="/api/v1")
 app.include_router(preorders_public_router, prefix="/api/v1")
 app.include_router(analytics_router, prefix="/api/v1")
+app.include_router(settings_router, prefix="/api/v1")
 
 
 @app.get("/")

--- a/src/modules/optimizations/carrier.py
+++ b/src/modules/optimizations/carrier.py
@@ -14,6 +14,7 @@ class ProformaCarrier:
 
     reference: str
     client: object
+    company: dict = field(default_factory=dict)
     requirements: List[dict] = field(default_factory=list)
     materials_summary: List[dict] = field(default_factory=list)
     edge_bandings_summary: List[dict] = field(default_factory=list)
@@ -31,11 +32,18 @@ class ProformaCarrier:
         return round(self.total_boards_cost + self.total_edge_banding_cost, 2)
 
     @classmethod
-    def from_payload(cls, payload: dict, client, reference: str) -> "ProformaCarrier":
-        """Construye el portador desde un payload de optimización + el cliente."""
+    def from_payload(
+        cls, payload: dict, client, reference: str, company: dict | None = None
+    ) -> "ProformaCarrier":
+        """Construye el portador desde un payload de optimización + el cliente.
+
+        ``company`` es el membrete vigente (datos de la empresa) que se renderiza en
+        vivo; no forma parte del snapshot con precio.
+        """
         return cls(
             reference=reference,
             client=client,
+            company=company or {},
             requirements=payload.get("requirements") or [],
             materials_summary=payload.get("materials_summary") or [],
             edge_bandings_summary=payload.get("edge_bandings_summary") or [],
@@ -49,15 +57,18 @@ class ProformaCarrier:
         )
 
     @classmethod
-    def from_order(cls, order) -> "ProformaCarrier":
+    def from_order(cls, order, company: dict | None = None) -> "ProformaCarrier":
         """Construye el portador desde una orden (snapshot + precios congelados).
 
         El desglose (tableros vs tapacantos) se toma del snapshot inmutable; el
-        gran total congelado vive en ``order.total`` (= tableros + tapacantos).
+        gran total congelado vive en ``order.total`` (= tableros + tapacantos). El
+        membrete (``company``) se renderiza en vivo, no se congela en el snapshot.
         """
         snapshot = order.optimization_snapshot or {}
         reference = order.code or f"ORD-{order.id:06d}"
-        carrier = cls.from_payload(snapshot, order.client, reference=reference)
+        carrier = cls.from_payload(
+            snapshot, order.client, reference=reference, company=company
+        )
         # La orden congela el conteo de tableros al confirmar.
         carrier.total_boards_used = order.total_boards_used
         return carrier

--- a/src/modules/optimizations/proforma.py
+++ b/src/modules/optimizations/proforma.py
@@ -247,7 +247,7 @@ class ProformaService:
         logo.hAlign = "LEFT"
 
         header_table = Table(
-            [[logo, ProformaService._build_contact_block(styles)]],
+            [[logo, ProformaService._build_contact_block(carrier, styles)]],
             colWidths=[CONTENT_WIDTH * 0.38, CONTENT_WIDTH * 0.62],
         )
         header_table.setStyle(
@@ -317,8 +317,12 @@ class ProformaService:
         return [header_table, rule, title_bar]
 
     @staticmethod
-    def _build_contact_block(styles) -> Table:
-        """Bloque de contacto con iconos: WhatsApp, correo y sucursales."""
+    def _build_contact_block(carrier: ProformaCarrier, styles) -> Table:
+        """Bloque de contacto con iconos: WhatsApp, correo y sucursales.
+
+        Lee los datos de la empresa (membrete) en vivo desde ``carrier.company``.
+        """
+        company = carrier.company or {}
         text_style = ParagraphStyle(
             "Contact",
             parent=styles["Normal"],
@@ -332,14 +336,14 @@ class ProformaService:
         rows = [
             [
                 _scaled_image(ICON_WHATSAPP, icon_w),
-                Paragraph(config.COMPANY_PHONE, text_style),
+                Paragraph(company.get("phone", ""), text_style),
             ],
             [
                 _scaled_image(ICON_EMAIL, icon_w),
-                Paragraph(config.COMPANY_EMAIL, text_style),
+                Paragraph(company.get("email", ""), text_style),
             ],
         ]
-        for branch in config.COMPANY_BRANCHES:
+        for branch in company.get("branches") or []:
             rows.append(
                 [
                     _scaled_image(ICON_ADDRESS, icon_w),

--- a/src/modules/optimizations/service.py
+++ b/src/modules/optimizations/service.py
@@ -30,8 +30,8 @@ from src.modules.optimizations.schemas import (
 )
 from src.modules.products.model import ProductModel, ProductType
 from src.modules.products.service import ProductService
+from src.modules.settings.service import SettingsService
 from src.shared.cache import cache
-from src.shared.config import config
 from src.shared.database import get_db
 from src.shared.exceptions import (
     BusinessRuleError,
@@ -60,6 +60,7 @@ class OptimizationService:
         self.db = db
         self.product_service = ProductService(db)
         self.material_resolver = MaterialResolver(db)
+        self.settings_service = SettingsService(db)
 
     def optimize_response(self, request: OptimizeRequest) -> OptimizeResponse:
         """Calcula (cache-first) y arma la respuesta del endpoint ``POST /optimize``.
@@ -109,7 +110,10 @@ class OptimizationService:
             raise EntityNotFoundError("Client", client_id)
         require_phone(client)
         return ProformaCarrier.from_payload(
-            payload, client, reference=f"OPT-{optimization_hash[:8]}"
+            payload,
+            client,
+            reference=f"OPT-{optimization_hash[:8]}",
+            company=self.settings_service.get_company(),
         )
 
     def compute(self, request: OptimizeRequest) -> Tuple[dict, str]:
@@ -127,13 +131,15 @@ class OptimizationService:
             request.requirements
         )
 
+        settings = self.settings_service.get_or_init()
         cutting_params = CuttingParameters(
-            kerf=config.KERF,
-            top_trim=config.TOP_TRIM,
-            bottom_trim=config.BOTTOM_TRIM,
-            left_trim=config.LEFT_TRIM,
-            right_trim=config.RIGHT_TRIM,
+            kerf=settings.kerf,
+            top_trim=settings.top_trim,
+            bottom_trim=settings.bottom_trim,
+            left_trim=settings.left_trim,
+            right_trim=settings.right_trim,
         )
+        waste_factor = settings.edge_banding_waste_factor
 
         # Resuelve a dimensiones+costo solo los materiales realmente referenciados,
         # agnóstico al origen (catálogo/retazo/manual). Aquí vive el único punto que
@@ -147,7 +153,7 @@ class OptimizationService:
         eb_products = self._resolve_edge_banding_products(request.requirements)
 
         optimization_hash = self._compute_hash(
-            request, cutting_params, resolved, eb_products
+            request, cutting_params, resolved, eb_products, waste_factor
         )
 
         cached = cache.get_json(optimization_hash)
@@ -166,7 +172,9 @@ class OptimizationService:
             for key, reqs in requirements_by_key.items()
         ]
 
-        payload = self._build_result_payload(request, results, resolved, eb_products)
+        payload = self._build_result_payload(
+            request, results, resolved, eb_products, waste_factor
+        )
         cache.set_json(optimization_hash, payload)
         return payload, optimization_hash
 
@@ -201,6 +209,7 @@ class OptimizationService:
         cutting_params: CuttingParameters,
         resolved: Dict[str, ResolvedMaterial],
         eb_products: Dict[int, ProductModel],
+        waste_factor: float,
     ) -> str:
         """Hash sha256 determinista de las entradas que afectan el resultado.
 
@@ -231,7 +240,7 @@ class OptimizationService:
                 "bottom_trim": cutting_params.bottom_trim,
                 "left_trim": cutting_params.left_trim,
                 "right_trim": cutting_params.right_trim,
-                "edge_banding_waste_factor": config.EDGE_BANDING_WASTE_FACTOR,
+                "edge_banding_waste_factor": waste_factor,
             },
             "edge_prices": edge_prices,
         }
@@ -365,6 +374,7 @@ class OptimizationService:
         self,
         requirements: List[Requirement],
         eb_products: Dict[int, ProductModel],
+        waste_factor: float,
     ) -> Tuple[List[dict], float]:
         """Agrega el metraje de tapacanto por tipo y devuelve ``(summary, total)``.
 
@@ -373,7 +383,7 @@ class OptimizationService:
         independiente de la rotación. Se aplica la merma configurada y se redondea
         al metro entero que se cobra.
         """
-        waste = config.EDGE_BANDING_WASTE_FACTOR
+        waste = waste_factor
         net_mm: Dict[int, float] = defaultdict(float)
         for req in requirements:
             spec = req.edge_banding
@@ -492,6 +502,7 @@ class OptimizationService:
         results: List[Tuple[List[Requirement], List[CuttingLayout]]],
         resolved: Dict[str, ResolvedMaterial],
         eb_products: Dict[int, ProductModel],
+        waste_factor: float,
     ) -> dict:
         """Arma el payload cacheable/serializable del resultado de optimización.
 
@@ -531,7 +542,9 @@ class OptimizationService:
                 layout_dicts.append(layout_dict)
 
         edge_bandings_summary, total_edge_banding_cost = (
-            self._build_edge_bandings_summary(request.requirements, eb_products)
+            self._build_edge_bandings_summary(
+                request.requirements, eb_products, waste_factor
+            )
         )
         return {
             "total_boards_used": total_boards_used,

--- a/src/modules/orders/router.py
+++ b/src/modules/orders/router.py
@@ -16,6 +16,7 @@ from src.modules.orders.schemas import (
     PieceCutUpdate,
 )
 from src.modules.orders.service import OrderService, order_service
+from src.modules.settings.service import SettingsService, settings_service
 from src.shared.pagination import PageParams
 from src.shared.responses import (
     ERROR_RESPONSES,
@@ -119,10 +120,11 @@ def get_order_proforma(
     order_id: int,
     format: str = _FORMAT_QUERY,
     svc: OrderService = Depends(order_service),
+    settings_svc: SettingsService = Depends(settings_service),
 ):
     """Proforma comercial (con precios congelados) renderizada desde el snapshot."""
     order = svc.get_or_404(order_id)
-    carrier = ProformaCarrier.from_order(order)
+    carrier = ProformaCarrier.from_order(order, company=settings_svc.get_company())
     pdf_buffer = ProformaService.generate_proforma_pdf(carrier)
     return pdf_response(pdf_buffer, f"proforma_{order.code or order.id}.pdf", format)
 
@@ -132,9 +134,10 @@ def get_order_production_sheet(
     order_id: int,
     format: str = _FORMAT_QUERY,
     svc: OrderService = Depends(order_service),
+    settings_svc: SettingsService = Depends(settings_service),
 ):
     """Hoja de producción (lista de corte y disposición, SIN precios) para el taller."""
     order = svc.get_or_404(order_id)
-    carrier = ProformaCarrier.from_order(order)
+    carrier = ProformaCarrier.from_order(order, company=settings_svc.get_company())
     pdf_buffer = ProformaService.generate_production_sheet_pdf(carrier)
     return pdf_response(pdf_buffer, f"produccion_{order.code or order.id}.pdf", format)

--- a/src/modules/preorders/service.py
+++ b/src/modules/preorders/service.py
@@ -149,6 +149,7 @@ class PreOrderService:
             payload,
             preorder.client,
             reference=preorder.code or f"PRE-{preorder.id:06d}",
+            company=self.optimization_service.settings_service.get_company(),
         )
 
     def _ensure_open(self, preorder: PreOrderModel) -> None:

--- a/src/modules/settings/model.py
+++ b/src/modules/settings/model.py
@@ -1,0 +1,43 @@
+from datetime import datetime
+
+from sqlalchemy import JSON, DateTime, Float, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.shared.database import Base
+
+# La configuración es única: una sola fila con este id fijo (patrón singleton).
+SETTINGS_ID = 1
+
+
+class SettingsModel(Base):
+    """Configuración única de la aplicación (fila singleton, ``id=1``).
+
+    Persiste lo que antes vivía solo en variables de entorno: los parámetros de
+    corte y los datos de la empresa (membrete de la proforma). La fila se siembra
+    perezosamente desde ``config`` en la primera lectura, por lo que el despliegue
+    es retrocompatible. La fuente de verdad en runtime es esta tabla; ``config``
+    solo aporta los valores iniciales.
+    """
+
+    __tablename__ = "settings"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+
+    # Parámetros de corte (mm)
+    kerf: Mapped[float] = mapped_column(Float)
+    top_trim: Mapped[float] = mapped_column(Float)
+    bottom_trim: Mapped[float] = mapped_column(Float)
+    left_trim: Mapped[float] = mapped_column(Float)
+    right_trim: Mapped[float] = mapped_column(Float)
+    edge_banding_waste_factor: Mapped[float] = mapped_column(Float)
+
+    # Datos de la empresa (membrete de la proforma)
+    company_name: Mapped[str] = mapped_column(String(128))
+    company_tagline: Mapped[str] = mapped_column(String(256))
+    company_email: Mapped[str] = mapped_column(String(128))
+    company_phone: Mapped[str] = mapped_column(String(128))
+    company_branches: Mapped[list] = mapped_column(JSON, default=list)
+
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )

--- a/src/modules/settings/router.py
+++ b/src/modules/settings/router.py
@@ -1,0 +1,41 @@
+from fastapi import APIRouter, Depends
+
+from src.modules.settings.schemas import (
+    CompanySettingsResponse,
+    CompanySettingsUpdate,
+    CuttingSettingsResponse,
+    CuttingSettingsUpdate,
+)
+from src.modules.settings.service import SettingsService, settings_service
+from src.shared.responses import ERROR_RESPONSES, DataResponse, ok
+
+router = APIRouter(prefix="/settings", tags=["settings"], responses=ERROR_RESPONSES)
+
+
+@router.get("/cutting", response_model=DataResponse[CuttingSettingsResponse])
+def get_cutting_settings(svc: SettingsService = Depends(settings_service)):
+    """Devuelve los parámetros de corte vigentes (sembrados desde config si faltan)."""
+    return ok(svc.get_or_init())
+
+
+@router.patch("/cutting", response_model=DataResponse[CuttingSettingsResponse])
+def update_cutting_settings(
+    data: CuttingSettingsUpdate, svc: SettingsService = Depends(settings_service)
+):
+    """Actualiza (parcialmente) los parámetros de corte."""
+    return ok(svc.update_cutting(data))
+
+
+@router.get("/company", response_model=DataResponse[CompanySettingsResponse])
+def get_company_settings(svc: SettingsService = Depends(settings_service)):
+    """Devuelve los datos de la empresa (membrete de la proforma)."""
+    return ok(svc.get_company())
+
+
+@router.patch("/company", response_model=DataResponse[CompanySettingsResponse])
+def update_company_settings(
+    data: CompanySettingsUpdate, svc: SettingsService = Depends(settings_service)
+):
+    """Actualiza (parcialmente) los datos de la empresa."""
+    svc.update_company(data)
+    return ok(svc.get_company())

--- a/src/modules/settings/schemas.py
+++ b/src/modules/settings/schemas.py
@@ -1,0 +1,58 @@
+from typing import List, Optional
+
+from pydantic import Field
+
+from src.shared.schemas import CamelModel
+
+
+# --- Parámetros de corte ------------------------------------------------------
+class CuttingSettingsResponse(CamelModel):
+    """Parámetros de corte vigentes (mm) que alimentan al optimizador."""
+
+    kerf: float = Field(..., ge=0, description="Ancho de sierra (kerf) en mm")
+    top_trim: float = Field(..., ge=0, description="Recorte superior en mm")
+    bottom_trim: float = Field(..., ge=0, description="Recorte inferior en mm")
+    left_trim: float = Field(..., ge=0, description="Recorte izquierdo en mm")
+    right_trim: float = Field(..., ge=0, description="Recorte derecho en mm")
+    edge_banding_waste_factor: float = Field(
+        ..., ge=0, description="Merma de tapacanto sobre el metraje neto (0.10 = +10%)"
+    )
+
+
+class CuttingSettingsUpdate(CamelModel):
+    """Actualización parcial de los parámetros de corte."""
+
+    kerf: Optional[float] = Field(None, ge=0)
+    top_trim: Optional[float] = Field(None, ge=0)
+    bottom_trim: Optional[float] = Field(None, ge=0)
+    left_trim: Optional[float] = Field(None, ge=0)
+    right_trim: Optional[float] = Field(None, ge=0)
+    edge_banding_waste_factor: Optional[float] = Field(None, ge=0)
+
+
+# --- Datos de la empresa ------------------------------------------------------
+class Branch(CamelModel):
+    """Sucursal mostrada en el membrete de la proforma."""
+
+    name: str = Field(..., min_length=1, max_length=128)
+    address: str = Field(..., min_length=1, max_length=256)
+
+
+class CompanySettingsResponse(CamelModel):
+    """Datos de la empresa vigentes (membrete de la proforma)."""
+
+    name: str = Field(..., max_length=128)
+    tagline: str = Field(..., max_length=256)
+    email: str = Field(..., max_length=128)
+    phone: str = Field(..., max_length=128)
+    branches: List[Branch] = Field(default_factory=list)
+
+
+class CompanySettingsUpdate(CamelModel):
+    """Actualización parcial de los datos de la empresa."""
+
+    name: Optional[str] = Field(None, max_length=128)
+    tagline: Optional[str] = Field(None, max_length=256)
+    email: Optional[str] = Field(None, max_length=128)
+    phone: Optional[str] = Field(None, max_length=128)
+    branches: Optional[List[Branch]] = None

--- a/src/modules/settings/service.py
+++ b/src/modules/settings/service.py
@@ -1,0 +1,103 @@
+from fastapi import Depends
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from src.modules.settings.model import SETTINGS_ID, SettingsModel
+from src.modules.settings.schemas import CompanySettingsUpdate, CuttingSettingsUpdate
+from src.shared.config import config
+from src.shared.database import get_db
+
+# Los datos de empresa se exponen en la API como ``name/tagline/...`` pero se
+# guardan con prefijo ``company_`` en la fila singleton (que también lleva los
+# parámetros de corte). Este mapa traduce el contrato del API a las columnas.
+_COMPANY_FIELD_MAP = {
+    "name": "company_name",
+    "tagline": "company_tagline",
+    "email": "company_email",
+    "phone": "company_phone",
+    "branches": "company_branches",
+}
+
+
+class SettingsService:
+    """Acceso a la configuración única (fila singleton) de la aplicación.
+
+    No es un CRUD: la fila se crea de forma perezosa sembrada desde ``config`` y
+    solo se lee o se actualiza parcialmente. Es la fuente de verdad en runtime de
+    los parámetros de corte y los datos de la empresa.
+    """
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    def get_or_init(self) -> SettingsModel:
+        """Devuelve la fila singleton; la crea sembrada desde ``config`` si falta.
+
+        Idempotente y seguro ante carrera: si dos peticiones casi simultáneas la
+        crean a la vez, el unique de la PK hace fallar la segunda y se re-lee la
+        ya creada (mismo patrón que ``ClientService.resolve``).
+        """
+        settings = self.db.get(SettingsModel, SETTINGS_ID)
+        if settings is not None:
+            return settings
+
+        settings = SettingsModel(
+            id=SETTINGS_ID,
+            kerf=config.KERF,
+            top_trim=config.TOP_TRIM,
+            bottom_trim=config.BOTTOM_TRIM,
+            left_trim=config.LEFT_TRIM,
+            right_trim=config.RIGHT_TRIM,
+            edge_banding_waste_factor=config.EDGE_BANDING_WASTE_FACTOR,
+            company_name=config.COMPANY_NAME,
+            company_tagline=config.COMPANY_TAGLINE,
+            company_email=config.COMPANY_EMAIL,
+            company_phone=config.COMPANY_PHONE,
+            company_branches=config.COMPANY_BRANCHES,
+        )
+        try:
+            self.db.add(settings)
+            self.db.commit()
+            self.db.refresh(settings)
+            return settings
+        except IntegrityError:
+            self.db.rollback()
+            return self.db.get(SettingsModel, SETTINGS_ID)
+
+    def update_cutting(self, data: CuttingSettingsUpdate) -> SettingsModel:
+        """Aplica un PATCH parcial a los parámetros de corte."""
+        settings = self.get_or_init()
+        for field, value in data.model_dump(exclude_unset=True).items():
+            setattr(settings, field, value)
+        self.db.commit()
+        self.db.refresh(settings)
+        return settings
+
+    def update_company(self, data: CompanySettingsUpdate) -> SettingsModel:
+        """Aplica un PATCH parcial a los datos de la empresa."""
+        settings = self.get_or_init()
+        for field, value in data.model_dump(exclude_unset=True).items():
+            setattr(settings, _COMPANY_FIELD_MAP[field], value)
+        self.db.commit()
+        self.db.refresh(settings)
+        return settings
+
+    def get_company(self) -> dict:
+        """Datos de empresa en el contrato del API (``name/tagline/...``).
+
+        Lo consume tanto la respuesta del endpoint como el ``ProformaCarrier`` para
+        renderizar el membrete en vivo.
+        """
+        settings = self.get_or_init()
+        return {
+            "name": settings.company_name,
+            "tagline": settings.company_tagline,
+            "email": settings.company_email,
+            "phone": settings.company_phone,
+            "branches": settings.company_branches or [],
+        }
+
+
+def settings_service(db: Session = Depends(get_db)) -> SettingsService:
+    """Provider de ``SettingsService`` para inyección en rutas."""
+    return SettingsService(db)

--- a/src/shared/config.py
+++ b/src/shared/config.py
@@ -61,7 +61,9 @@ class Config:
         env("SECRET_KEY") if ENVIRONMENT == "production" else env("SECRET_KEY", "")
     )
 
-    # Parámetros de corte (mm)
+    # Parámetros de corte (mm). Solo siembran la fila singleton de `settings` en su
+    # primera lectura; la fuente de verdad en runtime es la tabla `settings`
+    # (editable vía PATCH /settings/cutting).
     KERF = env.float("KERF", 5.0)
     TOP_TRIM = env.float("TOP_TRIM", 0.0)
     BOTTOM_TRIM = env.float("BOTTOM_TRIM", 0.0)
@@ -87,8 +89,9 @@ class Config:
     # usa HashRouter, por eso la base termina en "/#" (ruta = {base}/review/{token}).
     FRONTEND_BASE_URL = env("FRONTEND_BASE_URL", "http://localhost:3001/#")
 
-    # Datos de la empresa (membrete de la proforma). Valores dummy por defecto;
-    # los reales se definen en el .env.
+    # Datos de la empresa (membrete de la proforma). Valores dummy por defecto que
+    # solo siembran la fila singleton de `settings` en su primera lectura; la fuente
+    # de verdad en runtime es la tabla `settings` (editable vía PATCH /settings/company).
     COMPANY_NAME = env("COMPANY_NAME", "Mi Empresa")
     COMPANY_TAGLINE = env("COMPANY_TAGLINE", "eslogan de la empresa")
     COMPANY_EMAIL = env("COMPANY_EMAIL", "correo@empresa.com")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ import src.modules.optimizations.model  # noqa: F401,E402
 import src.modules.orders.model  # noqa: F401,E402
 import src.modules.preorders.model  # noqa: F401,E402
 import src.modules.products.model  # noqa: F401,E402
+import src.modules.settings.model  # noqa: F401,E402
 from main import app
 from src.shared.cache import cache
 from src.shared.database import Base, get_db

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,137 @@
+"""Tests del módulo settings: configuración única persistida y editable vía API."""
+
+from src.shared.config import config
+
+
+def _create_client(client):
+    return client.post(
+        "/api/v1/clients/",
+        json={"identifier": "0991112233", "firstName": "Ada", "phone": "0991112233"},
+    ).json()["data"]
+
+
+def _create_board(client, code="MEL18"):
+    return client.post(
+        "/api/v1/products/",
+        json={
+            "type": "board",
+            "code": code,
+            "name": f"Melamina {code}",
+            "price": 45.5,
+            "attributes": {"height": 2440, "width": 1220, "thickness": 18},
+        },
+    ).json()["data"]
+
+
+def _optimize_payload(client_id, product_id):
+    return {
+        "clientId": client_id,
+        "materials": [{"key": "b1", "source": "catalog", "productId": product_id}],
+        "requirements": [
+            {
+                "priority": 0,
+                "height": 400,
+                "width": 600,
+                "quantity": 2,
+                "materialKey": "b1",
+                "label": "Puerta",
+                "canRotate": True,
+            }
+        ],
+    }
+
+
+# --- Parámetros de corte ------------------------------------------------------
+def test_get_cutting_seeds_from_config(client):
+    """El primer GET siembra la fila singleton con los defaults de ``config``."""
+    resp = client.get("/api/v1/settings/cutting")
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["kerf"] == config.KERF
+    assert data["topTrim"] == config.TOP_TRIM
+    assert data["edgeBandingWasteFactor"] == config.EDGE_BANDING_WASTE_FACTOR
+
+
+def test_patch_cutting_persists_and_is_partial(client):
+    """El PATCH parcial persiste solo lo enviado y no pisa el resto."""
+    before = client.get("/api/v1/settings/cutting").json()["data"]
+
+    resp = client.patch("/api/v1/settings/cutting", json={"kerf": 4.0})
+    assert resp.status_code == 200
+    assert resp.json()["data"]["kerf"] == 4.0
+
+    after = client.get("/api/v1/settings/cutting").json()["data"]
+    assert after["kerf"] == 4.0
+    # Los demás parámetros quedan intactos.
+    assert after["topTrim"] == before["topTrim"]
+    assert after["rightTrim"] == before["rightTrim"]
+
+
+def test_patch_cutting_rejects_negative(client):
+    """Validación: los parámetros de corte no pueden ser negativos (422)."""
+    assert (
+        client.patch("/api/v1/settings/cutting", json={"kerf": -1}).status_code == 422
+    )
+
+
+def test_cutting_settings_drive_optimization(client):
+    """Cambiar el kerf en BD cambia el hash de la optimización (lo usa el optimizador)."""
+    created_client = _create_client(client)
+    board = _create_board(client)
+    payload = _optimize_payload(created_client["id"], board["id"])
+
+    first = client.post("/api/v1/optimize/", json=payload).json()["data"]
+
+    client.patch("/api/v1/settings/cutting", json={"kerf": 99.0})
+    second = client.post("/api/v1/optimize/", json=payload).json()["data"]
+
+    assert first["optimizationHash"] != second["optimizationHash"]
+
+
+# --- Datos de la empresa ------------------------------------------------------
+def test_get_company_seeds_from_config(client):
+    """El primer GET expone los datos de empresa sembrados desde ``config``."""
+    resp = client.get("/api/v1/settings/company")
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["name"] == config.COMPANY_NAME
+    assert data["phone"] == config.COMPANY_PHONE
+    assert isinstance(data["branches"], list)
+
+
+def test_patch_company_persists(client):
+    """El PATCH de empresa persiste teléfono y sucursales (lista de objetos)."""
+    resp = client.patch(
+        "/api/v1/settings/company",
+        json={
+            "phone": "0987654321",
+            "branches": [{"name": "Matriz", "address": "Av. Siempre Viva 123"}],
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["phone"] == "0987654321"
+    assert data["branches"] == [{"name": "Matriz", "address": "Av. Siempre Viva 123"}]
+
+    after = client.get("/api/v1/settings/company").json()["data"]
+    assert after["phone"] == "0987654321"
+    assert after["branches"][0]["name"] == "Matriz"
+
+
+def test_company_settings_render_in_proforma(client):
+    """La proforma usa los datos de empresa vigentes en BD (membrete en vivo)."""
+    created_client = _create_client(client)
+    board = _create_board(client)
+    optimization = client.post(
+        "/api/v1/optimize/", json=_optimize_payload(created_client["id"], board["id"])
+    ).json()["data"]
+
+    client.patch("/api/v1/settings/company", json={"phone": "0999999999"})
+
+    proforma = client.get(
+        f"/api/v1/optimize/{optimization['optimizationHash']}/proforma",
+        params={"clientId": created_client["id"]},
+    )
+    assert proforma.status_code == 200
+    assert proforma.headers["content-type"] == "application/pdf"
+    assert len(proforma.content) > 1000


### PR DESCRIPTION

  Introduce a singleton  table that replaces hard-coded env-var values
  for cutting parameters (kerf, trim sizes, edge-banding waste factor) and company
  letterhead data (name, tagline, email, phone, branches). The row is seeded lazily
  from config on first read, so existing deployments require no manual migration
  step. Add GET/PATCH /settings/cutting and /settings/company endpoints so operators
  can update these values at runtime without redeploying.

  - SettingsModel: singleton row (id=1), idempotent lazy init with race-safe IntegrityError retry
  - OptimizationService: reads cutting params and waste factor from DB instead of config
  - ProformaCarrier/ProformaService: company data passed in live (not frozen in snapshot)
  - Orders and preorders proforma endpoints: inject SettingsService to supply letterhead
  - Alembic migration: d3e4f5a6b7c8_add_settings_singleton_table