### PR TITLE
refactor: slim down orders now that quoting lives in preorders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,9 +6,10 @@ REDIS_URL=redis://redis:6379/0
 OPT_RESULT_TTL_SECONDS=259200
 CORS_ORIGINS=http://localhost:3000,http://localhost:3001
 
-# Órdenes (antiabuso)
-ORDER_VALIDITY_DAYS=15
-MAX_PENDING_ORDERS_PER_CLIENT=3
+# Pre-órdenes (cotización mutable): semilla de la sección "preorders" de settings.
+# En runtime la fuente de verdad es la tabla settings (PATCH /settings/preorders).
+PREORDER_VALIDITY_DAYS=15
+MAX_OPEN_PREORDERS_PER_CLIENT=5
 
 # Frontend de Maderable: base para el enlace de revisión del cliente.
 # El dashboard usa HashRouter: la base debe terminar en "/#" para que

--- a/alembic/versions/e4f5a6b7c8d9_drop_order_expires_at.py
+++ b/alembic/versions/e4f5a6b7c8d9_drop_order_expires_at.py
@@ -1,0 +1,34 @@
+"""drop orders.expires_at
+
+Revision ID: e4f5a6b7c8d9
+Revises: d3e4f5a6b7c8
+Create Date: 2026-06-16 10:00:00.000000
+
+La vigencia (y el barrido perezoso de expiración) de la ORDEN se retiró: la
+cotización mutable vive en la pre-orden y la orden nace ya ``confirmed``. La columna
+``expires_at`` queda sin uso.
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e4f5a6b7c8d9"
+down_revision: Union[str, None] = "d3e4f5a6b7c8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ``batch_alter_table`` es obligatorio para SQLite (dev), que no soporta DROP
+    # COLUMN directo en versiones antiguas; en Postgres (prod) se traduce a un ALTER
+    # nativo.
+    with op.batch_alter_table("orders") as batch_op:
+        batch_op.drop_column("expires_at")
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("orders") as batch_op:
+        batch_op.add_column(sa.Column("expires_at", sa.DateTime(), nullable=True))

--- a/alembic/versions/f5a6b7c8d9e0_add_preorder_settings.py
+++ b/alembic/versions/f5a6b7c8d9e0_add_preorder_settings.py
@@ -1,0 +1,49 @@
+"""add preorder config columns to settings
+
+Revision ID: f5a6b7c8d9e0
+Revises: e4f5a6b7c8d9
+Create Date: 2026-06-16 10:05:00.000000
+
+Mueve la config de la pre-orden (vigencia + tope de abiertas por cliente) de las
+variables de entorno a la fila singleton de ``settings``, igual que los parámetros de
+corte y el membrete. El ``server_default`` backfillea la fila existente a los defaults
+(15 días / 5 abiertas); en runtime ``SettingsService.get_or_init`` siembra valores
+explícitos desde ``config``.
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f5a6b7c8d9e0"
+down_revision: Union[str, None] = "e4f5a6b7c8d9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "settings",
+        sa.Column(
+            "preorder_validity_days",
+            sa.Integer(),
+            nullable=False,
+            server_default="15",
+        ),
+    )
+    op.add_column(
+        "settings",
+        sa.Column(
+            "max_open_preorders_per_client",
+            sa.Integer(),
+            nullable=False,
+            server_default="5",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("settings", "max_open_preorders_per_client")
+    op.drop_column("settings", "preorder_validity_days")

--- a/src/modules/analytics/constants.py
+++ b/src/modules/analytics/constants.py
@@ -14,7 +14,7 @@ from src.modules.orders.model import OrderStatus
 REALIZED_STATUSES = {OrderStatus.completed}
 
 # Ingreso perdido: no se cobrará nunca.
-LOST_STATUSES = {OrderStatus.cancelled, OrderStatus.expired}
+LOST_STATUSES = {OrderStatus.cancelled}
 
 # Pipeline comprometido: vinculado pero aún no completado.
 BOOKED_STATUSES = {
@@ -24,20 +24,18 @@ BOOKED_STATUSES = {
     OrderStatus.cut,
 }
 
-# ``draft``/``quoted`` se excluyen de todo ingreso (no vinculantes; hoy las órdenes
-# nacen en ``confirmed``).
+# Pendientes (abiertas, pre-producción): vinculadas pero aún sin entrar a taller. Hoy
+# las órdenes nacen ya ``confirmed`` (la cotización mutable vive en la pre-orden).
+PENDING_STATUSES = {OrderStatus.confirmed, OrderStatus.approved}
 
 # Etiquetas legibles por estado para los desgloses (eje del embudo).
 STATUS_LABELS = {
-    OrderStatus.draft: "Borrador",
-    OrderStatus.quoted: "Cotizada",
     OrderStatus.confirmed: "Confirmada",
     OrderStatus.approved: "Aprobada",
     OrderStatus.in_production: "En producción",
     OrderStatus.cut: "Cortada",
     OrderStatus.completed: "Completada",
     OrderStatus.cancelled: "Cancelada",
-    OrderStatus.expired: "Expirada",
 }
 
 

--- a/src/modules/analytics/schemas.py
+++ b/src/modules/analytics/schemas.py
@@ -30,7 +30,6 @@ class AnalyticsSummary(CamelModel):
     # Estados / pipeline.
     pending_orders_count: int
     cancellation_rate: float  # 0..1
-    expiry_rate: float  # 0..1
     # Tendencia base.
     order_count: int
     realized_revenue: float
@@ -86,5 +85,4 @@ class OperationsReport(CamelModel):
     average_efficiency: float
     total_area_cut_m2: float
     waste_estimate_m2: float
-    expiry_before_approval_rate: float
     lifecycle: List[DwellTime]

--- a/src/modules/analytics/service.py
+++ b/src/modules/analytics/service.py
@@ -13,6 +13,7 @@ from sqlalchemy import distinct, func
 from sqlalchemy.orm import Session
 
 from src.modules.analytics.constants import (
+    PENDING_STATUSES,
     REALIZED_STATUSES,
     STATUS_LABELS,
     Granularity,
@@ -30,12 +31,7 @@ from src.modules.analytics.schemas import (
     TimeSeries,
     TimeSeriesData,
 )
-from src.modules.orders.model import (
-    PENDING_STATUSES,
-    OrderLineModel,
-    OrderModel,
-    OrderStatus,
-)
+from src.modules.orders.model import OrderLineModel, OrderModel, OrderStatus
 from src.shared.database import get_db
 
 
@@ -50,7 +46,6 @@ class AnalyticsService:
         order_count = self._count(dr)
         completed_count = self._count(dr, REALIZED_STATUSES)
         cancelled = self._count(dr, {OrderStatus.cancelled})
-        expired = self._count(dr, {OrderStatus.expired})
 
         realized_revenue = self._revenue(dr, REALIZED_STATUSES)
         boards = self._boards_consumed(dr)
@@ -71,7 +66,6 @@ class AnalyticsService:
             waste_estimate_m2=waste,
             pending_orders_count=self._count(dr, PENDING_STATUSES),
             cancellation_rate=round(safe_div(cancelled, order_count), 4),
-            expiry_rate=round(safe_div(expired, order_count), 4),
             order_count=order_count,
             realized_revenue=realized_revenue,
             average_ticket=round(safe_div(realized_revenue, completed_count), 2),
@@ -167,7 +161,6 @@ class AnalyticsService:
             average_efficiency=avg_eff,
             total_area_cut_m2=area,
             waste_estimate_m2=waste,
-            expiry_before_approval_rate=self._expiry_before_approval(orders),
             lifecycle=self._lifecycle(orders),
         )
 
@@ -222,32 +215,11 @@ class AnalyticsService:
         weighted = sum(eff * area for eff, area in rows) / total_area
         return round(weighted, 2), round(total_area, 4)
 
-    def _expiry_before_approval(self, orders: list[OrderModel]) -> float:
-        """Fracción de órdenes confirmadas que expiraron sin llegar a ``approved``.
-
-        No usa timestamps (el ``created_at`` de ``expired`` es perezoso); solo el
-        conjunto de estados visitados por cada orden en su historial.
-        """
-        confirmed = OrderStatus.confirmed.value
-        approved = OrderStatus.approved.value
-        expired = OrderStatus.expired.value
-        ever_confirmed = 0
-        numerator = 0
-        for o in orders:
-            visited = {h.to_status for h in o.history}
-            if confirmed not in visited:
-                continue
-            ever_confirmed += 1
-            if expired in visited and approved not in visited:
-                numerator += 1
-        return round(safe_div(numerator, ever_confirmed), 4)
-
     def _lifecycle(self, orders: list[OrderModel]) -> list[DwellTime]:
         """Horas medias en cada estado, por par ``(from_status, to_status)``.
 
         El tiempo en un estado = intervalo entre el evento que entró a él y el que lo
-        dejó. El ``created_at`` de ``expired`` es perezoso (se escribe al leer la orden),
-        así que esos tramos son aproximados; ``sample_count`` transparenta la muestra.
+        dejó; ``sample_count`` transparenta el tamaño de la muestra.
         """
         acc: dict[tuple[str, str], list[float]] = defaultdict(lambda: [0.0, 0])
         for o in orders:

--- a/src/modules/optimizations/carrier.py
+++ b/src/modules/optimizations/carrier.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import List
+from typing import List, Optional
 
 
 @dataclass
@@ -15,6 +15,9 @@ class ProformaCarrier:
     reference: str
     client: object
     company: dict = field(default_factory=dict)
+    # Vigencia (días) que muestra la proforma; ``None`` la omite (p. ej. una orden
+    # ya confirmada no es una cotización vigente). La fijan los carriers de cotización.
+    validity_days: Optional[int] = None
     requirements: List[dict] = field(default_factory=list)
     materials_summary: List[dict] = field(default_factory=list)
     edge_bandings_summary: List[dict] = field(default_factory=list)
@@ -33,17 +36,24 @@ class ProformaCarrier:
 
     @classmethod
     def from_payload(
-        cls, payload: dict, client, reference: str, company: dict | None = None
+        cls,
+        payload: dict,
+        client,
+        reference: str,
+        company: dict | None = None,
+        validity_days: Optional[int] = None,
     ) -> "ProformaCarrier":
         """Construye el portador desde un payload de optimización + el cliente.
 
         ``company`` es el membrete vigente (datos de la empresa) que se renderiza en
-        vivo; no forma parte del snapshot con precio.
+        vivo; no forma parte del snapshot con precio. ``validity_days`` es la vigencia
+        de la cotización que muestra la proforma (``None`` la omite).
         """
         return cls(
             reference=reference,
             client=client,
             company=company or {},
+            validity_days=validity_days,
             requirements=payload.get("requirements") or [],
             materials_summary=payload.get("materials_summary") or [],
             edge_bandings_summary=payload.get("edge_bandings_summary") or [],

--- a/src/modules/optimizations/proforma.py
+++ b/src/modules/optimizations/proforma.py
@@ -26,7 +26,6 @@ from src.modules.optimizations.carrier import ProformaCarrier
 from src.modules.optimizations.labels import edge_banding_notation
 from src.modules.optimizations.patterns import group_layouts
 from src.modules.optimizations.visualization import VisualizationService
-from src.shared.config import config
 
 # Paleta de marca MADERABLE (muestreada del membrete oficial).
 BRAND_CORAL = colors.HexColor("#E8564B")  # acento principal / cabeceras de tabla
@@ -163,10 +162,16 @@ class ProformaService:
         story.extend(ProformaService._build_layout_pages(carrier))
 
         story.append(Spacer(1, 0.3 * inch))
+        # La vigencia solo aplica a cotizaciones (pre-orden / optimización en vivo); una
+        # orden ya confirmada no la lleva (``carrier.validity_days`` es ``None``).
+        validity_note = (
+            f"Esta proforma es válida por {carrier.validity_days} días. "
+            if carrier.validity_days
+            else ""
+        )
         story.append(
             Paragraph(
-                f"Esta proforma es válida por {config.ORDER_VALIDITY_DAYS} días. "
-                "Los precios no incluyen IVA.",
+                f"{validity_note}Los precios no incluyen IVA.",
                 ParagraphStyle(
                     "Note",
                     parent=styles["Normal"],

--- a/src/modules/optimizations/service.py
+++ b/src/modules/optimizations/service.py
@@ -114,6 +114,9 @@ class OptimizationService:
             client,
             reference=f"OPT-{optimization_hash[:8]}",
             company=self.settings_service.get_company(),
+            validity_days=self.settings_service.get_preorder_config()[
+                "preorder_validity_days"
+            ],
         )
 
     def compute(self, request: OptimizeRequest) -> Tuple[dict, str]:

--- a/src/modules/orders/model.py
+++ b/src/modules/orders/model.py
@@ -9,42 +9,31 @@ from src.shared.database import Base
 
 
 class OrderStatus(str, Enum):
-    """Estados del proceso comercial de una orden."""
+    """Estados del proceso productivo de una orden.
 
-    draft = "draft"
-    quoted = "quoted"
+    La revisión previa del cliente (cotización mutable) vive en la pre-orden; una
+    orden nace ya ``confirmed`` y desde ahí sólo avanza por producción.
+    """
+
     confirmed = "confirmed"
     approved = "approved"
     in_production = "in_production"
     cut = "cut"
     completed = "completed"
     cancelled = "cancelled"
-    expired = "expired"
 
 
 # Estados sin salida: la orden ya no se transforma.
-TERMINAL_STATUSES = {OrderStatus.completed, OrderStatus.cancelled, OrderStatus.expired}
-
-# Pendientes (abiertas, pre-producción): cuentan para el tope antiabuso por cliente
-# y para el barrido perezoso de vigencia. La revisión previa del cliente ahora vive
-# en la pre-orden, así que una orden nace ya ``confirmed`` (sin estado ``quoted``).
-PENDING_STATUSES = {OrderStatus.confirmed, OrderStatus.approved}
+TERMINAL_STATUSES = {OrderStatus.completed, OrderStatus.cancelled}
 
 # Mapa de transiciones válidas de la máquina de estados (ver diseño §7.2).
 TRANSITIONS: dict[OrderStatus, set[OrderStatus]] = {
-    OrderStatus.draft: {OrderStatus.quoted, OrderStatus.cancelled},
-    OrderStatus.quoted: {
-        OrderStatus.confirmed,
-        OrderStatus.expired,
-        OrderStatus.cancelled,
-    },
     OrderStatus.confirmed: {OrderStatus.approved, OrderStatus.cancelled},
     OrderStatus.approved: {OrderStatus.in_production, OrderStatus.cancelled},
     OrderStatus.in_production: {OrderStatus.cut},
     OrderStatus.cut: {OrderStatus.completed},
     OrderStatus.completed: set(),
     OrderStatus.cancelled: set(),
-    OrderStatus.expired: set(),
 }
 
 
@@ -74,7 +63,6 @@ class OrderModel(Base):
 
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     confirmed_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
-    expires_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
 
     client: Mapped["ClientModel"] = relationship("ClientModel")  # noqa: F821
     lines: Mapped[list["OrderLineModel"]] = relationship(

--- a/src/modules/orders/router.py
+++ b/src/modules/orders/router.py
@@ -7,7 +7,6 @@ from src.modules.optimizations.proforma import ProformaService, pdf_response
 from src.modules.orders.model import OrderStatus
 from src.modules.orders.schemas import (
     CuttingPlanResponse,
-    OrderCreate,
     OrderExportResponse,
     OrderInvoiceUpdate,
     OrderResponse,
@@ -33,12 +32,6 @@ _FORMAT_QUERY = Query(
     description="Formato de salida: 'pdf' (archivo) o 'base64' (JSON)",
     pattern="^(pdf|base64)$",
 )
-
-
-@router.post("/", response_model=DataResponse[OrderResponse], status_code=201)
-def create_order(data: OrderCreate, svc: OrderService = Depends(order_service)):
-    """Crea (o recupera, por idempotencia) una orden congelando el snapshot."""
-    return ok(svc.create(data))
 
 
 @router.get("/", response_model=PaginatedResponse[OrderResponse])

--- a/src/modules/orders/schemas.py
+++ b/src/modules/orders/schemas.py
@@ -135,7 +135,6 @@ class OrderResponse(CamelModel):
     notes: Optional[str] = None
     created_at: datetime
     confirmed_at: Optional[datetime] = None
-    expires_at: Optional[datetime] = None
     lines: List[OrderLineResponse] = Field(default_factory=list)
     pieces: List[OrderPieceResponse] = Field(default_factory=list)
     history: List[OrderStatusHistoryResponse] = Field(default_factory=list)

--- a/src/modules/orders/service.py
+++ b/src/modules/orders/service.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import List, Optional, Tuple
 
 from fastapi import Depends
@@ -10,7 +10,6 @@ from src.modules.optimizations.patterns import base_label
 from src.modules.optimizations.schemas import OptimizeRequest
 from src.modules.optimizations.service import OptimizationService
 from src.modules.orders.model import (
-    PENDING_STATUSES,
     TERMINAL_STATUSES,
     TRANSITIONS,
     OrderBoardModel,
@@ -31,7 +30,6 @@ from src.modules.orders.schemas import (
     PieceCutResponse,
     PlacedPieceResponse,
 )
-from src.shared.config import config
 from src.shared.database import get_db
 from src.shared.exceptions import BusinessRuleError, ConflictError, EntityNotFoundError
 
@@ -47,9 +45,6 @@ class OrderService:
         order = self.db.get(OrderModel, order_id)
         if order is None:
             raise EntityNotFoundError("Order", order_id)
-        if self._expire_if_stale(order):
-            self.db.commit()
-            self.db.refresh(order)
         return order
 
     def list_orders(
@@ -58,13 +53,7 @@ class OrderService:
         limit: int = 20,
         offset: int = 0,
     ) -> Tuple[List[OrderModel], int]:
-        """Lista órdenes (más recientes primero) con conteo total: ``(items, total)``.
-
-        Barre primero las pendientes vencidas (las marca ``expired`` y persiste)
-        para que el filtro por estado, el total y la página reflejen el estado ya
-        expirado, sin que una expiración perezosa desbalancee el conteo.
-        """
-        self._sweep_expired()
+        """Lista órdenes (más recientes primero) con conteo total: ``(items, total)``."""
         query = self.db.query(OrderModel)
         if status is not None:
             query = query.filter(OrderModel.status == status.value)
@@ -99,8 +88,6 @@ class OrderService:
         if existing is not None:
             return existing
 
-        self._enforce_pending_cap(data.client_id)
-
         total_boards_cost = payload["total_boards_cost"]
         total_edge_banding_cost = payload.get("total_edge_banding_cost", 0.0)
         grand_total = round(total_boards_cost + total_edge_banding_cost, 2)
@@ -121,7 +108,6 @@ class OrderService:
             notes=data.notes,
             created_at=now,
             confirmed_at=now,
-            expires_at=now + timedelta(days=config.ORDER_VALIDITY_DAYS),
         )
         # Líneas de cobro = tableros usados + tapacantos (productos consumidos).
         order.lines = [
@@ -365,53 +351,12 @@ class OrderService:
             external_invoice_id=order.external_invoice_id,
         )
 
-    def _sweep_expired(self) -> None:
-        """Expira (y persiste) las pendientes vencidas antes de contar/paginar.
-
-        Acotado a las pendientes con vigencia vencida, no a toda la tabla.
-        """
-        stale = (
-            self.db.query(OrderModel)
-            .filter(
-                OrderModel.status.in_([s.value for s in PENDING_STATUSES]),
-                OrderModel.expires_at < datetime.utcnow(),
-            )
-            .all()
-        )
-        if any([self._expire_if_stale(o) for o in stale]):
-            self.db.commit()
-
-    def _expire_if_stale(self, order: OrderModel) -> bool:
-        """Marca como ``expired`` una orden pendiente cuya vigencia ya venció.
-
-        Expiración perezosa: se dispara al leer (get/list) o al evaluar el tope de
-        pendientes. Solo afecta a estados pendientes (confirmed/approved). No hace
-        commit: el llamador decide cuándo persistir el barrido. Devuelve ``True``
-        si transicionó la orden.
-        """
-        if (
-            order.expires_at is not None
-            and order.status in {s.value for s in PENDING_STATUSES}
-            and order.expires_at < datetime.utcnow()
-        ):
-            order.history.append(
-                OrderStatusHistoryModel(
-                    from_status=order.status,
-                    to_status=OrderStatus.expired.value,
-                    actor="system",
-                    note="Vigencia vencida",
-                )
-            )
-            order.status = OrderStatus.expired.value
-            return True
-        return False
-
     def _find_active_duplicate(
         self, client_id: int, optimization_hash: str
     ) -> Optional[OrderModel]:
         """Orden no terminal del cliente con el mismo hash (idempotencia)."""
         terminal = [s.value for s in TERMINAL_STATUSES]
-        candidate = (
+        return (
             self.db.query(OrderModel)
             .filter(
                 OrderModel.client_id == client_id,
@@ -420,34 +365,6 @@ class OrderService:
             )
             .first()
         )
-        if candidate is not None and self._expire_if_stale(candidate):
-            # La duplicada estaba vencida: ya no cuenta, se crea una nueva orden.
-            self.db.commit()
-            return None
-        return candidate
-
-    def _enforce_pending_cap(self, client_id: int) -> None:
-        """Bloquea si el cliente excede el tope de órdenes pendientes.
-
-        Primero expira las pendientes vencidas (no cuentan para el tope).
-        """
-        pending = [s.value for s in PENDING_STATUSES]
-        candidates = (
-            self.db.query(OrderModel)
-            .filter(
-                OrderModel.client_id == client_id,
-                OrderModel.status.in_(pending),
-            )
-            .all()
-        )
-        if any([self._expire_if_stale(o) for o in candidates]):
-            self.db.commit()
-        active = sum(1 for o in candidates if o.status in pending)
-        if active >= config.MAX_PENDING_ORDERS_PER_CLIENT:
-            raise BusinessRuleError(
-                f"El cliente ya tiene {active} pedido(s) pendiente(s); "
-                "resuélvalos o espere a que expiren antes de crear otro."
-            )
 
 
 def _attach_cutting_plan(order: OrderModel, payload: dict) -> None:

--- a/src/modules/preorders/review_service.py
+++ b/src/modules/preorders/review_service.py
@@ -85,10 +85,13 @@ class PreOrderReviewService:
             if previous.status == ReviewLinkStatus.active.value:
                 previous.status = ReviewLinkStatus.revoked.value
 
+        validity_days = self.preorders.settings_service.get_preorder_config()[
+            "preorder_validity_days"
+        ]
         now = datetime.utcnow()
         preorder.status = PreOrderStatus.sent.value
         preorder.sent_at = now
-        preorder.expires_at = now + timedelta(days=config.PREORDER_VALIDITY_DAYS)
+        preorder.expires_at = now + timedelta(days=validity_days)
 
         raw_token = secrets.token_urlsafe(32)
         link = PreOrderReviewLinkModel(

--- a/src/modules/preorders/service.py
+++ b/src/modules/preorders/service.py
@@ -14,7 +14,7 @@ from src.modules.preorders.model import (
     PreOrderStatus,
 )
 from src.modules.preorders.schemas import PreOrderCreate, PreOrderUpdate
-from src.shared.config import config
+from src.modules.settings.service import SettingsService
 from src.shared.database import get_db
 from src.shared.exceptions import BusinessRuleError, EntityNotFoundError
 
@@ -33,6 +33,7 @@ class PreOrderService:
     def __init__(self, db: Session):
         self.db = db
         self.optimization_service = OptimizationService(db)
+        self.settings_service = SettingsService(db)
 
     def get_or_404(self, preorder_id: int) -> PreOrderModel:
         preorder = self.db.get(PreOrderModel, preorder_id)
@@ -69,6 +70,9 @@ class PreOrderService:
             raise EntityNotFoundError("Client", data.client_id)
         self._enforce_open_cap(data.client_id)
 
+        validity_days = self.settings_service.get_preorder_config()[
+            "preorder_validity_days"
+        ]
         now = datetime.utcnow()
         preorder = PreOrderModel(
             client_id=data.client_id,
@@ -78,7 +82,7 @@ class PreOrderService:
             source=data.source,
             notes=data.notes,
             created_at=now,
-            expires_at=now + timedelta(days=config.PREORDER_VALIDITY_DAYS),
+            expires_at=now + timedelta(days=validity_days),
         )
         self.db.add(preorder)
         self.db.flush()  # asigna id para componer el code legible
@@ -143,13 +147,16 @@ class PreOrderService:
         return self.optimization_service.optimize_response(self.build_request(preorder))
 
     def build_carrier(self, preorder: PreOrderModel) -> ProformaCarrier:
-        """Portador de proforma (PDF) recalculado para la pre-orden."""
+        """Portador de proforma (PDF) recalculado para la pre-orden (cotización)."""
         payload, _ = self.compute_payload(preorder)
         return ProformaCarrier.from_payload(
             payload,
             preorder.client,
             reference=preorder.code or f"PRE-{preorder.id:06d}",
-            company=self.optimization_service.settings_service.get_company(),
+            company=self.settings_service.get_company(),
+            validity_days=self.settings_service.get_preorder_config()[
+                "preorder_validity_days"
+            ],
         )
 
     def _ensure_open(self, preorder: PreOrderModel) -> None:
@@ -196,7 +203,10 @@ class PreOrderService:
         if any([self._expire_if_stale(p) for p in candidates]):
             self.db.commit()
         active = sum(1 for p in candidates if p.status in _OPEN_VALUES)
-        if active >= config.MAX_OPEN_PREORDERS_PER_CLIENT:
+        cap = self.settings_service.get_preorder_config()[
+            "max_open_preorders_per_client"
+        ]
+        if active >= cap:
             raise BusinessRuleError(
                 f"El cliente ya tiene {active} pre-orden(es) abierta(s); "
                 "ciérrelas o espere a que expiren antes de crear otra."

--- a/src/modules/settings/model.py
+++ b/src/modules/settings/model.py
@@ -31,6 +31,10 @@ class SettingsModel(Base):
     right_trim: Mapped[float] = mapped_column(Float)
     edge_banding_waste_factor: Mapped[float] = mapped_column(Float)
 
+    # Pre-órdenes (cotización mutable): vigencia y tope de abiertas por cliente
+    preorder_validity_days: Mapped[int] = mapped_column(Integer)
+    max_open_preorders_per_client: Mapped[int] = mapped_column(Integer)
+
     # Datos de la empresa (membrete de la proforma)
     company_name: Mapped[str] = mapped_column(String(128))
     company_tagline: Mapped[str] = mapped_column(String(256))

--- a/src/modules/settings/router.py
+++ b/src/modules/settings/router.py
@@ -5,6 +5,8 @@ from src.modules.settings.schemas import (
     CompanySettingsUpdate,
     CuttingSettingsResponse,
     CuttingSettingsUpdate,
+    PreOrderSettingsResponse,
+    PreOrderSettingsUpdate,
 )
 from src.modules.settings.service import SettingsService, settings_service
 from src.shared.responses import ERROR_RESPONSES, DataResponse, ok
@@ -24,6 +26,20 @@ def update_cutting_settings(
 ):
     """Actualiza (parcialmente) los parámetros de corte."""
     return ok(svc.update_cutting(data))
+
+
+@router.get("/preorders", response_model=DataResponse[PreOrderSettingsResponse])
+def get_preorder_settings(svc: SettingsService = Depends(settings_service)):
+    """Devuelve la config de pre-órdenes vigente (sembrada desde config si falta)."""
+    return ok(svc.get_or_init())
+
+
+@router.patch("/preorders", response_model=DataResponse[PreOrderSettingsResponse])
+def update_preorder_settings(
+    data: PreOrderSettingsUpdate, svc: SettingsService = Depends(settings_service)
+):
+    """Actualiza (parcialmente) la vigencia y el tope de pre-órdenes."""
+    return ok(svc.update_preorders(data))
 
 
 @router.get("/company", response_model=DataResponse[CompanySettingsResponse])

--- a/src/modules/settings/schemas.py
+++ b/src/modules/settings/schemas.py
@@ -30,6 +30,25 @@ class CuttingSettingsUpdate(CamelModel):
     edge_banding_waste_factor: Optional[float] = Field(None, ge=0)
 
 
+# --- Pre-órdenes (cotización mutable) -----------------------------------------
+class PreOrderSettingsResponse(CamelModel):
+    """Config de pre-órdenes vigente: vigencia y tope de abiertas por cliente."""
+
+    preorder_validity_days: int = Field(
+        ..., ge=1, description="Días de vigencia de una pre-orden (cotización)"
+    )
+    max_open_preorders_per_client: int = Field(
+        ..., ge=1, description="Tope de pre-órdenes abiertas por cliente (antiabuso)"
+    )
+
+
+class PreOrderSettingsUpdate(CamelModel):
+    """Actualización parcial de la config de pre-órdenes."""
+
+    preorder_validity_days: Optional[int] = Field(None, ge=1)
+    max_open_preorders_per_client: Optional[int] = Field(None, ge=1)
+
+
 # --- Datos de la empresa ------------------------------------------------------
 class Branch(CamelModel):
     """Sucursal mostrada en el membrete de la proforma."""

--- a/src/modules/settings/service.py
+++ b/src/modules/settings/service.py
@@ -3,7 +3,11 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from src.modules.settings.model import SETTINGS_ID, SettingsModel
-from src.modules.settings.schemas import CompanySettingsUpdate, CuttingSettingsUpdate
+from src.modules.settings.schemas import (
+    CompanySettingsUpdate,
+    CuttingSettingsUpdate,
+    PreOrderSettingsUpdate,
+)
 from src.shared.config import config
 from src.shared.database import get_db
 
@@ -49,6 +53,8 @@ class SettingsService:
             left_trim=config.LEFT_TRIM,
             right_trim=config.RIGHT_TRIM,
             edge_banding_waste_factor=config.EDGE_BANDING_WASTE_FACTOR,
+            preorder_validity_days=config.PREORDER_VALIDITY_DAYS,
+            max_open_preorders_per_client=config.MAX_OPEN_PREORDERS_PER_CLIENT,
             company_name=config.COMPANY_NAME,
             company_tagline=config.COMPANY_TAGLINE,
             company_email=config.COMPANY_EMAIL,
@@ -72,6 +78,28 @@ class SettingsService:
         self.db.commit()
         self.db.refresh(settings)
         return settings
+
+    def update_preorders(self, data: PreOrderSettingsUpdate) -> SettingsModel:
+        """Aplica un PATCH parcial a la config de pre-órdenes (vigencia + tope)."""
+        settings = self.get_or_init()
+        for field, value in data.model_dump(exclude_unset=True).items():
+            setattr(settings, field, value)
+        self.db.commit()
+        self.db.refresh(settings)
+        return settings
+
+    def get_preorder_config(self) -> dict:
+        """Vigencia y tope de pre-órdenes vigentes (fuente de verdad en runtime).
+
+        Lo consumen ``PreOrderService`` (expires_at + tope de abiertas),
+        ``PreOrderReviewService`` (refresco de expires_at al generar el enlace) y los
+        carriers de cotización (vigencia mostrada en la proforma).
+        """
+        settings = self.get_or_init()
+        return {
+            "preorder_validity_days": settings.preorder_validity_days,
+            "max_open_preorders_per_client": settings.max_open_preorders_per_client,
+        }
 
     def update_company(self, data: CompanySettingsUpdate) -> SettingsModel:
         """Aplica un PATCH parcial a los datos de la empresa."""

--- a/src/shared/config.py
+++ b/src/shared/config.py
@@ -76,11 +76,10 @@ class Config:
 
     OPT_RESULT_TTL_SECONDS = env.int("OPT_RESULT_TTL_SECONDS", 259200)
 
-    # Órdenes: vigencia de la cotización y tope de pendientes por cliente (antiabuso)
-    ORDER_VALIDITY_DAYS = env.int("ORDER_VALIDITY_DAYS", 15)
-    MAX_PENDING_ORDERS_PER_CLIENT = env.int("MAX_PENDING_ORDERS_PER_CLIENT", 3)
-
-    # Pre-órdenes (cotización mutable): vigencia y tope de abiertas por cliente.
+    # Pre-órdenes (cotización mutable): vigencia y tope de abiertas por cliente. Solo
+    # siembran la sección "preorders" de la fila singleton de `settings` en su primera
+    # lectura; la fuente de verdad en runtime es la tabla `settings` (editable vía
+    # PATCH /settings/preorders), igual que los parámetros de corte.
     PREORDER_VALIDITY_DAYS = env.int("PREORDER_VALIDITY_DAYS", 15)
     MAX_OPEN_PREORDERS_PER_CLIENT = env.int("MAX_OPEN_PREORDERS_PER_CLIENT", 5)
 

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -5,7 +5,7 @@ precisión (la máquina de estados no deja alcanzar todos los casos limpio). El 
 y el ``db_session`` comparten la misma SQLite en memoria por el override de ``get_db``.
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from src.modules.orders.model import (
     OrderLineModel,
@@ -62,7 +62,6 @@ def _seed_order(
         total_boards_used=boards,
         created_at=created_at,
         confirmed_at=created_at,
-        expires_at=created_at + timedelta(days=15),
     )
     if lines is not None:
         order.lines = lines
@@ -94,7 +93,6 @@ def test_summary_empty_range_returns_zeros_not_nulls(client):
         "wasteEstimateM2",
         "pendingOrdersCount",
         "cancellationRate",
-        "expiryRate",
         "orderCount",
         "realizedRevenue",
         "averageTicket",
@@ -110,17 +108,15 @@ def test_summary_revenue_and_rates_isolated_by_status(client, db_session):
     _seed_order(db_session, client_id=1, status="completed", total=100.0)
     _seed_order(db_session, client_id=2, status="confirmed", total=200.0)
     _seed_order(db_session, client_id=1, status="cancelled", total=50.0)
-    _seed_order(db_session, client_id=3, status="expired", total=30.0)
 
     data = client.get("/api/v1/analytics/summary", params=_RANGE).json()["data"]
 
-    assert data["orderCount"] == 4
+    assert data["orderCount"] == 3
     assert data["realizedRevenue"] == 100.0  # solo completed
     assert data["averageTicket"] == 100.0  # 100 / 1 completada
     assert data["pendingOrdersCount"] == 1  # confirmed (approved: 0)
-    assert data["cancellationRate"] == 0.25  # 1 / 4
-    assert data["expiryRate"] == 0.25  # 1 / 4
-    assert data["activeClientsCount"] == 3  # clientes 1, 2, 3 distintos
+    assert data["cancellationRate"] == round(1 / 3, 4)  # 1 / 3
+    assert data["activeClientsCount"] == 2  # clientes 1 y 2 distintos
 
 
 def test_summary_efficiency_is_area_weighted_and_ignores_edge_banding(
@@ -258,7 +254,7 @@ def test_breakdown_status_densifies_all_states(client, db_session):
     ]
 
     assert data["dimension"] == "status"
-    assert len(data["items"]) == 9  # todos los OrderStatus
+    assert len(data["items"]) == 6  # todos los OrderStatus
     by_key = {it["key"]: it for it in data["items"]}
     assert by_key["completed"]["orderCount"] == 2
     assert by_key["completed"]["revenue"] == 300.0
@@ -272,7 +268,7 @@ def test_breakdown_status_empty_range(client):
     data = client.get("/api/v1/analytics/breakdown/status", params=_RANGE).json()[
         "data"
     ]
-    assert len(data["items"]) == 9
+    assert len(data["items"]) == 6
     assert all(it["orderCount"] == 0 and it["revenue"] == 0 for it in data["items"])
 
 
@@ -302,41 +298,9 @@ def test_operations_lifecycle_dwell_times(client, db_session):
     assert cycle[("approved", "in_production")]["avgHours"] == 3.0
 
 
-def test_operations_expiry_before_approval_rate(client, db_session):
-    # A: confirmed → expired (sin aprobar) → numerador.
-    _seed_order(
-        db_session,
-        status="expired",
-        history=[
-            _hist("confirmed", datetime(2026, 6, 15, 0, 0)),
-            _hist("expired", datetime(2026, 6, 16, 0, 0), from_status="confirmed"),
-        ],
-    )
-    # B: confirmed → approved → expired → no cuenta (llegó a approved).
-    _seed_order(
-        db_session,
-        status="expired",
-        history=[
-            _hist("confirmed", datetime(2026, 6, 15, 0, 0)),
-            _hist("approved", datetime(2026, 6, 15, 1, 0), from_status="confirmed"),
-            _hist("expired", datetime(2026, 6, 16, 0, 0), from_status="approved"),
-        ],
-    )
-    # C: solo confirmed → denominador, no numerador.
-    _seed_order(
-        db_session,
-        status="confirmed",
-        history=[_hist("confirmed", datetime(2026, 6, 15, 0, 0))],
-    )
-
-    data = client.get("/api/v1/analytics/operations", params=_RANGE).json()["data"]
-    assert data["expiryBeforeApprovalRate"] == round(1 / 3, 4)
-
-
 def test_operations_empty_range(client):
     data = client.get("/api/v1/analytics/operations", params=_RANGE).json()["data"]
     assert data["averageEfficiency"] == 0
     assert data["totalAreaCutM2"] == 0
     assert data["wasteEstimateM2"] == 0
-    assert data["expiryBeforeApprovalRate"] == 0
     assert data["lifecycle"] == []

--- a/tests/test_edge_banding.py
+++ b/tests/test_edge_banding.py
@@ -7,6 +7,8 @@ import pytest
 from src.modules.optimizations.labels import edge_banding_notation
 from src.modules.optimizations.schemas import EdgeBandingSpec, EdgeSide
 from src.modules.optimizations.service import OptimizationService
+from src.modules.orders.schemas import OrderCreate
+from src.modules.orders.service import OrderService
 from src.shared.config import config
 
 
@@ -398,21 +400,26 @@ def test_placed_piece_notation_includes_band_type(client):
 # --------------------------------------------------------------------------- #
 # Cobro durable en órdenes
 # --------------------------------------------------------------------------- #
-def test_order_charges_edge_banding(client):
+def _mint_order(client, db_session, payload):
+    """Mintea una orden por el servicio (la creación HTTP se retiró) y la lee vía GET."""
+    order = OrderService(db_session).create(OrderCreate.model_validate(payload))
+    return client.get(f"/api/v1/orders/{order.id}").json()["data"]
+
+
+def test_order_charges_edge_banding(client, db_session):
     c = _create_client(client)
     b = _create_board(client, price=45.5)
     eb = _create_edge_banding(client, price=2.0)
 
-    resp = client.post(
-        "/api/v1/orders/",
-        json={
+    data = _mint_order(
+        client,
+        db_session,
+        {
             "clientId": c["id"],
             "materials": _materials(b["id"]),
             "requirements": [_requirement(eb["id"], ["top", "bottom"])],
         },
     )
-    assert resp.status_code == 201
-    data = resp.json()["data"]
 
     # Dos líneas de cobro: tablero + tapacanto.
     lines = {line["productCode"]: line for line in data["lines"]}
@@ -438,18 +445,19 @@ def test_order_charges_edge_banding(client):
     assert {"MEL18", "TAP22"} <= codes
 
 
-def test_order_proforma_with_edge_banding_renders(client):
+def test_order_proforma_with_edge_banding_renders(client, db_session):
     c = _create_client(client)
     b = _create_board(client)
     eb = _create_edge_banding(client)
-    order = client.post(
-        "/api/v1/orders/",
-        json={
+    order = _mint_order(
+        client,
+        db_session,
+        {
             "clientId": c["id"],
             "materials": _materials(b["id"]),
             "requirements": [_requirement(eb["id"], ["top", "bottom"])],
         },
-    ).json()["data"]
+    )
 
     proforma = client.get(f"/api/v1/orders/{order['id']}/proforma")
     assert proforma.status_code == 200

--- a/tests/test_order_cutting_plan.py
+++ b/tests/test_order_cutting_plan.py
@@ -1,6 +1,8 @@
 """Tests del plan de corte por orden: materialización, marcado táctil y gate."""
 
 from src.modules.orders.model import OrderBoardModel, OrderPlacedPieceModel
+from src.modules.orders.schemas import OrderCreate
+from src.modules.orders.service import OrderService
 
 
 def _create_client(client, identifier="0991112233", phone="0991112233"):
@@ -46,11 +48,17 @@ def _order_payload(client_id, product_id, height=400, width=600, quantity=3):
     }
 
 
-def _create_order(client, quantity=3, width=600):
+def _mint(client, db_session, payload):
+    """Mintea una orden por el servicio (la creación HTTP se retiró) y la lee vía GET."""
+    order = OrderService(db_session).create(OrderCreate.model_validate(payload))
+    return client.get(f"/api/v1/orders/{order.id}").json()["data"]
+
+
+def _create_order(client, db_session, quantity=3, width=600):
     c = _create_client(client)
     b = _create_board(client)
     payload = _order_payload(c["id"], b["id"], quantity=quantity, width=width)
-    return client.post("/api/v1/orders/", json=payload).json()["data"]
+    return _mint(client, db_session, payload)
 
 
 def _to_production(client, order_id):
@@ -69,9 +77,9 @@ def _get_plan(client, order_id):
     return resp.json()["data"]
 
 
-def test_create_order_materializes_cutting_plan(client):
+def test_create_order_materializes_cutting_plan(client, db_session):
     """Crear la orden expande el snapshot en tableros físicos y piezas colocadas."""
-    order = _create_order(client, quantity=3)
+    order = _create_order(client, db_session, quantity=3)
     plan = _get_plan(client, order["id"])
 
     assert plan["orderId"] == order["id"]
@@ -116,9 +124,9 @@ def test_cutting_plan_unknown_order_returns_404(client):
     assert resp.status_code == 404
 
 
-def test_mark_piece_requires_in_production(client):
+def test_mark_piece_requires_in_production(client, db_session):
     """Antes de producción no hay nada que cortar: marcar da 422."""
-    order = _create_order(client)
+    order = _create_order(client, db_session)
     piece_id = _get_plan(client, order["id"])["boards"][0]["pieces"][0]["id"]
 
     resp = client.patch(
@@ -129,8 +137,8 @@ def test_mark_piece_requires_in_production(client):
     assert "producción" in resp.json()["errors"][0]["message"]
 
 
-def test_mark_and_unmark_piece_updates_progress(client):
-    order = _create_order(client, quantity=3)
+def test_mark_and_unmark_piece_updates_progress(client, db_session):
+    order = _create_order(client, db_session, quantity=3)
     _to_production(client, order["id"])
     piece_id = _get_plan(client, order["id"])["boards"][0]["pieces"][0]["id"]
     url = f"/api/v1/orders/{order['id']}/cutting-plan/pieces/{piece_id}"
@@ -152,16 +160,12 @@ def test_mark_and_unmark_piece_updates_progress(client):
     assert undone["progress"] == {"cutPieces": 0, "totalPieces": 3}
 
 
-def test_mark_piece_of_another_order_returns_404(client):
+def test_mark_piece_of_another_order_returns_404(client, db_session):
     """Una pieza ajena a la orden no existe para ella (404, sin filtrar datos)."""
     c = _create_client(client)
     b = _create_board(client)
-    first = client.post(
-        "/api/v1/orders/", json=_order_payload(c["id"], b["id"], width=600)
-    ).json()["data"]
-    second = client.post(
-        "/api/v1/orders/", json=_order_payload(c["id"], b["id"], width=500)
-    ).json()["data"]
+    first = _mint(client, db_session, _order_payload(c["id"], b["id"], width=600))
+    second = _mint(client, db_session, _order_payload(c["id"], b["id"], width=500))
     _to_production(client, first["id"])
     foreign_piece = _get_plan(client, second["id"])["boards"][0]["pieces"][0]["id"]
 
@@ -172,9 +176,9 @@ def test_mark_piece_of_another_order_returns_404(client):
     assert resp.status_code == 404
 
 
-def test_transition_to_cut_blocked_until_all_pieces_marked(client):
+def test_transition_to_cut_blocked_until_all_pieces_marked(client, db_session):
     """Gate de producción: in_production → cut exige el plan de corte completo."""
-    order = _create_order(client, quantity=3)
+    order = _create_order(client, db_session, quantity=3)
     _to_production(client, order["id"])
     pieces = _get_plan(client, order["id"])["boards"][0]["pieces"]
 
@@ -202,7 +206,7 @@ def test_transition_to_cut_blocked_until_all_pieces_marked(client):
 
 def test_lazy_materialization_for_legacy_orders(client, db_session):
     """Órdenes previas a la feature reconstruyen el plan desde el snapshot."""
-    order = _create_order(client, quantity=2)
+    order = _create_order(client, db_session, quantity=2)
 
     # Simula una orden creada antes de la feature: sin filas de plan de corte.
     db_session.query(OrderPlacedPieceModel).delete()

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -1,8 +1,18 @@
-"""Tests del módulo orders: creación (snapshot), idempotencia, tope, estados."""
+"""Tests del módulo orders: creación (snapshot), idempotencia, estados.
+
+Las órdenes ya no se crean por HTTP (``POST /orders`` se retiró): nacen al confirmar
+una pre-orden. Aquí se mintan directamente por ``OrderService.create`` (la vía interna
+que conserva el flujo) reusando la sesión del fixture ``client``, y se leen vía GET para
+verificar la proyección API en camelCase.
+"""
 
 from datetime import datetime
 
-from src.shared.config import config
+import pytest
+
+from src.modules.orders.schemas import OrderCreate
+from src.modules.orders.service import OrderService
+from src.shared.exceptions import BusinessRuleError, EntityNotFoundError
 
 
 def _create_client(client, identifier="0991112233", phone="0991112233"):
@@ -48,13 +58,22 @@ def _order_payload(client_id, product_id, height=400, width=600, quantity=2):
     }
 
 
-def test_create_order_freezes_snapshot_and_charges_boards(client):
+def _mint_order(db_session, payload):
+    """Crea la orden por el servicio y devuelve el ``OrderModel``."""
+    return OrderService(db_session).create(OrderCreate.model_validate(payload))
+
+
+def _create_order(client, db_session, payload):
+    """Mintea la orden y devuelve su proyección API (GET) en camelCase."""
+    order = _mint_order(db_session, payload)
+    return client.get(f"/api/v1/orders/{order.id}").json()["data"]
+
+
+def test_create_order_freezes_snapshot_and_charges_boards(client, db_session):
     c = _create_client(client)
     b = _create_board(client)
 
-    resp = client.post("/api/v1/orders/", json=_order_payload(c["id"], b["id"]))
-    assert resp.status_code == 201
-    data = resp.json()["data"]
+    data = _create_order(client, db_session, _order_payload(c["id"], b["id"]))
 
     assert data["status"] == "confirmed"
     assert data["code"] == f"ORD-{datetime.utcnow().year}-{data['id']:04d}"
@@ -71,6 +90,9 @@ def test_create_order_freezes_snapshot_and_charges_boards(client):
     # Totales inmutables = suma por tableros.
     assert data["total"] == data["subtotal"] == line["lineTotal"]
 
+    # La orden ya no lleva vigencia (la cotización mutable vive en la pre-orden).
+    assert "expiresAt" not in data
+
     # Lista de corte = piezas (insumo de producción, no se cobra).
     assert len(data["pieces"]) == 1
     piece = data["pieces"][0]
@@ -82,7 +104,7 @@ def test_create_order_freezes_snapshot_and_charges_boards(client):
     assert data["history"][0]["fromStatus"] is None
 
 
-def test_create_order_blocked_without_client_phone(client):
+def test_create_order_blocked_without_client_phone(client, db_session):
     """Regla de negocio: sin celular registrado no se crea el pedido (422)."""
     b = _create_board(client)
     no_phone = client.post(
@@ -90,68 +112,39 @@ def test_create_order_blocked_without_client_phone(client):
         json={"identifier": "0990000000", "firstName": "Sin", "lastName": "Tel"},
     ).json()["data"]
 
-    resp = client.post("/api/v1/orders/", json=_order_payload(no_phone["id"], b["id"]))
-    assert resp.status_code == 422
-    assert "celular" in resp.json()["errors"][0]["message"].lower()
+    with pytest.raises(BusinessRuleError) as exc:
+        _mint_order(db_session, _order_payload(no_phone["id"], b["id"]))
+    assert "celular" in str(exc.value).lower()
     # No se persistió ninguna orden.
     assert client.get("/api/v1/orders/").json()["data"] == []
 
 
-def test_create_order_unknown_client_returns_404(client):
+def test_create_order_unknown_client_returns_404(client, db_session):
     """Un ``clientId`` inexistente da 404 limpio antes de congelar nada."""
     b = _create_board(client)
-    resp = client.post("/api/v1/orders/", json=_order_payload(99999, b["id"]))
-    assert resp.status_code == 404
-    assert "Client 99999" in resp.json()["errors"][0]["message"]
+    with pytest.raises(EntityNotFoundError) as exc:
+        _mint_order(db_session, _order_payload(99999, b["id"]))
+    assert "Client 99999" in str(exc.value)
 
 
-def test_create_order_is_idempotent(client):
+def test_create_order_is_idempotent(client, db_session):
     c = _create_client(client)
     b = _create_board(client)
     payload = _order_payload(c["id"], b["id"])
 
-    first = client.post("/api/v1/orders/", json=payload).json()["data"]
-    second = client.post("/api/v1/orders/", json=payload).json()["data"]
+    first = _mint_order(db_session, payload)
+    second = _mint_order(db_session, payload)
 
-    assert first["id"] == second["id"]
-    assert first["code"] == second["code"]
+    assert first.id == second.id
+    assert first.code == second.code
     # No se crean dos órdenes para el mismo (cliente, hash).
     assert len(client.get("/api/v1/orders/").json()["data"]) == 1
 
 
-def test_pending_cap_blocks_excess_orders(client, monkeypatch):
-    monkeypatch.setattr(config, "MAX_PENDING_ORDERS_PER_CLIENT", 2)
+def test_status_transitions_valid_and_invalid(client, db_session):
     c = _create_client(client)
     b = _create_board(client)
-
-    # Dos órdenes distintas (distinto hash) → ambas quedan pendientes.
-    assert (
-        client.post(
-            "/api/v1/orders/", json=_order_payload(c["id"], b["id"], width=600)
-        ).status_code
-        == 201
-    )
-    assert (
-        client.post(
-            "/api/v1/orders/", json=_order_payload(c["id"], b["id"], width=500)
-        ).status_code
-        == 201
-    )
-
-    # La tercera excede el tope de pendientes.
-    third = client.post(
-        "/api/v1/orders/", json=_order_payload(c["id"], b["id"], width=450)
-    )
-    assert third.status_code == 422
-    assert "pendiente" in third.json()["errors"][0]["message"]
-
-
-def test_status_transitions_valid_and_invalid(client):
-    c = _create_client(client)
-    b = _create_board(client)
-    order = client.post(
-        "/api/v1/orders/", json=_order_payload(c["id"], b["id"])
-    ).json()["data"]
+    order = _create_order(client, db_session, _order_payload(c["id"], b["id"]))
     oid = order["id"]
 
     ok = client.patch(f"/api/v1/orders/{oid}/status", json={"status": "approved"})
@@ -170,12 +163,10 @@ def test_status_transitions_valid_and_invalid(client):
     assert "inválida" in bad.json()["errors"][0]["message"]
 
 
-def test_invalid_transition_from_confirmed(client):
+def test_invalid_transition_from_confirmed(client, db_session):
     c = _create_client(client)
     b = _create_board(client)
-    order = client.post(
-        "/api/v1/orders/", json=_order_payload(c["id"], b["id"])
-    ).json()["data"]
+    order = _create_order(client, db_session, _order_payload(c["id"], b["id"]))
     # confirmed → completed (salta estados) no es válido.
     bad = client.patch(
         f"/api/v1/orders/{order['id']}/status", json={"status": "completed"}
@@ -183,13 +174,11 @@ def test_invalid_transition_from_confirmed(client):
     assert bad.status_code == 422
 
 
-def test_list_orders_filter_by_status(client):
+def test_list_orders_filter_by_status(client, db_session):
     c = _create_client(client)
     b = _create_board(client)
-    o1 = client.post(
-        "/api/v1/orders/", json=_order_payload(c["id"], b["id"], width=600)
-    ).json()["data"]
-    client.post("/api/v1/orders/", json=_order_payload(c["id"], b["id"], width=500))
+    o1 = _create_order(client, db_session, _order_payload(c["id"], b["id"], width=600))
+    _create_order(client, db_session, _order_payload(c["id"], b["id"], width=500))
 
     # Aprobar solo la primera.
     client.patch(f"/api/v1/orders/{o1['id']}/status", json={"status": "approved"})
@@ -207,12 +196,10 @@ def test_get_order_404(client):
     assert client.get("/api/v1/orders/999999").status_code == 404
 
 
-def test_order_proforma_pdf_and_base64(client):
+def test_order_proforma_pdf_and_base64(client, db_session):
     c = _create_client(client)
     b = _create_board(client)
-    order = client.post(
-        "/api/v1/orders/", json=_order_payload(c["id"], b["id"])
-    ).json()["data"]
+    order = _create_order(client, db_session, _order_payload(c["id"], b["id"]))
     oid = order["id"]
 
     pdf = client.get(f"/api/v1/orders/{oid}/proforma")
@@ -229,12 +216,10 @@ def test_order_proforma_pdf_and_base64(client):
     assert order["code"] in body["filename"]
 
 
-def test_order_production_sheet_pdf(client):
+def test_order_production_sheet_pdf(client, db_session):
     c = _create_client(client)
     b = _create_board(client)
-    order = client.post(
-        "/api/v1/orders/", json=_order_payload(c["id"], b["id"])
-    ).json()["data"]
+    order = _create_order(client, db_session, _order_payload(c["id"], b["id"]))
 
     sheet = client.get(f"/api/v1/orders/{order['id']}/production-sheet")
     assert sheet.status_code == 200
@@ -247,12 +232,10 @@ def test_order_documents_404(client):
     assert client.get("/api/v1/orders/999999/production-sheet").status_code == 404
 
 
-def test_order_export_document(client):
+def test_order_export_document(client, db_session):
     c = _create_client(client)
     b = _create_board(client)
-    order = client.post(
-        "/api/v1/orders/", json=_order_payload(c["id"], b["id"])
-    ).json()["data"]
+    order = _create_order(client, db_session, _order_payload(c["id"], b["id"]))
 
     resp = client.get(f"/api/v1/orders/{order['id']}/export")
     assert resp.status_code == 200
@@ -276,12 +259,10 @@ def test_order_export_document(client):
     assert data["subtotal"] == data["total"] == line["lineTotal"]
 
 
-def test_set_external_invoice_id_and_reflect_in_export(client):
+def test_set_external_invoice_id_and_reflect_in_export(client, db_session):
     c = _create_client(client)
     b = _create_board(client)
-    order = client.post(
-        "/api/v1/orders/", json=_order_payload(c["id"], b["id"])
-    ).json()["data"]
+    order = _create_order(client, db_session, _order_payload(c["id"], b["id"]))
     oid = order["id"]
 
     resp = client.post(
@@ -301,12 +282,10 @@ def test_set_external_invoice_id_and_reflect_in_export(client):
     assert exported["externalInvoiceId"] == "FAC-001-42"
 
 
-def test_set_external_invoice_id_conflict_on_different_id(client):
+def test_set_external_invoice_id_conflict_on_different_id(client, db_session):
     c = _create_client(client)
     b = _create_board(client)
-    order = client.post(
-        "/api/v1/orders/", json=_order_payload(c["id"], b["id"])
-    ).json()["data"]
+    order = _create_order(client, db_session, _order_payload(c["id"], b["id"]))
     oid = order["id"]
 
     client.post(
@@ -327,41 +306,6 @@ def test_billing_seam_404(client):
         ).status_code
         == 404
     )
-
-
-def test_order_expires_lazily_on_read(client, monkeypatch):
-    """Una orden vencida se transiciona a ``expired`` al leerla (barrido perezoso)."""
-    monkeypatch.setattr(config, "ORDER_VALIDITY_DAYS", -1)
-    c = _create_client(client)
-    b = _create_board(client)
-    order = client.post(
-        "/api/v1/orders/", json=_order_payload(c["id"], b["id"])
-    ).json()["data"]
-    # Nace confirmed, pero su vigencia ya está vencida (expiresAt en el pasado).
-    assert order["status"] == "confirmed"
-
-    fetched = client.get(f"/api/v1/orders/{order['id']}").json()["data"]
-    assert fetched["status"] == "expired"
-    assert fetched["history"][-1]["toStatus"] == "expired"
-    assert fetched["history"][-1]["fromStatus"] == "confirmed"
-
-
-def test_expired_order_frees_pending_cap(client, monkeypatch):
-    """Las pendientes vencidas no cuentan para el tope: se expiran al evaluarlo."""
-    monkeypatch.setattr(config, "MAX_PENDING_ORDERS_PER_CLIENT", 1)
-    monkeypatch.setattr(config, "ORDER_VALIDITY_DAYS", -1)
-    c = _create_client(client)
-    b = _create_board(client)
-
-    first = client.post(
-        "/api/v1/orders/", json=_order_payload(c["id"], b["id"], width=600)
-    )
-    assert first.status_code == 201
-    # La primera está vencida; la segunda (distinto hash) no choca con el tope.
-    second = client.post(
-        "/api/v1/orders/", json=_order_payload(c["id"], b["id"], width=500)
-    )
-    assert second.status_code == 201
 
 
 def _manual_material_payload(client_id):
@@ -391,13 +335,11 @@ def _manual_material_payload(client_id):
     }
 
 
-def test_create_order_with_non_catalog_material(client):
+def test_create_order_with_non_catalog_material(client, db_session):
     """Un material 'manual' se congela tal cual el snapshot: línea sin productId."""
     c = _create_client(client)
 
-    resp = client.post("/api/v1/orders/", json=_manual_material_payload(c["id"]))
-    assert resp.status_code == 201
-    data = resp.json()["data"]
+    data = _create_order(client, db_session, _manual_material_payload(c["id"]))
 
     # Cobro = el material manual, identificado por code/name (sin productId).
     assert len(data["lines"]) == 1
@@ -417,7 +359,7 @@ def test_create_order_with_non_catalog_material(client):
     assert len(client.get("/api/v1/orders/").json()["data"]) == 1
 
 
-def test_create_mixed_catalog_and_offcut_order(client):
+def test_create_mixed_catalog_and_offcut_order(client, db_session):
     """Orden mixta: tablero de catálogo + retazo de empresa (costo 0)."""
     c = _create_client(client)
     b = _create_board(client)
@@ -452,9 +394,7 @@ def test_create_mixed_catalog_and_offcut_order(client):
             },
         ],
     }
-    resp = client.post("/api/v1/orders/", json=payload)
-    assert resp.status_code == 201
-    data = resp.json()["data"]
+    data = _create_order(client, db_session, payload)
 
     assert len(data["lines"]) == 2
     catalog_line = next(line for line in data["lines"] if line["productId"] is not None)
@@ -471,12 +411,10 @@ def test_create_mixed_catalog_and_offcut_order(client):
     assert piece_product_ids == {b["id"], None}
 
 
-def test_non_catalog_order_renders_proforma_and_production_sheet(client):
+def test_non_catalog_order_renders_proforma_and_production_sheet(client, db_session):
     """Proforma y hoja de producción se renderizan del snapshot, sin catálogo."""
     c = _create_client(client)
-    order = client.post(
-        "/api/v1/orders/", json=_manual_material_payload(c["id"])
-    ).json()["data"]
+    order = _create_order(client, db_session, _manual_material_payload(c["id"]))
 
     proforma = client.get(f"/api/v1/orders/{order['id']}/proforma")
     assert proforma.status_code == 200

--- a/tests/test_preorders.py
+++ b/tests/test_preorders.py
@@ -3,7 +3,6 @@
 from datetime import datetime, timedelta
 
 from src.modules.preorders.model import PreOrderModel
-from src.shared.config import config
 
 from .test_orders import _create_board, _create_client, _order_payload
 
@@ -85,8 +84,12 @@ def test_update_blocked_when_not_open(client, db_session):
     assert "ya no puede editarse" in resp.json()["errors"][0]["message"]
 
 
-def test_open_cap_enforced(client, monkeypatch):
-    monkeypatch.setattr(config, "MAX_OPEN_PREORDERS_PER_CLIENT", 2)
+def test_open_cap_enforced(client):
+    # El tope se lee de settings (no de env): bajarlo a 2 vía la API de configuración.
+    patched = client.patch(
+        "/api/v1/settings/preorders", json={"maxOpenPreordersPerClient": 2}
+    )
+    assert patched.status_code == 200
     c, b = _setup(client)
     assert _create_preorder(client, c, b, width=600).status_code == 201
     assert _create_preorder(client, c, b, width=500).status_code == 201

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,5 +1,7 @@
 """Tests del módulo settings: configuración única persistida y editable vía API."""
 
+from datetime import datetime
+
 from src.shared.config import config
 
 
@@ -86,6 +88,61 @@ def test_cutting_settings_drive_optimization(client):
     second = client.post("/api/v1/optimize/", json=payload).json()["data"]
 
     assert first["optimizationHash"] != second["optimizationHash"]
+
+
+# --- Pre-órdenes (cotización mutable) -----------------------------------------
+def test_get_preorders_seeds_from_config(client):
+    """El primer GET siembra la sección preorders con los defaults de ``config``."""
+    resp = client.get("/api/v1/settings/preorders")
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["preorderValidityDays"] == config.PREORDER_VALIDITY_DAYS
+    assert data["maxOpenPreordersPerClient"] == config.MAX_OPEN_PREORDERS_PER_CLIENT
+
+
+def test_patch_preorders_persists_and_is_partial(client):
+    """El PATCH parcial persiste solo lo enviado y no pisa el resto."""
+    before = client.get("/api/v1/settings/preorders").json()["data"]
+
+    resp = client.patch("/api/v1/settings/preorders", json={"preorderValidityDays": 30})
+    assert resp.status_code == 200
+    assert resp.json()["data"]["preorderValidityDays"] == 30
+
+    after = client.get("/api/v1/settings/preorders").json()["data"]
+    assert after["preorderValidityDays"] == 30
+    # El tope queda intacto.
+    assert after["maxOpenPreordersPerClient"] == before["maxOpenPreordersPerClient"]
+
+
+def test_patch_preorders_rejects_below_one(client):
+    """Validación: vigencia y tope deben ser ≥ 1 (422)."""
+    assert (
+        client.patch(
+            "/api/v1/settings/preorders", json={"preorderValidityDays": 0}
+        ).status_code
+        == 422
+    )
+    assert (
+        client.patch(
+            "/api/v1/settings/preorders", json={"maxOpenPreordersPerClient": 0}
+        ).status_code
+        == 422
+    )
+
+
+def test_preorder_validity_comes_from_settings(client):
+    """La pre-orden toma su vigencia de settings (no de env): el gap = días config."""
+    created_client = _create_client(client)
+    board = _create_board(client)
+
+    client.patch("/api/v1/settings/preorders", json={"preorderValidityDays": 7})
+    pre = client.post(
+        "/api/v1/preorders/", json=_optimize_payload(created_client["id"], board["id"])
+    ).json()["data"]
+
+    created = datetime.fromisoformat(pre["createdAt"])
+    expires = datetime.fromisoformat(pre["expiresAt"])
+    assert (expires - created).days == 7
 
 
 # --- Datos de la empresa ------------------------------------------------------


### PR DESCRIPTION
    The mutable quote flow (review link, client decision) already lives in the
    preorders module, so an order is born `confirmed` and only advances through
    production. This removes the order-as-quote machinery that became dead weight.

    - Orders: drop `expires_at`, `PENDING_STATUSES`, lazy expiry sweep and the per-client pending cap. Drop the unreachable `draft`/`quoted`/`expired` statuses; live states are confirmed→approved→in_production→cut→completed (+ cancelled). `_find_active_duplicate` (idempotency) is kept.
    - Settings: move preorder validity + open cap to the singleton `settings` row (editable via GET/PATCH /settings/preorders, both >= 1), mirroring the cutting/company pattern. `config.PREORDER_*` stays as the seed.
    - Proforma validity line is threaded through the carrier (`ProformaCarrier.validity_days`): quote carriers (preorder / /optimize/{hash}/proforma) show it; a confirmed order omits it.
    - Remove the direct `POST /orders` HTTP route (was the bot path); orders are minted only via PreOrderReviewService.confirm. `OrderService.create` and `OrderCreate` are kept for internal use.
    - Analytics: drop the now-meaningless `expiryRate` and `expiryBeforeApprovalRate`; redefine `PENDING_STATUSES` locally and prune STATUS_LABELS/LOST_STATUSES.
    - Migrations: drop orders.expires_at; add preorder config columns to settings (server_default 15/5 backfill)