### PR TITLE
feat: enforce RBAC on all endpoints + refresh-token sessions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,11 +20,13 @@ FRONTEND_BASE_URL=http://localhost:3001/#
 EDGE_BANDING_WASTE_FACTOR=0.10
 
 # Autenticación (JWT). SECRET_KEY firma los tokens: OBLIGATORIO en producción;
-# en local/staging cae a un placeholder de desarrollo. ACCESS_TOKEN_EXPIRE_MINUTES
-# es la vigencia del token de acceso (480 = 8 h).
+# en local/staging cae a un placeholder de desarrollo. El access token es corto
+# (ACCESS_TOKEN_EXPIRE_MINUTES) y se renueva con el refresh token, cuya vigencia
+# es REFRESH_TOKEN_EXPIRE_DAYS. Ver docs/AUTH.md.
 SECRET_KEY=dev-secret-change-me
 JWT_ALGORITHM=HS256
-ACCESS_TOKEN_EXPIRE_MINUTES=480
+ACCESS_TOKEN_EXPIRE_MINUTES=30
+REFRESH_TOKEN_EXPIRE_DAYS=30
 
 # Primer administrador (semilla idempotente al migrar). Si ambos están definidos
 # y no existe un usuario con ese email, la migración lo crea con rol "administrador".

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -18,6 +18,7 @@ from src.modules.preorders import model as preorders_model  # noqa: F401
 from src.modules.products.model import ProductModel  # noqa: F401
 from src.modules.settings.model import SettingsModel  # noqa: F401
 from src.modules.users.model import UserModel  # noqa: F401
+from src.modules.users.refresh_token_model import RefreshTokenModel  # noqa: F401
 from src.shared.config import config as app_config
 from src.shared.database import Base
 

--- a/alembic/versions/862298678742_add_refresh_tokens_table.py
+++ b/alembic/versions/862298678742_add_refresh_tokens_table.py
@@ -1,0 +1,53 @@
+"""add refresh_tokens table
+
+Revision ID: 862298678742
+Revises: af91f2429419
+Create Date: 2026-06-16 22:26:02.015781
+
+Refresh tokens de sesión: par renovable del access JWT. Solo se guarda el sha256
+del token (``token_hash``), nunca el token en claro.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "862298678742"
+down_revision: Union[str, None] = "af91f2429419"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "refresh_tokens",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("token_hash", sa.String(length=64), nullable=False),
+        sa.Column("expires_at", sa.DateTime(), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_refresh_tokens_token_hash"),
+        "refresh_tokens",
+        ["token_hash"],
+        unique=True,
+    )
+    op.create_index(
+        op.f("ix_refresh_tokens_user_id"),
+        "refresh_tokens",
+        ["user_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_refresh_tokens_user_id"), table_name="refresh_tokens")
+    op.drop_index(op.f("ix_refresh_tokens_token_hash"), table_name="refresh_tokens")
+    op.drop_table("refresh_tokens")

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -1,0 +1,93 @@
+# Autenticación y autorización (RBAC)
+
+Contrato de auth del API Cutter para el dashboard web (React). Todos los endpoints
+salvo los públicos exigen un **access token** (JWT) en el header
+`Authorization: Bearer <accessToken>`. La autorización es por **rol** según la
+matriz de permisos.
+
+## Roles
+
+| Rol (valor en BD)    | Descripción                                  |
+|----------------------|----------------------------------------------|
+| `administrador`      | Acceso total (gestión, config, analítica).   |
+| `vendedor`           | Comercial: catálogo (lectura), clientes, optimizador, pre-órdenes, órdenes. |
+| `operador`           | Taller: lectura de órdenes y plan de corte.  |
+
+El login es por `email` (único). La contraseña se guarda solo como hash bcrypt.
+
+## Flujo de sesión
+
+1. **Login** → `POST /api/v1/auth/login` con `{ email, password }`.
+   Respuesta: `{ accessToken, refreshToken, tokenType: "bearer", expiresIn, user }`.
+   - `accessToken`: JWT corto (por defecto 30 min, `ACCESS_TOKEN_EXPIRE_MINUTES`).
+   - `refreshToken`: token opaco largo (por defecto 30 días, `REFRESH_TOKEN_EXPIRE_DAYS`).
+   - `expiresIn`: vigencia del access token en segundos.
+2. **Usar el API** → enviar `Authorization: Bearer <accessToken>` en cada request.
+3. **Renovar** → cuando el access token expira (o ante un `401`), llamar
+   `POST /api/v1/auth/refresh` con `{ refreshToken }`. Devuelve un **par nuevo**
+   (mismo shape que login). El refresh presentado **se rota**: queda invalidado y se
+   emite otro. Guardar siempre el `refreshToken` más reciente.
+4. **Cerrar sesión** → `POST /api/v1/auth/logout` con `{ refreshToken }` (revoca ese
+   refresh; idempotente, `204`).
+
+### Seguridad del refresh token (rotación y reúso)
+
+- Cada `refreshToken` se usa **una sola vez**: `refresh` lo revoca y entrega uno nuevo.
+- Si se reusa un refresh **ya rotado** (señal de robo), el API revoca **toda la
+  familia** de refresh tokens del usuario y responde `401`. El usuario debe
+  volver a hacer login. → El front nunca debe reusar un refresh viejo; debe
+  reemplazarlo por el que devuelve `refresh`.
+- En reposo solo se guarda el `sha256` del token, nunca el token en claro.
+
+## Autoservicio (cualquier rol autenticado)
+
+- `GET /api/v1/auth/me` → usuario autenticado.
+- `PATCH /api/v1/auth/me` con `{ fullName }` → edita **solo** el nombre propio.
+  No permite cambiar `role`, `isActive` ni `email` (eso es gestión solo-admin).
+- `POST /api/v1/auth/change-password` con `{ currentPassword, newPassword }` → cambia
+  la propia contraseña verificando la actual. **Revoca todos los refresh tokens** del
+  usuario (cierra otras sesiones); el front debe re-loguear tras un `204`.
+
+## Semántica de errores
+
+| Código | Significado | Acción del front |
+|--------|-------------|------------------|
+| `401 UNAUTHORIZED` | Falta el token, es inválido o expiró; o credenciales malas. | Intentar `refresh`; si también `401`, redirigir a login. |
+| `403 FORBIDDEN`    | Autenticado pero el **rol** no tiene permiso para esa área. | Mostrar "sin permiso"; no reintentar. |
+
+Todos los errores comparten la envoltura `{ errors: [{ code, message, field? }], meta }`.
+
+## Matriz de permisos por endpoint
+
+Fuente de verdad: `src/modules/users/permissions.py` (`RESOURCE_ROLES`). Cada ruta
+se protege con `Depends(require_permission("<clave>"))`.
+
+| Área (`clave`)        | administrador | vendedor | operador | Endpoints |
+|-----------------------|:---:|:---:|:---:|---|
+| `users:manage`        | ✅ | ❌ | ❌ | `/users/*` |
+| `settings:manage`     | ✅ | ❌ | ❌ | `/settings/*` |
+| `analytics`           | ✅ | ❌ | ❌ | `/analytics/*` |
+| `products:read`       | ✅ | ✅ | ❌ | `GET /products/*` |
+| `products:write`      | ✅ | ❌ | ❌ | `POST/PUT/DELETE /products/*` |
+| `clients:manage`      | ✅ | ✅ | ❌ | `/clients/*` |
+| `optimizer`           | ✅ | ✅ | ❌ | `/optimize/*`, `/optimization-drafts/*` |
+| `preorders`           | ✅ | ✅ | ❌ | `/preorders/*` (interno) |
+| `orders:read`         | ✅ | ✅ | ✅ | `GET /orders`, `GET /orders/{id}`, `GET /orders/{id}/proforma` |
+| `orders:write`        | ✅ | ✅ | ❌ | `PATCH /orders/{id}/status`, `POST /orders/{id}/invoice`, `GET /orders/{id}/export` |
+| `cutting_plan`        | ✅ | ✅ | ✅ | `GET/PATCH /orders/{id}/cutting-plan*`, `GET /orders/{id}/production-sheet` |
+
+## Endpoints públicos (sin token)
+
+- `GET /health`, `GET /api/v1/health/`, `/health/ready`, `/api/v1/cutter/*` — diagnóstico.
+- `POST /api/v1/auth/login`, `POST /api/v1/auth/refresh`, `POST /api/v1/auth/logout`.
+- `GET/POST /api/v1/public/review/{token}*` — flujo de revisión del cliente:
+  el **token del enlace** es la única credencial (no usa JWT).
+
+## Configuración (env)
+
+| Var | Default | Descripción |
+|-----|---------|-------------|
+| `SECRET_KEY` | `dev-secret-change-me` (obligatorio en prod) | Firma HS256 del JWT. |
+| `ACCESS_TOKEN_EXPIRE_MINUTES` | `30` | Vigencia del access token. |
+| `REFRESH_TOKEN_EXPIRE_DAYS` | `30` | Vigencia del refresh token. |
+| `ADMIN_EMAIL` / `ADMIN_PASSWORD` | vacío | Siembran el primer admin (migración idempotente). |

--- a/src/modules/analytics/router.py
+++ b/src/modules/analytics/router.py
@@ -15,9 +15,16 @@ from src.modules.analytics.schemas import (
     TimeSeries,
 )
 from src.modules.analytics.service import AnalyticsService, analytics_service
+from src.modules.users.dependencies import require_permission
 from src.shared.responses import ERROR_RESPONSES, DataResponse, ok
 
-router = APIRouter(prefix="/analytics", tags=["analytics"], responses=ERROR_RESPONSES)
+# Analítica del dashboard: solo "administrador" (RESOURCE_ROLES["analytics"]).
+router = APIRouter(
+    prefix="/analytics",
+    tags=["analytics"],
+    responses=ERROR_RESPONSES,
+    dependencies=[Depends(require_permission("analytics"))],
+)
 
 
 @router.get("/summary", response_model=DataResponse[AnalyticsSummary])

--- a/src/modules/clients/router.py
+++ b/src/modules/clients/router.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends, Query
 
 from src.modules.clients.schemas import ClientCreate, ClientResponse, ClientUpdate
 from src.modules.clients.service import ClientService, client_service
+from src.modules.users.dependencies import require_permission
 from src.shared.exceptions import EntityNotFoundError
 from src.shared.pagination import PageParams
 from src.shared.responses import (
@@ -14,7 +15,13 @@ from src.shared.responses import (
     page,
 )
 
-router = APIRouter(prefix="/clients", tags=["clients"], responses=ERROR_RESPONSES)
+# Gestión de clientes: "administrador" y "vendedor" (RESOURCE_ROLES["clients:manage"]).
+router = APIRouter(
+    prefix="/clients",
+    tags=["clients"],
+    responses=ERROR_RESPONSES,
+    dependencies=[Depends(require_permission("clients:manage"))],
+)
 
 
 @router.post("/", response_model=DataResponse[ClientResponse], status_code=201)

--- a/src/modules/optimization_drafts/router.py
+++ b/src/modules/optimization_drafts/router.py
@@ -10,6 +10,7 @@ from src.modules.optimization_drafts.service import (
     OptimizationDraftService,
     optimization_draft_service,
 )
+from src.modules.users.dependencies import require_permission
 from src.shared.pagination import PageParams
 from src.shared.responses import (
     ERROR_RESPONSES,
@@ -19,10 +20,12 @@ from src.shared.responses import (
     page,
 )
 
+# Borradores del optimizador: "administrador" y "vendedor" (RESOURCE_ROLES["optimizer"]).
 router = APIRouter(
     prefix="/optimization-drafts",
     tags=["optimization-drafts"],
     responses=ERROR_RESPONSES,
+    dependencies=[Depends(require_permission("optimizer"))],
 )
 
 

--- a/src/modules/optimizations/router.py
+++ b/src/modules/optimizations/router.py
@@ -3,9 +3,16 @@ from fastapi import APIRouter, Depends, Query
 from src.modules.optimizations.proforma import ProformaService, pdf_response
 from src.modules.optimizations.schemas import OptimizeRequest, OptimizeResponse
 from src.modules.optimizations.service import OptimizationService, optimization_service
+from src.modules.users.dependencies import require_permission
 from src.shared.responses import ERROR_RESPONSES, DataResponse, ok
 
-router = APIRouter(prefix="/optimize", tags=["optimize"], responses=ERROR_RESPONSES)
+# Optimizador: "administrador" y "vendedor" (RESOURCE_ROLES["optimizer"]).
+router = APIRouter(
+    prefix="/optimize",
+    tags=["optimize"],
+    responses=ERROR_RESPONSES,
+    dependencies=[Depends(require_permission("optimizer"))],
+)
 
 
 @router.post("/", response_model=DataResponse[OptimizeResponse])

--- a/src/modules/orders/router.py
+++ b/src/modules/orders/router.py
@@ -16,6 +16,7 @@ from src.modules.orders.schemas import (
 )
 from src.modules.orders.service import OrderService, order_service
 from src.modules.settings.service import SettingsService, settings_service
+from src.modules.users.dependencies import require_permission
 from src.shared.pagination import PageParams
 from src.shared.responses import (
     ERROR_RESPONSES,
@@ -27,6 +28,13 @@ from src.shared.responses import (
 
 router = APIRouter(prefix="/orders", tags=["orders"], responses=ERROR_RESPONSES)
 
+# Lectura/proforma: admin + vendedor + operador. Escritura (estado, factura,
+# export): admin + vendedor. Plan de corte (ver/marcar + hoja de producción):
+# admin + vendedor + operador (el operador trabaja en taller).
+_READ = Depends(require_permission("orders:read"))
+_WRITE = Depends(require_permission("orders:write"))
+_CUTTING = Depends(require_permission("cutting_plan"))
+
 _FORMAT_QUERY = Query(
     default="pdf",
     description="Formato de salida: 'pdf' (archivo) o 'base64' (JSON)",
@@ -34,7 +42,7 @@ _FORMAT_QUERY = Query(
 )
 
 
-@router.get("/", response_model=PaginatedResponse[OrderResponse])
+@router.get("/", response_model=PaginatedResponse[OrderResponse], dependencies=[_READ])
 def list_orders(
     status: Optional[OrderStatus] = Query(
         default=None, description="Filtra órdenes por estado"
@@ -49,13 +57,19 @@ def list_orders(
     return page(items, total, paging.limit, paging.offset)
 
 
-@router.get("/{order_id}", response_model=DataResponse[OrderResponse])
+@router.get(
+    "/{order_id}", response_model=DataResponse[OrderResponse], dependencies=[_READ]
+)
 def get_order(order_id: int, svc: OrderService = Depends(order_service)):
     """Obtiene una orden por ID."""
     return ok(svc.get_or_404(order_id))
 
 
-@router.patch("/{order_id}/status", response_model=DataResponse[OrderResponse])
+@router.patch(
+    "/{order_id}/status",
+    response_model=DataResponse[OrderResponse],
+    dependencies=[_WRITE],
+)
 def update_order_status(
     order_id: int,
     data: OrderStatusUpdate,
@@ -66,7 +80,9 @@ def update_order_status(
 
 
 @router.get(
-    "/{order_id}/cutting-plan", response_model=DataResponse[CuttingPlanResponse]
+    "/{order_id}/cutting-plan",
+    response_model=DataResponse[CuttingPlanResponse],
+    dependencies=[_CUTTING],
 )
 def get_cutting_plan(order_id: int, svc: OrderService = Depends(order_service)):
     """Plan de corte para la vista de taller: tableros físicos, piezas y avance."""
@@ -76,6 +92,7 @@ def get_cutting_plan(order_id: int, svc: OrderService = Depends(order_service)):
 @router.patch(
     "/{order_id}/cutting-plan/pieces/{piece_id}",
     response_model=DataResponse[PieceCutResponse],
+    dependencies=[_CUTTING],
 )
 def mark_piece_cut(
     order_id: int,
@@ -90,7 +107,11 @@ def mark_piece_cut(
     return ok(svc.mark_piece_cut(order_id, piece_id, data.cut))
 
 
-@router.post("/{order_id}/invoice", response_model=DataResponse[OrderResponse])
+@router.post(
+    "/{order_id}/invoice",
+    response_model=DataResponse[OrderResponse],
+    dependencies=[_WRITE],
+)
 def set_order_invoice(
     order_id: int,
     data: OrderInvoiceUpdate,
@@ -100,7 +121,11 @@ def set_order_invoice(
     return ok(svc.set_external_invoice_id(order_id, data.external_invoice_id))
 
 
-@router.get("/{order_id}/export", response_model=DataResponse[OrderExportResponse])
+@router.get(
+    "/{order_id}/export",
+    response_model=DataResponse[OrderExportResponse],
+    dependencies=[_WRITE],
+)
 def export_order(order_id: int, svc: OrderService = Depends(order_service)):
     """Documento de facturación neutral para el proveedor externo (cobro=tableros)."""
     return ok(svc.build_export(order_id))
@@ -108,7 +133,7 @@ def export_order(order_id: int, svc: OrderService = Depends(order_service)):
 
 # Exentos de la envoltura JSON: transporte de archivo PDF (StreamingResponse) y su
 # variante base64 son "el archivo, transportado", no recursos JSON de dominio.
-@router.get("/{order_id}/proforma")
+@router.get("/{order_id}/proforma", dependencies=[_READ])
 def get_order_proforma(
     order_id: int,
     format: str = _FORMAT_QUERY,
@@ -122,7 +147,7 @@ def get_order_proforma(
     return pdf_response(pdf_buffer, f"proforma_{order.code or order.id}.pdf", format)
 
 
-@router.get("/{order_id}/production-sheet")
+@router.get("/{order_id}/production-sheet", dependencies=[_CUTTING])
 def get_order_production_sheet(
     order_id: int,
     format: str = _FORMAT_QUERY,

--- a/src/modules/preorders/router.py
+++ b/src/modules/preorders/router.py
@@ -17,6 +17,7 @@ from src.modules.preorders.schemas import (
     ReviewLinkResponse,
 )
 from src.modules.preorders.service import PreOrderService, preorder_service
+from src.modules.users.dependencies import require_permission
 from src.shared.pagination import PageParams
 from src.shared.responses import (
     ERROR_RESPONSES,
@@ -26,7 +27,15 @@ from src.shared.responses import (
     page,
 )
 
-router = APIRouter(prefix="/preorders", tags=["preorders"], responses=ERROR_RESPONSES)
+# Pre-órdenes (cotización interna): "administrador" y "vendedor"
+# (RESOURCE_ROLES["preorders"]). El flujo público del cliente vive en
+# ``public_router.py`` y se autentica solo por el token del enlace.
+router = APIRouter(
+    prefix="/preorders",
+    tags=["preorders"],
+    responses=ERROR_RESPONSES,
+    dependencies=[Depends(require_permission("preorders"))],
+)
 
 _FORMAT_QUERY = Query(
     default="pdf",

--- a/src/modules/products/router.py
+++ b/src/modules/products/router.py
@@ -6,6 +6,7 @@ from src.modules.products.model import ProductType
 from src.modules.products.schemas import ProductCreate, ProductResponse, ProductUpdate
 from src.modules.products.service import ProductService, product_service
 from src.modules.products.types.edge_banding import BandType
+from src.modules.users.dependencies import require_permission
 from src.shared.exceptions import EntityNotFoundError
 from src.shared.pagination import PageParams
 from src.shared.responses import (
@@ -18,14 +19,25 @@ from src.shared.responses import (
 
 router = APIRouter(prefix="/products", tags=["products"], responses=ERROR_RESPONSES)
 
+# Lectura del catálogo: admin + vendedor. Escritura: solo admin.
+_READ = Depends(require_permission("products:read"))
+_WRITE = Depends(require_permission("products:write"))
 
-@router.post("/", response_model=DataResponse[ProductResponse], status_code=201)
+
+@router.post(
+    "/",
+    response_model=DataResponse[ProductResponse],
+    status_code=201,
+    dependencies=[_WRITE],
+)
 def create_product(data: ProductCreate, svc: ProductService = Depends(product_service)):
     """Crea un producto (los ``attributes`` se validan según el ``type``)."""
     return ok(svc.create(data))
 
 
-@router.get("/", response_model=PaginatedResponse[ProductResponse])
+@router.get(
+    "/", response_model=PaginatedResponse[ProductResponse], dependencies=[_READ]
+)
 def list_products(
     paging: PageParams = Depends(),
     type: Optional[ProductType] = Query(
@@ -42,6 +54,7 @@ def list_products(
 @router.get(
     "/{board_id}/edge-bandings",
     response_model=DataResponse[List[ProductResponse]],
+    dependencies=[_READ],
 )
 def get_board_edge_bandings(
     board_id: int,
@@ -59,13 +72,17 @@ def get_board_edge_bandings(
     return ok(svc.find_edge_bandings_for_board(board_id, band_type))
 
 
-@router.get("/{product_id}", response_model=DataResponse[ProductResponse])
+@router.get(
+    "/{product_id}", response_model=DataResponse[ProductResponse], dependencies=[_READ]
+)
 def get_product(product_id: int, svc: ProductService = Depends(product_service)):
     """Obtiene un producto por ID."""
     return ok(svc.get_or_404(product_id))
 
 
-@router.get("/code/{code}", response_model=DataResponse[ProductResponse])
+@router.get(
+    "/code/{code}", response_model=DataResponse[ProductResponse], dependencies=[_READ]
+)
 def get_product_by_code(code: str, svc: ProductService = Depends(product_service)):
     """Obtiene un producto por código."""
     product = svc.get_by_code(code)
@@ -74,7 +91,9 @@ def get_product_by_code(code: str, svc: ProductService = Depends(product_service
     return ok(product)
 
 
-@router.put("/{product_id}", response_model=DataResponse[ProductResponse])
+@router.put(
+    "/{product_id}", response_model=DataResponse[ProductResponse], dependencies=[_WRITE]
+)
 def update_product(
     product_id: int,
     data: ProductUpdate,
@@ -84,7 +103,7 @@ def update_product(
     return ok(svc.update(product_id, data))
 
 
-@router.delete("/{product_id}", status_code=204)
+@router.delete("/{product_id}", status_code=204, dependencies=[_WRITE])
 def delete_product(product_id: int, svc: ProductService = Depends(product_service)):
     """Elimina un producto."""
     svc.delete(product_id)

--- a/src/modules/settings/router.py
+++ b/src/modules/settings/router.py
@@ -9,9 +9,16 @@ from src.modules.settings.schemas import (
     PreOrderSettingsUpdate,
 )
 from src.modules.settings.service import SettingsService, settings_service
+from src.modules.users.dependencies import require_permission
 from src.shared.responses import ERROR_RESPONSES, DataResponse, ok
 
-router = APIRouter(prefix="/settings", tags=["settings"], responses=ERROR_RESPONSES)
+# Configuración del sistema: solo "administrador" (RESOURCE_ROLES["settings:manage"]).
+router = APIRouter(
+    prefix="/settings",
+    tags=["settings"],
+    responses=ERROR_RESPONSES,
+    dependencies=[Depends(require_permission("settings:manage"))],
+)
 
 
 @router.get("/cutting", response_model=DataResponse[CuttingSettingsResponse])

--- a/src/modules/users/auth_router.py
+++ b/src/modules/users/auth_router.py
@@ -2,7 +2,18 @@ from fastapi import APIRouter, Depends
 
 from src.modules.users.dependencies import get_current_user
 from src.modules.users.model import UserModel
-from src.modules.users.schemas import LoginRequest, TokenResponse, UserResponse
+from src.modules.users.refresh_token_service import (
+    RefreshTokenService,
+    refresh_token_service,
+)
+from src.modules.users.schemas import (
+    ChangePasswordRequest,
+    LoginRequest,
+    ProfileUpdate,
+    RefreshRequest,
+    TokenResponse,
+    UserResponse,
+)
 from src.modules.users.service import UserService, user_service
 from src.shared.config import config
 from src.shared.exceptions import AuthenticationError
@@ -12,24 +23,72 @@ from src.shared.security import create_access_token
 router = APIRouter(prefix="/auth", tags=["auth"], responses=ERROR_RESPONSES)
 
 
+def _token_response(user: UserModel, refresh_token: str) -> TokenResponse:
+    """Arma el par de tokens (access JWT + refresh) y los datos del usuario."""
+    return TokenResponse(
+        access_token=create_access_token(user.id, user.role),
+        refresh_token=refresh_token,
+        expires_in=config.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+        user=UserResponse.model_validate(user),
+    )
+
+
 @router.post("/login", response_model=DataResponse[TokenResponse])
-def login(data: LoginRequest, svc: UserService = Depends(user_service)):
-    """Valida email + contraseña y emite un JWT de acceso."""
+def login(
+    data: LoginRequest,
+    svc: UserService = Depends(user_service),
+    refresh_svc: RefreshTokenService = Depends(refresh_token_service),
+):
+    """Valida email + contraseña y emite un par access/refresh."""
     user = svc.authenticate(data.email, data.password)
     if user is None:
         # Mensaje genérico: no revela si el email existe o si fue la contraseña.
         raise AuthenticationError("Email o contraseña incorrectos")
-    token = create_access_token(user.id, user.role)
-    return ok(
-        TokenResponse(
-            access_token=token,
-            expires_in=config.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
-            user=UserResponse.model_validate(user),
-        )
-    )
+    return ok(_token_response(user, refresh_svc.issue(user.id)))
+
+
+@router.post("/refresh", response_model=DataResponse[TokenResponse])
+def refresh(
+    data: RefreshRequest,
+    refresh_svc: RefreshTokenService = Depends(refresh_token_service),
+):
+    """Canjea un refresh token por un par nuevo (rota el presentado)."""
+    user, new_refresh = refresh_svc.rotate(data.refresh_token)
+    return ok(_token_response(user, new_refresh))
+
+
+@router.post("/logout", status_code=204)
+def logout(
+    data: RefreshRequest,
+    refresh_svc: RefreshTokenService = Depends(refresh_token_service),
+):
+    """Cierra la sesión revocando el refresh token presentado (idempotente)."""
+    refresh_svc.revoke(data.refresh_token)
 
 
 @router.get("/me", response_model=DataResponse[UserResponse])
 def me(current_user: UserModel = Depends(get_current_user)):
-    """Devuelve el usuario autenticado (primer consumidor de la infra de auth)."""
+    """Devuelve el usuario autenticado."""
     return ok(current_user)
+
+
+@router.patch("/me", response_model=DataResponse[UserResponse])
+def update_me(
+    data: ProfileUpdate,
+    current_user: UserModel = Depends(get_current_user),
+    svc: UserService = Depends(user_service),
+):
+    """Autoservicio: el propio usuario edita su perfil (solo ``fullName``)."""
+    return ok(svc.update_profile(current_user, data))
+
+
+@router.post("/change-password", status_code=204)
+def change_password(
+    data: ChangePasswordRequest,
+    current_user: UserModel = Depends(get_current_user),
+    svc: UserService = Depends(user_service),
+    refresh_svc: RefreshTokenService = Depends(refresh_token_service),
+):
+    """Autoservicio: cambia la propia contraseña y revoca las sesiones abiertas."""
+    svc.change_password(current_user, data.current_password, data.new_password)
+    refresh_svc.revoke_all_for_user(current_user.id)

--- a/src/modules/users/dependencies.py
+++ b/src/modules/users/dependencies.py
@@ -1,9 +1,11 @@
 """Dependencias de autenticación y autorización.
 
-``get_current_user`` resuelve el usuario autenticado desde el JWT y ``require_role``
-restringe por rol. Hoy solo las consume ``GET /auth/me``; el resto de endpoints
-del sistema siguen abiertos. En la fase de *enforcement* se aplicará ``require_role``
-a cada ruta según la matriz documentada en ``permissions.py``.
+``get_current_user`` resuelve el usuario autenticado desde el JWT; ``require_role``
+restringe por rol y ``require_permission`` por **área** (clave de la matriz
+``RESOURCE_ROLES``). Los endpoints declaran intención con
+``Depends(require_permission("orders:write"))`` y la matriz queda como única fuente
+de verdad. ``require_role`` valida contra el rol **leído de la BD** (vía
+``get_current_user``), así que un cambio de rol surte efecto al instante.
 """
 
 from typing import Optional
@@ -13,6 +15,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from src.modules.users.enums import UserRole
 from src.modules.users.model import UserModel
+from src.modules.users.permissions import RESOURCE_ROLES
 from src.modules.users.service import UserService, user_service
 from src.shared.exceptions import AuthenticationError, AuthorizationError
 from src.shared.security import decode_access_token
@@ -43,8 +46,8 @@ def get_current_user(
 def require_role(*roles: UserRole):
     """Factory de dependencia: exige que el usuario tenga uno de ``roles``.
 
-    Listo para usar en la fase de enforcement, p. ej.
-    ``Depends(require_role(UserRole.ADMIN))`` en el CRUD de usuarios.
+    p. ej. ``Depends(require_role(UserRole.ADMIN))``. Prefiere ``require_permission``
+    cuando exista una clave de área en ``RESOURCE_ROLES`` (centraliza la política).
     """
     allowed = {role.value for role in roles}
 
@@ -54,3 +57,12 @@ def require_role(*roles: UserRole):
         return current_user
 
     return dependency
+
+
+def require_permission(resource: str):
+    """Dependencia de autorización por área, resuelta contra ``RESOURCE_ROLES``.
+
+    ``Depends(require_permission("orders:write"))``. Una clave inexistente revienta
+    con ``KeyError`` al **cargar el router** (no en runtime), atrapando typos en CI.
+    """
+    return require_role(*RESOURCE_ROLES[resource])

--- a/src/modules/users/refresh_token_model.py
+++ b/src/modules/users/refresh_token_model.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.shared.database import Base
+
+
+class RefreshTokenModel(Base):
+    """Refresh token emitido al iniciar sesión: par renovable del access JWT.
+
+    Solo se guarda el ``token_hash`` (sha256), nunca el token en claro. La rotación
+    revoca el actual y emite otro (``revoked_at``); la revocación masiva (cambio de
+    contraseña, detección de reúso) marca ``revoked_at`` en lote. Un token sirve si
+    no está revocado y no ha expirado.
+    """
+
+    __tablename__ = "refresh_tokens"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id"), index=True, nullable=False
+    )
+    token_hash: Mapped[str] = mapped_column(String(64), unique=True, index=True)
+    expires_at: Mapped[datetime] = mapped_column(DateTime)
+    revoked_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)

--- a/src/modules/users/refresh_token_service.py
+++ b/src/modules/users/refresh_token_service.py
@@ -1,0 +1,108 @@
+"""Ciclo de vida de los refresh tokens: emisión, rotación y revocación.
+
+El access token (JWT) es corto; el refresh es largo y opaco, y se canjea en
+``/auth/refresh`` por un par nuevo. Diseño:
+
+- **Rotación**: cada refresh se usa una sola vez. ``rotate`` revoca el presentado
+  y emite otro, de modo que un refresh válido cambia en cada renovación.
+- **Detección de reúso**: si llega un refresh ya revocado (señal de robo: alguien
+  reusó uno que ya rotó), se revoca **toda** la familia del usuario y se rechaza.
+- **Revocación**: ``revoke`` (logout) y ``revoke_all_for_user`` (cambio de
+  contraseña) marcan ``revoked_at``.
+
+Solo se persiste el sha256 del token (``hash_token``); el token en claro existe
+únicamente en la respuesta al cliente.
+"""
+
+from datetime import datetime, timedelta
+from typing import Optional, Tuple
+
+from fastapi import Depends
+from sqlalchemy.orm import Session
+
+from src.modules.users.model import UserModel
+from src.modules.users.refresh_token_model import RefreshTokenModel
+from src.shared.config import config
+from src.shared.database import get_db
+from src.shared.exceptions import AuthenticationError
+from src.shared.security import generate_refresh_token, hash_token
+
+# Mensaje uniforme: no distingue inexistente/expirado/revocado (sin oráculo).
+_INVALID = "Sesión inválida o expirada"
+
+
+class RefreshTokenService:
+    """Emite, rota y revoca refresh tokens contra la tabla ``refresh_tokens``."""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    def issue(self, user_id: int) -> str:
+        """Crea un refresh token para el usuario y devuelve el token en claro."""
+        raw = generate_refresh_token()
+        self.db.add(
+            RefreshTokenModel(
+                user_id=user_id,
+                token_hash=hash_token(raw),
+                expires_at=self._expiry(),
+            )
+        )
+        self.db.commit()
+        return raw
+
+    def rotate(self, raw: str) -> Tuple[UserModel, str]:
+        """Valida el refresh, lo revoca y emite uno nuevo: ``(usuario, token_nuevo)``."""
+        record = self._get(raw)
+        if record is None or record.expires_at <= datetime.utcnow():
+            raise AuthenticationError(_INVALID)
+        if record.revoked_at is not None:
+            # Reúso de un token ya rotado: posible robo. Revoca toda la familia.
+            self.revoke_all_for_user(record.user_id)
+            raise AuthenticationError(_INVALID)
+
+        user = self.db.get(UserModel, record.user_id)
+        if user is None or not user.is_active:
+            raise AuthenticationError("Usuario no encontrado o inactivo")
+
+        record.revoked_at = datetime.utcnow()
+        raw_new = generate_refresh_token()
+        self.db.add(
+            RefreshTokenModel(
+                user_id=user.id,
+                token_hash=hash_token(raw_new),
+                expires_at=self._expiry(),
+            )
+        )
+        self.db.commit()
+        return user, raw_new
+
+    def revoke(self, raw: str) -> None:
+        """Revoca un refresh token (logout). No-op si no existe o ya está revocado."""
+        record = self._get(raw)
+        if record is not None and record.revoked_at is None:
+            record.revoked_at = datetime.utcnow()
+            self.db.commit()
+
+    def revoke_all_for_user(self, user_id: int) -> None:
+        """Revoca todos los refresh tokens activos del usuario (cambio de contraseña)."""
+        self.db.query(RefreshTokenModel).filter(
+            RefreshTokenModel.user_id == user_id,
+            RefreshTokenModel.revoked_at.is_(None),
+        ).update({RefreshTokenModel.revoked_at: datetime.utcnow()})
+        self.db.commit()
+
+    def _get(self, raw: str) -> Optional[RefreshTokenModel]:
+        return (
+            self.db.query(RefreshTokenModel)
+            .filter(RefreshTokenModel.token_hash == hash_token(raw))
+            .first()
+        )
+
+    @staticmethod
+    def _expiry() -> datetime:
+        return datetime.utcnow() + timedelta(days=config.REFRESH_TOKEN_EXPIRE_DAYS)
+
+
+def refresh_token_service(db: Session = Depends(get_db)) -> RefreshTokenService:
+    """Provider de ``RefreshTokenService`` para inyección en rutas."""
+    return RefreshTokenService(db)

--- a/src/modules/users/router.py
+++ b/src/modules/users/router.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, Query
 
+from src.modules.users.dependencies import require_permission
 from src.modules.users.schemas import UserCreate, UserResponse, UserUpdate
 from src.modules.users.service import UserService, user_service
 from src.shared.pagination import PageParams
@@ -13,9 +14,13 @@ from src.shared.responses import (
     page,
 )
 
-# Nota: en esta fase el CRUD queda abierto. El enforcement (solo "administrador")
-# se añadirá con Depends(require_role(UserRole.ADMIN)) según permissions.py.
-router = APIRouter(prefix="/users", tags=["users"], responses=ERROR_RESPONSES)
+# Gestión de usuarios: solo "administrador" (RESOURCE_ROLES["users:manage"]).
+router = APIRouter(
+    prefix="/users",
+    tags=["users"],
+    responses=ERROR_RESPONSES,
+    dependencies=[Depends(require_permission("users:manage"))],
+)
 
 
 @router.post("/", response_model=DataResponse[UserResponse], status_code=201)

--- a/src/modules/users/schemas.py
+++ b/src/modules/users/schemas.py
@@ -46,15 +46,41 @@ class UserResponse(UserBase):
     created_at: datetime = Field(..., description="Fecha de creación")
 
 
+class ProfileUpdate(CamelModel):
+    """Autoservicio: el propio usuario edita su perfil (solo ``fullName``)."""
+
+    full_name: Optional[str] = Field(
+        None, max_length=128, description="Nombre completo"
+    )
+
+
+class ChangePasswordRequest(CamelModel):
+    """Autoservicio: cambio de la propia contraseña verificando la actual."""
+
+    current_password: str = Field(..., description="Contraseña actual")
+    new_password: str = Field(
+        ..., min_length=8, max_length=128, description="Nueva contraseña"
+    )
+
+
 class LoginRequest(CamelModel):
     email: EmailStr = Field(..., description="Email de login")
     password: str = Field(..., description="Contraseña")
 
 
-class TokenResponse(CamelModel):
-    """Respuesta del login: token de acceso + datos del usuario autenticado."""
+class RefreshRequest(CamelModel):
+    """Canje del refresh token por un par nuevo en ``/auth/refresh``."""
 
-    access_token: str = Field(..., description="JWT de acceso")
+    refresh_token: str = Field(..., description="Refresh token opaco emitido al login")
+
+
+class TokenResponse(CamelModel):
+    """Respuesta de login/refresh: par de tokens + datos del usuario autenticado."""
+
+    access_token: str = Field(..., description="JWT de acceso (corto)")
+    refresh_token: str = Field(
+        ..., description="Refresh token opaco (largo, revocable)"
+    )
     token_type: str = Field(default="bearer", description="Tipo de token")
-    expires_in: int = Field(..., description="Vigencia del token en segundos")
+    expires_in: int = Field(..., description="Vigencia del access token en segundos")
     user: UserResponse = Field(..., description="Usuario autenticado")

--- a/src/modules/users/service.py
+++ b/src/modules/users/service.py
@@ -5,9 +5,10 @@ from sqlalchemy.orm import Session
 
 from src.modules.users.enums import UserRole
 from src.modules.users.model import UserModel
-from src.modules.users.schemas import UserCreate, UserUpdate
+from src.modules.users.schemas import ProfileUpdate, UserCreate, UserUpdate
 from src.shared.crud import CRUDService
 from src.shared.database import get_db
+from src.shared.exceptions import AuthenticationError
 from src.shared.security import hash_password, verify_password
 
 
@@ -38,6 +39,27 @@ class UserService(CRUDService[UserModel, UserCreate, UserUpdate]):
         for field, value in changes.items():
             setattr(obj, field, value)
         return self._persist(obj)
+
+    def update_profile(self, user: UserModel, data: ProfileUpdate) -> UserModel:
+        """Autoservicio: el propio usuario edita su perfil (solo ``full_name``).
+
+        No toca ``role``/``is_active``/``email``: eso es gestión y vive en el CRUD
+        solo-admin. Semántica PATCH: solo aplica los campos enviados.
+        """
+        for field, value in data.model_dump(exclude_unset=True).items():
+            setattr(user, field, value)
+        return self._persist(user)
+
+    def change_password(self, user: UserModel, current: str, new: str) -> None:
+        """Autoservicio: cambia la propia contraseña verificando la actual.
+
+        Lanza ``AuthenticationError`` (401) si la contraseña actual no coincide.
+        El caller revoca los refresh tokens para forzar re-login en otros equipos.
+        """
+        if not verify_password(current, user.hashed_password):
+            raise AuthenticationError("La contraseña actual es incorrecta")
+        user.hashed_password = hash_password(new)
+        self._persist(user)
 
     def get_by_email(self, email: str) -> Optional[UserModel]:
         """Obtiene un usuario por email (identificador de login)."""

--- a/src/shared/config.py
+++ b/src/shared/config.py
@@ -65,9 +65,12 @@ class Config:
 
     # JWT (autenticación). HS256 firma con SECRET_KEY; el access token expira a los
     # ACCESS_TOKEN_EXPIRE_MINUTES. En producción SECRET_KEY es obligatorio (arriba);
-    # en otros entornos cae a un placeholder de desarrollo.
+    # en otros entornos cae a un placeholder de desarrollo. El access token es corto
+    # (renovable vía /auth/refresh): el front presenta el refresh token y obtiene un
+    # par nuevo. REFRESH_TOKEN_EXPIRE_DAYS acota la vida del refresh (opaco, revocable).
     JWT_ALGORITHM = env("JWT_ALGORITHM", "HS256")
-    ACCESS_TOKEN_EXPIRE_MINUTES = env.int("ACCESS_TOKEN_EXPIRE_MINUTES", 480)
+    ACCESS_TOKEN_EXPIRE_MINUTES = env.int("ACCESS_TOKEN_EXPIRE_MINUTES", 30)
+    REFRESH_TOKEN_EXPIRE_DAYS = env.int("REFRESH_TOKEN_EXPIRE_DAYS", 30)
 
     # Semilla del primer administrador (migración idempotente). Si ambos están
     # definidos y no existe un usuario con ese email, la migración lo crea con rol

--- a/src/shared/security.py
+++ b/src/shared/security.py
@@ -6,6 +6,8 @@ Infraestructura sin dependencias de FastAPI/SQLAlchemy. El módulo de usuarios
 de ``shared.config``.
 """
 
+import hashlib
+import secrets
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
@@ -65,3 +67,21 @@ def decode_access_token(token: str) -> dict:
         raise AuthenticationError("El token de sesión expiró") from exc
     except jwt.InvalidTokenError as exc:
         raise AuthenticationError("Token de sesión inválido") from exc
+
+
+def generate_refresh_token() -> str:
+    """Genera un refresh token opaco de 256 bits (CSPRNG).
+
+    Es la credencial que canjea ``/auth/refresh`` por un nuevo access token. Opaco
+    (no JWT) para poder revocarlo: en reposo solo se guarda su ``hash_token``.
+    """
+    return secrets.token_urlsafe(32)
+
+
+def hash_token(raw: str) -> str:
+    """sha256 hex de un token opaco. Se persiste el hash, nunca el token en claro.
+
+    Un token aleatorio de 256 bits es su propio salt, por eso sha256 sin salt basta
+    (mismo criterio que los enlaces de revisión de pre-órdenes).
+    """
+    return hashlib.sha256(raw.encode()).hexdigest()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,9 +15,16 @@ import src.modules.preorders.model  # noqa: F401,E402
 import src.modules.products.model  # noqa: F401,E402
 import src.modules.settings.model  # noqa: F401,E402
 import src.modules.users.model  # noqa: F401,E402
+import src.modules.users.refresh_token_model  # noqa: F401,E402
 from main import app
+from src.modules.users.schemas import UserCreate
+from src.modules.users.service import UserService
 from src.shared.cache import cache
 from src.shared.database import Base, get_db
+
+# Credenciales del admin que el cliente autenticado por defecto usa (ver ``client``).
+_CONFTEST_ADMIN_EMAIL = "conftest-admin@empresa.com"
+_CONFTEST_ADMIN_PWD = "conftest-admin-pwd"
 
 
 class _InMemoryRedis:
@@ -66,8 +73,12 @@ def db_session():
 
 
 @pytest.fixture
-def client(db_session):
-    """TestClient con ``get_db`` apuntando a la base aislada del test."""
+def anon_client(db_session):
+    """TestClient sin autenticación, con ``get_db`` sobre la base aislada del test.
+
+    Para los tests de auth (login, refresh, enforcement por rol), que controlan el
+    header ``Authorization`` por request. El resto de suites usa ``client``.
+    """
 
     def override_get_db():
         try:
@@ -79,3 +90,31 @@ def client(db_session):
     with TestClient(app) as test_client:
         yield test_client
     app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def client(anon_client, db_session):
+    """TestClient autenticado como administrador por defecto.
+
+    El enforcement RBAC protege casi todos los endpoints; para que las suites de
+    cada módulo prueben su lógica sin fricción de auth, este cliente adjunta por
+    defecto el Bearer de un admin sembrado. Los tests que necesitan controlar la
+    autenticación (``test_users.py``) usan ``anon_client``.
+    """
+    svc = UserService(db_session)
+    if svc.get_by_email(_CONFTEST_ADMIN_EMAIL) is None:
+        svc.create(
+            UserCreate(
+                email=_CONFTEST_ADMIN_EMAIL,
+                password=_CONFTEST_ADMIN_PWD,
+                role="administrador",
+                full_name="Conftest Admin",
+            )
+        )
+    resp = anon_client.post(
+        "/api/v1/auth/login",
+        json={"email": _CONFTEST_ADMIN_EMAIL, "password": _CONFTEST_ADMIN_PWD},
+    )
+    token = resp.json()["data"]["accessToken"]
+    anon_client.headers.update({"Authorization": f"Bearer {token}"})
+    return anon_client

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -148,6 +148,8 @@ def test_unhandled_exception_returns_500_envelope(db_session, monkeypatch):
         raise RuntimeError("boom")
 
     from src.modules.products.service import ProductService
+    from src.modules.users.schemas import UserCreate
+    from src.modules.users.service import UserService
 
     monkeypatch.setattr(ProductService, "get_or_404", _boom)
 
@@ -157,7 +159,23 @@ def test_unhandled_exception_returns_500_envelope(db_session, monkeypatch):
     app.dependency_overrides[get_db] = override_get_db
     try:
         with TestClient(app, raise_server_exceptions=False) as test_client:
-            resp = test_client.get("/api/v1/products/1")
+            # El endpoint exige auth: autentica como admin para llegar al handler
+            # (donde el monkeypatch dispara la excepción no controlada).
+            UserService(db_session).create(
+                UserCreate(
+                    email="boom-admin@empresa.com",
+                    password="boom-admin-pwd",
+                    role="administrador",
+                    full_name="Boom",
+                )
+            )
+            token = test_client.post(
+                "/api/v1/auth/login",
+                json={"email": "boom-admin@empresa.com", "password": "boom-admin-pwd"},
+            ).json()["data"]["accessToken"]
+            resp = test_client.get(
+                "/api/v1/products/1", headers={"Authorization": f"Bearer {token}"}
+            )
         assert resp.status_code == 500
         body = resp.json()
         assert body["errors"][0]["code"] == "INTERNAL_SERVER_ERROR"

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,11 +1,13 @@
-"""Tests del módulo users: helpers de seguridad, CRUD, login y dependencias."""
+"""Tests del módulo users: seguridad, CRUD, login, refresh, autoservicio y RBAC."""
 
 import pytest
 
-from src.modules.users.dependencies import require_role
+from src.modules.users.dependencies import require_permission, require_role
 from src.modules.users.enums import UserRole
 from src.modules.users.model import UserModel
 from src.modules.users.permissions import RESOURCE_ROLES
+from src.modules.users.schemas import UserCreate
+from src.modules.users.service import UserService
 from src.shared.exceptions import AuthenticationError, AuthorizationError
 from src.shared.security import (
     create_access_token,
@@ -13,6 +15,18 @@ from src.shared.security import (
     hash_password,
     verify_password,
 )
+
+_PWD = "supersecret123"
+
+
+@pytest.fixture
+def client(anon_client):
+    """En esta suite ``client`` es el cliente SIN autenticación por defecto.
+
+    Sobreescribe el ``client`` admin-autenticado de ``conftest`` para poder probar
+    el login, el refresh y el enforcement por rol controlando el header a mano.
+    """
+    return anon_client
 
 
 def _user_payload(
@@ -29,8 +43,8 @@ def _user_payload(
     }
 
 
-def _create_user(client, **kw):
-    return client.post("/api/v1/users/", json=_user_payload(**kw))
+def _auth_header(token):
+    return {"Authorization": f"Bearer {token}"}
 
 
 def _login(client, email, password):
@@ -39,8 +53,34 @@ def _login(client, email, password):
     )
 
 
-def _auth_header(token):
-    return {"Authorization": f"Bearer {token}"}
+def _token(client, email, password=_PWD):
+    return _login(client, email, password).json()["data"]["accessToken"]
+
+
+@pytest.fixture
+def auth(client, db_session):
+    """Factory de headers Bearer por rol (siembra el usuario y hace login).
+
+    ``auth("administrador")`` -> headers autenticados de un admin. Siembra directo
+    en la BD (sin pasar por el CRUD protegido) y reusa la sesión del ``client``.
+    """
+
+    def _for(role: str, email: str | None = None):
+        email = email or f"{role}@empresa.com"
+        svc = UserService(db_session)
+        if svc.get_by_email(email) is None:
+            svc.create(
+                UserCreate(
+                    email=email, password=_PWD, role=role, full_name=role.title()
+                )
+            )
+        return _auth_header(_token(client, email))
+
+    return _for
+
+
+def _create_user(client, headers, **kw):
+    return client.post("/api/v1/users/", json=_user_payload(**kw), headers=headers)
 
 
 # --- Helpers de seguridad (unitarios, sin DB) -------------------------------
@@ -77,7 +117,7 @@ def test_tampered_token_raises_authentication_error():
         decode_access_token(tampered)
 
 
-# --- require_role (unitario) ------------------------------------------------
+# --- require_role / require_permission (unitarios) --------------------------
 
 
 def _fake_user(role):
@@ -102,66 +142,90 @@ def test_require_role_blocks_other_role():
         dep(current_user=_fake_user("operador"))
 
 
-# --- CRUD vía API -----------------------------------------------------------
+def test_require_permission_resolves_matrix():
+    dep = require_permission("orders:read")  # admin + vendedor + operador
+    assert dep(current_user=_fake_user("operador")).role == "operador"
 
 
-def test_create_user_hashes_password_and_hides_it(client):
-    resp = _create_user(client)
+def test_require_permission_blocks_disallowed_role():
+    dep = require_permission("users:manage")  # solo admin
+    with pytest.raises(AuthorizationError):
+        dep(current_user=_fake_user("vendedor"))
+
+
+def test_require_permission_unknown_key_raises_keyerror():
+    # Un typo en la clave revienta al construir la dependencia (carga del router).
+    with pytest.raises(KeyError):
+        require_permission("does:not:exist")
+
+
+# --- CRUD de usuarios (vía API, como admin) ---------------------------------
+
+
+def test_create_user_hashes_password_and_hides_it(client, auth):
+    resp = _create_user(client, auth("administrador"))
     assert resp.status_code == 201
     data = resp.json()["data"]
     assert data["email"] == "seller@empresa.com"
     assert data["role"] == "vendedor"
     assert data["isActive"] is True
     assert "id" in data
-    # La contraseña ni su hash se exponen jamás.
     assert "password" not in data
     assert "hashedPassword" not in data
 
 
-def test_create_user_role_is_case_insensitive(client):
-    resp = _create_user(client, email="admin2@empresa.com", role="ADMINISTRADOR")
+def test_create_user_role_is_case_insensitive(client, auth):
+    resp = _create_user(
+        client, auth("administrador"), email="admin2@empresa.com", role="ADMINISTRADOR"
+    )
     assert resp.status_code == 201
     assert resp.json()["data"]["role"] == "administrador"
 
 
-def test_create_duplicate_email_returns_409(client):
-    _create_user(client)
-    dup = _create_user(client, full_name="Otro")
+def test_create_duplicate_email_returns_409(client, auth):
+    admin = auth("administrador")
+    _create_user(client, admin)
+    dup = _create_user(client, admin, full_name="Otro")
     assert dup.status_code == 409
     assert dup.json()["errors"][0]["message"] == "El email ya está registrado"
 
 
-def test_invalid_email_returns_422(client):
-    resp = _create_user(client, email="no-es-email")
+def test_invalid_email_returns_422(client, auth):
+    resp = _create_user(client, auth("administrador"), email="no-es-email")
     assert resp.status_code == 422
 
 
-def test_short_password_returns_422(client):
-    resp = _create_user(client, password="short")
+def test_short_password_returns_422(client, auth):
+    resp = _create_user(client, auth("administrador"), password="short")
     assert resp.status_code == 422
 
 
-def test_get_missing_user_returns_404(client):
-    resp = client.get("/api/v1/users/999999")
+def test_get_missing_user_returns_404(client, auth):
+    resp = client.get("/api/v1/users/999999", headers=auth("administrador"))
     assert resp.status_code == 404
     assert resp.json()["errors"][0]["code"] == "NOT_FOUND"
 
 
-def test_list_and_search_users(client):
-    _create_user(client, email="ana@empresa.com", full_name="Ana")
-    _create_user(client, email="beto@empresa.com", full_name="Beto")
-    all_users = client.get("/api/v1/users/")
+def test_list_and_search_users(client, auth):
+    admin = auth("administrador")
+    _create_user(client, admin, email="ana@empresa.com", full_name="Ana")
+    _create_user(client, admin, email="beto@empresa.com", full_name="Beto")
+    all_users = client.get("/api/v1/users/", headers=admin)
     assert all_users.status_code == 200
-    assert all_users.json()["meta"]["pagination"]["total"] == 2
-    found = client.get("/api/v1/users/", params={"search": "ana"})
+    # El admin sembrado por la fixture también cuenta.
+    emails = {u["email"] for u in all_users.json()["data"]}
+    assert {"ana@empresa.com", "beto@empresa.com"} <= emails
+    found = client.get("/api/v1/users/", params={"search": "ana"}, headers=admin)
     assert [u["email"] for u in found.json()["data"]] == ["ana@empresa.com"]
 
 
-def test_update_user_fields(client):
-    created = _create_user(client).json()["data"]
+def test_update_user_fields(client, auth):
+    admin = auth("administrador")
+    created = _create_user(client, admin).json()["data"]
     resp = client.put(
         f"/api/v1/users/{created['id']}",
         json={"fullName": "Nuevo Nombre", "role": "operador"},
+        headers=admin,
     )
     assert resp.status_code == 200
     data = resp.json()["data"]
@@ -169,70 +233,145 @@ def test_update_user_fields(client):
     assert data["role"] == "operador"
 
 
-def test_update_password_allows_login_with_new_password(client):
-    created = _create_user(client).json()["data"]
-    client.put(f"/api/v1/users/{created['id']}", json={"password": "brand-new-pass"})
-    # La contraseña vieja deja de servir; la nueva funciona.
+def test_update_password_allows_login_with_new_password(client, auth):
+    admin = auth("administrador")
+    created = _create_user(client, admin).json()["data"]
+    client.put(
+        f"/api/v1/users/{created['id']}",
+        json={"password": "brand-new-pass"},
+        headers=admin,
+    )
     assert _login(client, "seller@empresa.com", "supersecret").status_code == 401
     assert _login(client, "seller@empresa.com", "brand-new-pass").status_code == 200
 
 
-def test_delete_user(client):
-    created = _create_user(client).json()["data"]
-    assert client.delete(f"/api/v1/users/{created['id']}").status_code == 204
-    assert client.get(f"/api/v1/users/{created['id']}").status_code == 404
+def test_delete_user(client, auth):
+    admin = auth("administrador")
+    created = _create_user(client, admin).json()["data"]
+    assert (
+        client.delete(f"/api/v1/users/{created['id']}", headers=admin).status_code
+        == 204
+    )
+    assert (
+        client.get(f"/api/v1/users/{created['id']}", headers=admin).status_code == 404
+    )
 
 
-# --- Login / auth -----------------------------------------------------------
+def test_create_user_invalid_role_returns_422(client, auth):
+    resp = _create_user(client, auth("administrador"), role="superusuario")
+    assert resp.status_code == 422
 
 
-def test_login_success_returns_token_and_user(client):
-    _create_user(client)
-    resp = _login(client, "seller@empresa.com", "supersecret")
+# --- Login / refresh / logout -----------------------------------------------
+
+
+def test_login_success_returns_token_pair_and_user(client, auth):
+    auth("administrador")  # siembra + asegura que el login funciona
+    resp = _login(client, "administrador@empresa.com", _PWD)
     assert resp.status_code == 200
     data = resp.json()["data"]
     assert data["tokenType"] == "bearer"
     assert data["accessToken"]
+    assert data["refreshToken"]
     assert data["expiresIn"] > 0
-    assert data["user"]["email"] == "seller@empresa.com"
-    assert data["user"]["role"] == "vendedor"
+    assert data["user"]["email"] == "administrador@empresa.com"
+    assert data["user"]["role"] == "administrador"
 
 
-def test_login_wrong_password_returns_401(client):
-    _create_user(client)
-    resp = _login(client, "seller@empresa.com", "incorrecta")
+def test_login_wrong_password_returns_401(client, auth):
+    auth("vendedor")
+    resp = _login(client, "vendedor@empresa.com", "incorrecta")
     assert resp.status_code == 401
     assert resp.json()["errors"][0]["code"] == "UNAUTHORIZED"
 
 
 def test_login_unknown_email_returns_401(client):
-    resp = _login(client, "nadie@empresa.com", "supersecret")
+    resp = _login(client, "nadie@empresa.com", _PWD)
     assert resp.status_code == 401
 
 
-def test_login_inactive_user_returns_401(client):
-    created = _create_user(client).json()["data"]
-    client.put(f"/api/v1/users/{created['id']}", json={"isActive": False})
-    resp = _login(client, "seller@empresa.com", "supersecret")
+def test_login_inactive_user_returns_401(client, auth):
+    admin = auth("administrador")
+    created = _create_user(client, admin).json()["data"]
+    client.put(
+        f"/api/v1/users/{created['id']}", json={"isActive": False}, headers=admin
+    )
+    assert _login(client, "seller@empresa.com", "supersecret").status_code == 401
+
+
+def test_refresh_rotates_tokens_and_invalidates_old(client, auth):
+    auth("vendedor")
+    first = _login(client, "vendedor@empresa.com", _PWD).json()["data"]
+    rotated = client.post(
+        "/api/v1/auth/refresh", json={"refreshToken": first["refreshToken"]}
+    )
+    assert rotated.status_code == 200
+    new = rotated.json()["data"]
+    assert new["accessToken"] and new["refreshToken"]
+    assert new["refreshToken"] != first["refreshToken"]
+    # El refresh viejo ya no sirve (rotación).
+    reuse = client.post(
+        "/api/v1/auth/refresh", json={"refreshToken": first["refreshToken"]}
+    )
+    assert reuse.status_code == 401
+
+
+def test_refresh_unknown_token_returns_401(client):
+    resp = client.post("/api/v1/auth/refresh", json={"refreshToken": "no-existe"})
     assert resp.status_code == 401
+
+
+def test_refresh_reuse_revokes_whole_family(client, auth):
+    auth("vendedor")
+    first = _login(client, "vendedor@empresa.com", _PWD).json()["data"]
+    second = client.post(
+        "/api/v1/auth/refresh", json={"refreshToken": first["refreshToken"]}
+    ).json()["data"]
+    # Reusar el primero (ya rotado) dispara la detección de robo.
+    assert (
+        client.post(
+            "/api/v1/auth/refresh", json={"refreshToken": first["refreshToken"]}
+        ).status_code
+        == 401
+    )
+    # …y revoca también el segundo (familia entera).
+    assert (
+        client.post(
+            "/api/v1/auth/refresh", json={"refreshToken": second["refreshToken"]}
+        ).status_code
+        == 401
+    )
+
+
+def test_logout_revokes_refresh_token(client, auth):
+    auth("vendedor")
+    tokens = _login(client, "vendedor@empresa.com", _PWD).json()["data"]
+    assert (
+        client.post(
+            "/api/v1/auth/logout", json={"refreshToken": tokens["refreshToken"]}
+        ).status_code
+        == 204
+    )
+    assert (
+        client.post(
+            "/api/v1/auth/refresh", json={"refreshToken": tokens["refreshToken"]}
+        ).status_code
+        == 401
+    )
 
 
 # --- get_current_user vía /auth/me ------------------------------------------
 
 
-def test_me_with_valid_token(client):
-    _create_user(client)
-    token = _login(client, "seller@empresa.com", "supersecret").json()["data"][
-        "accessToken"
-    ]
-    resp = client.get("/api/v1/auth/me", headers=_auth_header(token))
+def test_me_with_valid_token(client, auth):
+    headers = auth("vendedor")
+    resp = client.get("/api/v1/auth/me", headers=headers)
     assert resp.status_code == 200
-    assert resp.json()["data"]["email"] == "seller@empresa.com"
+    assert resp.json()["data"]["email"] == "vendedor@empresa.com"
 
 
 def test_me_without_token_returns_401(client):
-    resp = client.get("/api/v1/auth/me")
-    assert resp.status_code == 401
+    assert client.get("/api/v1/auth/me").status_code == 401
 
 
 def test_me_with_invalid_token_returns_401(client):
@@ -240,26 +379,161 @@ def test_me_with_invalid_token_returns_401(client):
     assert resp.status_code == 401
 
 
-def test_me_with_token_of_deleted_user_returns_401(client):
-    created = _create_user(client).json()["data"]
-    token = _login(client, "seller@empresa.com", "supersecret").json()["data"][
-        "accessToken"
-    ]
-    client.delete(f"/api/v1/users/{created['id']}")
-    resp = client.get("/api/v1/auth/me", headers=_auth_header(token))
-    assert resp.status_code == 401
+def test_me_with_token_of_deleted_user_returns_401(client, auth):
+    admin = auth("administrador")
+    created = _create_user(client, admin).json()["data"]
+    token = _token(client, "seller@empresa.com", "supersecret")
+    client.delete(f"/api/v1/users/{created['id']}", headers=admin)
+    assert client.get("/api/v1/auth/me", headers=_auth_header(token)).status_code == 401
 
 
 def test_me_with_nonnumeric_subject_returns_401(client):
-    # Token bien firmado pero con un 'sub' no numérico: la dependencia lo rechaza.
     token = create_access_token(subject="no-soy-un-id", role="vendedor")
-    resp = client.get("/api/v1/auth/me", headers=_auth_header(token))
+    assert client.get("/api/v1/auth/me", headers=_auth_header(token)).status_code == 401
+
+
+# --- Autoservicio: PATCH /auth/me + change-password -------------------------
+
+
+def test_update_me_changes_full_name_only(client, auth):
+    headers = auth("operador")
+    resp = client.patch(
+        "/api/v1/auth/me",
+        json={"fullName": "Operario Renombrado", "role": "administrador"},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["fullName"] == "Operario Renombrado"
+    # El rol NO se puede auto-cambiar: el campo extra se ignora.
+    assert data["role"] == "operador"
+
+
+def test_update_me_requires_auth(client):
+    assert client.patch("/api/v1/auth/me", json={"fullName": "x"}).status_code == 401
+
+
+def test_change_password_revokes_sessions_and_rotates_credential(client, auth):
+    auth("vendedor")
+    session = _login(client, "vendedor@empresa.com", _PWD).json()["data"]
+    headers = _auth_header(session["accessToken"])
+    resp = client.post(
+        "/api/v1/auth/change-password",
+        json={"currentPassword": _PWD, "newPassword": "nueva-clave-1"},
+        headers=headers,
+    )
+    assert resp.status_code == 204
+    # Los refresh previos quedan revocados (cierre de sesiones abiertas).
+    assert (
+        client.post(
+            "/api/v1/auth/refresh", json={"refreshToken": session["refreshToken"]}
+        ).status_code
+        == 401
+    )
+    # La clave vieja deja de servir; la nueva funciona.
+    assert _login(client, "vendedor@empresa.com", _PWD).status_code == 401
+    assert _login(client, "vendedor@empresa.com", "nueva-clave-1").status_code == 200
+
+
+def test_change_password_wrong_current_returns_401(client, auth):
+    headers = auth("vendedor")
+    resp = client.post(
+        "/api/v1/auth/change-password",
+        json={"currentPassword": "no-es", "newPassword": "otra-clave-1"},
+        headers=headers,
+    )
     assert resp.status_code == 401
 
 
-def test_create_user_invalid_role_returns_422(client):
-    resp = _create_user(client, role="superusuario")
-    assert resp.status_code == 422
+def test_change_password_requires_auth(client):
+    resp = client.post(
+        "/api/v1/auth/change-password",
+        json={"currentPassword": "x", "newPassword": "yyyyyyyy"},
+    )
+    assert resp.status_code == 401
+
+
+# --- Enforcement por permiso (representativo de la matriz) ------------------
+
+
+def test_users_endpoint_requires_admin(client, auth):
+    assert client.get("/api/v1/users/").status_code == 401  # sin token
+    assert client.get("/api/v1/users/", headers=auth("vendedor")).status_code == 403
+    assert (
+        client.get("/api/v1/users/", headers=auth("administrador")).status_code == 200
+    )
+
+
+def test_products_read_allows_seller(client, auth):
+    assert client.get("/api/v1/products/", headers=auth("vendedor")).status_code == 200
+    # El operador no entra al catálogo.
+    assert client.get("/api/v1/products/", headers=auth("operador")).status_code == 403
+
+
+def test_products_write_requires_admin(client, auth):
+    # DELETE no lleva body: la autorización decide antes de tocar el recurso.
+    assert (
+        client.delete("/api/v1/products/999", headers=auth("vendedor")).status_code
+        == 403
+    )
+    # El admin pasa la autorización; el 404 (no existe) prueba que se permitió.
+    assert (
+        client.delete("/api/v1/products/999", headers=auth("administrador")).status_code
+        == 404
+    )
+
+
+def test_analytics_is_admin_only(client, auth):
+    assert (
+        client.get("/api/v1/analytics/summary", headers=auth("vendedor")).status_code
+        == 403
+    )
+    assert (
+        client.get(
+            "/api/v1/analytics/summary", headers=auth("administrador")
+        ).status_code
+        == 200
+    )
+
+
+def test_settings_is_admin_only(client, auth):
+    assert (
+        client.get("/api/v1/settings/cutting", headers=auth("vendedor")).status_code
+        == 403
+    )
+    assert (
+        client.get(
+            "/api/v1/settings/cutting", headers=auth("administrador")
+        ).status_code
+        == 200
+    )
+
+
+def test_clients_block_operator_allow_seller(client, auth):
+    assert client.get("/api/v1/clients/", headers=auth("operador")).status_code == 403
+    assert client.get("/api/v1/clients/", headers=auth("vendedor")).status_code == 200
+
+
+def test_orders_read_allows_operator(client, auth):
+    assert client.get("/api/v1/orders/", headers=auth("operador")).status_code == 200
+
+
+def test_orders_write_blocks_operator(client, auth):
+    resp = client.patch("/api/v1/orders/999/status", json={}, headers=auth("operador"))
+    assert resp.status_code == 403
+
+
+def test_cutting_plan_allows_operator(client, auth):
+    # Permitido para operador: el 404 (orden inexistente) prueba que pasó la auth.
+    resp = client.get("/api/v1/orders/999/cutting-plan", headers=auth("operador"))
+    assert resp.status_code != 403
+    assert resp.status_code != 401
+
+
+def test_public_endpoints_need_no_auth(client):
+    assert client.get("/api/v1/health/").status_code == 200
+    # El flujo público de revisión se autentica solo por token: sin él, 404 uniforme.
+    assert client.get("/api/v1/public/review/token-desconocido").status_code == 404
 
 
 # --- Matriz de permisos (spec) ----------------------------------------------
@@ -269,6 +543,5 @@ def test_permission_matrix_reflects_roles():
     assert RESOURCE_ROLES["users:manage"] == (UserRole.ADMIN,)
     assert RESOURCE_ROLES["analytics"] == (UserRole.ADMIN,)
     assert RESOURCE_ROLES["products:read"] == (UserRole.ADMIN, UserRole.SELLER)
-    # El operador solo entra al plan de corte; no a cotizar/crear órdenes.
     assert UserRole.OPERATOR in RESOURCE_ROLES["cutting_plan"]
     assert UserRole.OPERATOR not in RESOURCE_ROLES["orders:write"]


### PR DESCRIPTION
    The users/auth module had JWT login and an unused permission matrix
    (RESOURCE_ROLES); every other endpoint was open. This wires authorization
    into the whole API and rounds out session handling.

    Authorization:
    - Add require_permission("<area>") in users/dependencies.py, resolving RESOURCE_ROLES as the single source of truth (a bad key fails at router import, not at runtime). It delegates to require_role, which checks the live DB role via get_current_user, so role changes take effect at once.
    - Apply it across the 9 routers: router-level where uniform (users, settings, analytics, clients, optimize, optimization-drafts, preorders) and per-route where it varies (products read/write, orders read/write/cutting_plan). Public by design: health/cutter, the /auth session endpoints, and the token-gated /public/review/{token}*.

    Sessions (refresh tokens):
    - login and POST /auth/refresh return a short access JWT (ACCESS_TOKEN_EXPIRE_MINUTES, default 30) plus a long opaque refresh token (refresh_tokens table stores only its sha256; REFRESH_TOKEN_EXPIRE_DAYS, default 30). refresh rotates single-use; reusing a rotated token revokes the whole user family (theft detection). POST /auth/logout revokes a refresh. New refresh_token_model.py + refresh_token_service.py and a migration.

    Self-service (any authenticated role):
    - PATCH /auth/me (fullName only) and POST /auth/change-password (verifies current password, then revokes all refresh tokens). User CRUD stays admin-only under /users/*