### PR TITLE
feat: audit trail & user attribution across models

### DIFF
--- a/alembic/versions/b4d8f1c2a9e7_add_audit_trail_and_user_attribution.py
+++ b/alembic/versions/b4d8f1c2a9e7_add_audit_trail_and_user_attribution.py
@@ -1,0 +1,155 @@
+"""add audit trail and user attribution
+
+Revision ID: b4d8f1c2a9e7
+Revises: 862298678742
+Create Date: 2026-06-17 12:00:00.000000
+
+Atribución de usuario y auditoría transversal:
+
+- ``created_by``/``updated_by`` (FK nullable a ``users``) en catálogo y agregados,
+  más ``created_at``/``updated_at`` donde faltaban (clients, products, settings).
+- Atribución real del actor en el historial de órdenes (``actor_user_id`` +
+  ``actor_label``) y quién cortó cada pieza (``cut_by`` + ``cut_by_label``).
+- Nueva tabla ``preorder_status_history`` (espejo de ``order_status_history``).
+
+Las FK son nullable: las acciones de cliente/sistema y las filas previas a esta
+funcionalidad quedan en NULL. Se usa ``batch_alter_table`` para que SQLite pueda
+añadir columnas con FK (copia-y-mueve); en Postgres es un ALTER directo.
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b4d8f1c2a9e7"
+down_revision: Union[str, None] = "862298678742"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Convención para nombrar las constraints reflejadas al recrear la tabla en SQLite.
+NAMING_CONVENTION = {
+    "ix": "ix_%(column_0_label)s",
+    "uq": "uq_%(table_name)s_%(column_0_name)s",
+    "ck": "ck_%(table_name)s_%(constraint_name)s",
+    "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+    "pk": "pk_%(table_name)s",
+}
+
+
+def _batch(table: str):
+    """``batch_alter_table`` con la convención de nombres aplicada."""
+    return op.batch_alter_table(table, naming_convention=NAMING_CONVENTION)
+
+
+def _user_fk(table: str, name: str) -> sa.Column:
+    """Columna FK nullable a ``users.id`` con nombre explícito (lo exige el batch)."""
+    return sa.Column(
+        name,
+        sa.Integer(),
+        sa.ForeignKey("users.id", name=f"fk_{table}_{name}_users"),
+        nullable=True,
+    )
+
+
+def upgrade() -> None:
+    # Catálogo y agregados: timestamps faltantes + atribución created_by/updated_by.
+    with _batch("clients") as batch:
+        batch.add_column(sa.Column("created_at", sa.DateTime(), nullable=True))
+        batch.add_column(sa.Column("updated_at", sa.DateTime(), nullable=True))
+        batch.add_column(_user_fk("clients", "created_by"))
+        batch.add_column(_user_fk("clients", "updated_by"))
+
+    with _batch("products") as batch:
+        batch.add_column(sa.Column("created_at", sa.DateTime(), nullable=True))
+        batch.add_column(sa.Column("updated_at", sa.DateTime(), nullable=True))
+        batch.add_column(_user_fk("products", "created_by"))
+        batch.add_column(_user_fk("products", "updated_by"))
+
+    with _batch("settings") as batch:
+        batch.add_column(sa.Column("created_at", sa.DateTime(), nullable=True))
+        batch.add_column(_user_fk("settings", "created_by"))
+        batch.add_column(_user_fk("settings", "updated_by"))
+
+    with _batch("orders") as batch:
+        batch.add_column(_user_fk("orders", "created_by"))
+
+    with _batch("preorders") as batch:
+        batch.add_column(_user_fk("preorders", "created_by"))
+        batch.add_column(_user_fk("preorders", "updated_by"))
+
+    # Historial de órdenes: actor real (FK + snapshot legible).
+    with _batch("order_status_history") as batch:
+        batch.add_column(_user_fk("order_status_history", "actor_user_id"))
+        batch.add_column(sa.Column("actor_label", sa.String(length=128), nullable=True))
+
+    # Plan de corte: quién cortó cada pieza.
+    with _batch("order_placed_pieces") as batch:
+        batch.add_column(_user_fk("order_placed_pieces", "cut_by"))
+        batch.add_column(sa.Column("cut_by_label", sa.String(length=128), nullable=True))
+
+    # Historial de pre-órdenes (no existía): espejo de order_status_history.
+    op.create_table(
+        "preorder_status_history",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column(
+            "preorder_id", sa.Integer(), sa.ForeignKey("preorders.id"), nullable=False
+        ),
+        sa.Column("from_status", sa.String(length=32), nullable=True),
+        sa.Column("to_status", sa.String(length=32), nullable=False),
+        sa.Column("actor", sa.String(length=32), nullable=True),
+        sa.Column(
+            "actor_user_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=True
+        ),
+        sa.Column("actor_label", sa.String(length=128), nullable=True),
+        sa.Column("note", sa.String(length=512), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_preorder_status_history_preorder_id",
+        "preorder_status_history",
+        ["preorder_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_preorder_status_history_preorder_id",
+        table_name="preorder_status_history",
+    )
+    op.drop_table("preorder_status_history")
+
+    with _batch("order_placed_pieces") as batch:
+        batch.drop_column("cut_by_label")
+        batch.drop_column("cut_by")
+
+    with _batch("order_status_history") as batch:
+        batch.drop_column("actor_label")
+        batch.drop_column("actor_user_id")
+
+    with _batch("preorders") as batch:
+        batch.drop_column("updated_by")
+        batch.drop_column("created_by")
+
+    with _batch("orders") as batch:
+        batch.drop_column("created_by")
+
+    with _batch("settings") as batch:
+        batch.drop_column("updated_by")
+        batch.drop_column("created_by")
+        batch.drop_column("created_at")
+
+    with _batch("products") as batch:
+        batch.drop_column("updated_by")
+        batch.drop_column("created_by")
+        batch.drop_column("updated_at")
+        batch.drop_column("created_at")
+
+    with _batch("clients") as batch:
+        batch.drop_column("updated_by")
+        batch.drop_column("created_by")
+        batch.drop_column("updated_at")
+        batch.drop_column("created_at")

--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ from src.modules.users.auth_router import router as auth_router
 from src.modules.users.router import router as users_router
 from src.shared.config import config
 from src.shared.errors import register_exception_handlers
-from src.shared.middleware import RequestIDMiddleware
+from src.shared.middleware import CurrentUserMiddleware, RequestIDMiddleware
 
 # Configurar logging
 logging.basicConfig(
@@ -55,6 +55,8 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+# Usuario autenticado en contexto para auditoría genérica (created_by/updated_by).
+app.add_middleware(CurrentUserMiddleware)
 # Correlación por request (requestId + header X-Request-ID). Se añade de último
 # para envolver al resto del stack y estar disponible en éxito y en error.
 app.add_middleware(RequestIDMiddleware)

--- a/src/modules/clients/model.py
+++ b/src/modules/clients/model.py
@@ -4,9 +4,10 @@ from sqlalchemy import String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from src.shared.database import Base
+from src.shared.mixins import AuditMixin, TimestampMixin
 
 
-class ClientModel(Base):
+class ClientModel(TimestampMixin, AuditMixin, Base):
     """Modelo ORM para clientes."""
 
     __tablename__ = "clients"

--- a/src/modules/orders/model.py
+++ b/src/modules/orders/model.py
@@ -63,6 +63,11 @@ class OrderModel(Base):
 
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     confirmed_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    # Quién creó la orden: staff (flujo directo) o NULL si nació de una
+    # confirmación de cliente / del sistema (la pre-orden audita ese origen).
+    created_by: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("users.id"), nullable=True
+    )
 
     client: Mapped["ClientModel"] = relationship("ClientModel")  # noqa: F821
     lines: Mapped[list["OrderLineModel"]] = relationship(
@@ -207,6 +212,10 @@ class OrderPlacedPieceModel(Base):
     # Lados canteados geométricos, tal cual el snapshot (nulo si no lleva canto).
     edges: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
     cut_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    # Quién marcó la pieza como cortada: FK al operario + etiqueta congelada.
+    # NULL mientras esté pendiente (en sincronía con ``cut_at``).
+    cut_by: Mapped[Optional[int]] = mapped_column(ForeignKey("users.id"), nullable=True)
+    cut_by_label: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
 
     order: Mapped["OrderModel"] = relationship("OrderModel")
     board: Mapped["OrderBoardModel"] = relationship(
@@ -215,7 +224,12 @@ class OrderPlacedPieceModel(Base):
 
 
 class OrderStatusHistoryModel(Base):
-    """Auditoría de transiciones de estado de una orden."""
+    """Auditoría de transiciones de estado de una orden.
+
+    ``actor`` es el TIPO de actor (``staff``/``client``/``system``); ``actor_user_id``
+    es la FK al usuario de staff (NULL para cliente/sistema) y ``actor_label`` el
+    snapshot legible del nombre al momento del hecho.
+    """
 
     __tablename__ = "order_status_history"
 
@@ -224,6 +238,10 @@ class OrderStatusHistoryModel(Base):
     from_status: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
     to_status: Mapped[str] = mapped_column(String(32))
     actor: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
+    actor_user_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("users.id"), nullable=True
+    )
+    actor_label: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
     note: Mapped[Optional[str]] = mapped_column(String(512), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
 

--- a/src/modules/orders/router.py
+++ b/src/modules/orders/router.py
@@ -17,6 +17,8 @@ from src.modules.orders.schemas import (
 from src.modules.orders.service import OrderService, order_service
 from src.modules.settings.service import SettingsService, settings_service
 from src.modules.users.dependencies import require_permission
+from src.modules.users.model import UserModel
+from src.shared.audit import staff_actor
 from src.shared.pagination import PageParams
 from src.shared.responses import (
     ERROR_RESPONSES,
@@ -68,15 +70,19 @@ def get_order(order_id: int, svc: OrderService = Depends(order_service)):
 @router.patch(
     "/{order_id}/status",
     response_model=DataResponse[OrderResponse],
-    dependencies=[_WRITE],
 )
 def update_order_status(
     order_id: int,
     data: OrderStatusUpdate,
     svc: OrderService = Depends(order_service),
+    current_user: UserModel = Depends(require_permission("orders:write")),
 ):
     """Transiciona el estado de una orden validando la máquina de estados."""
-    return ok(svc.transition(order_id, data.status, actor="sales", note=data.note))
+    return ok(
+        svc.transition(
+            order_id, data.status, actor=staff_actor(current_user), note=data.note
+        )
+    )
 
 
 @router.get(
@@ -92,19 +98,23 @@ def get_cutting_plan(order_id: int, svc: OrderService = Depends(order_service)):
 @router.patch(
     "/{order_id}/cutting-plan/pieces/{piece_id}",
     response_model=DataResponse[PieceCutResponse],
-    dependencies=[_CUTTING],
 )
 def mark_piece_cut(
     order_id: int,
     piece_id: int,
     data: PieceCutUpdate,
     svc: OrderService = Depends(order_service),
+    current_user: UserModel = Depends(require_permission("cutting_plan")),
 ):
     """Marca (o desmarca, ``cut=false``) una pieza colocada como cortada.
 
     Solo con la orden ``in_production``. Idempotente: re-marcar no cambia nada.
     """
-    return ok(svc.mark_piece_cut(order_id, piece_id, data.cut))
+    return ok(
+        svc.mark_piece_cut(
+            order_id, piece_id, data.cut, actor=staff_actor(current_user)
+        )
+    )
 
 
 @router.post(

--- a/src/modules/orders/schemas.py
+++ b/src/modules/orders/schemas.py
@@ -115,7 +115,15 @@ class OrderStatusHistoryResponse(CamelModel):
     id: int
     from_status: Optional[OrderStatus] = None
     to_status: OrderStatus
-    actor: Optional[str] = None
+    actor: Optional[str] = Field(
+        default=None, description="Actor type: staff | client | system"
+    )
+    actor_user_id: Optional[int] = Field(
+        default=None, description="Staff user id (null for client/system)"
+    )
+    actor_label: Optional[str] = Field(
+        default=None, description="Frozen actor name at the time of the action"
+    )
     note: Optional[str] = None
     created_at: datetime
 
@@ -158,6 +166,12 @@ class PlacedPieceResponse(CamelModel):
     )
     cut: bool = Field(..., description="Whether the piece was already cut")
     cut_at: Optional[datetime] = None
+    cut_by: Optional[int] = Field(
+        default=None, description="User id who cut the piece (null while pending)"
+    )
+    cut_by_label: Optional[str] = Field(
+        default=None, description="Frozen name of who cut the piece"
+    )
 
 
 class CuttingProgress(CamelModel):

--- a/src/modules/orders/service.py
+++ b/src/modules/orders/service.py
@@ -30,6 +30,7 @@ from src.modules.orders.schemas import (
     PieceCutResponse,
     PlacedPieceResponse,
 )
+from src.shared.audit import Actor, system_actor
 from src.shared.database import get_db
 from src.shared.exceptions import BusinessRuleError, ConflictError, EntityNotFoundError
 
@@ -61,11 +62,13 @@ class OrderService:
         orders = query.order_by(OrderModel.id.desc()).offset(offset).limit(limit).all()
         return orders, total
 
-    def create(self, data: OrderCreate) -> OrderModel:
+    def create(self, data: OrderCreate, actor: Optional[Actor] = None) -> OrderModel:
         """Recalcula (cache-first), congela el snapshot y crea la orden.
 
         Idempotente: un re-POST idéntico devuelve la orden activa existente.
+        ``actor`` audita el origen (cliente al confirmar la pre-orden, o sistema).
         """
+        actor = actor or system_actor()
         # Regla de negocio: el cliente debe existir y tener un celular registrado
         # antes de congelar cualquier pedido (también bloquea re-POST sin celular).
         client = self.db.get(ClientModel, data.client_id)
@@ -108,6 +111,7 @@ class OrderService:
             notes=data.notes,
             created_at=now,
             confirmed_at=now,
+            created_by=actor.user_id,
         )
         # Líneas de cobro = tableros usados + tapacantos (productos consumidos).
         order.lines = [
@@ -159,7 +163,9 @@ class OrderService:
             OrderStatusHistoryModel(
                 from_status=None,
                 to_status=data.status.value,
-                actor="system",
+                actor=actor.type,
+                actor_user_id=actor.user_id,
+                actor_label=actor.label,
                 note="Orden creada",
             )
         ]
@@ -175,14 +181,15 @@ class OrderService:
         self,
         order_id: int,
         to_status: OrderStatus,
-        actor: str = "system",
+        actor: Optional[Actor] = None,
         note: Optional[str] = None,
     ) -> OrderModel:
         """Valida y aplica una transición de estado, registrando el historial.
 
         Gate de producción: pasar a ``cut`` exige que todas las piezas del plan
-        de corte estén marcadas como cortadas.
+        de corte estén marcadas como cortadas. ``actor`` audita quién la origina.
         """
+        actor = actor or system_actor()
         order = self.get_or_404(order_id)
         if (
             to_status == OrderStatus.cut
@@ -235,13 +242,19 @@ class OrderService:
         )
 
     def mark_piece_cut(
-        self, order_id: int, placed_piece_id: int, cut: bool
+        self,
+        order_id: int,
+        placed_piece_id: int,
+        cut: bool,
+        actor: Optional[Actor] = None,
     ) -> PieceCutResponse:
         """Marca (o desmarca) una pieza colocada como cortada, idempotente.
 
         Solo con la orden ``in_production``: antes no hay nada que cortar y
-        después el corte ya quedó cerrado por la transición.
+        después el corte ya quedó cerrado por la transición. ``actor`` registra
+        quién la cortó (FK + etiqueta), en sincronía con ``cut_at``.
         """
+        actor = actor or system_actor()
         order = self.get_or_404(order_id)
         self._ensure_cutting_plan(order)
         if order.status != OrderStatus.in_production.value:
@@ -253,8 +266,12 @@ class OrderService:
             raise EntityNotFoundError("OrderPlacedPiece", placed_piece_id)
         if cut and piece.cut_at is None:
             piece.cut_at = datetime.utcnow()
+            piece.cut_by = actor.user_id
+            piece.cut_by_label = actor.label
         elif not cut:
             piece.cut_at = None
+            piece.cut_by = None
+            piece.cut_by_label = None
         self.db.commit()
         self.db.refresh(piece)
         all_pieces = [p for board in order.boards for p in board.pieces]
@@ -281,7 +298,7 @@ class OrderService:
         self,
         order: OrderModel,
         to_status: OrderStatus,
-        actor: str = "system",
+        actor: Actor,
         note: Optional[str] = None,
     ) -> None:
         """Valida y aplica la transición sin commit (el llamador persiste).
@@ -298,7 +315,9 @@ class OrderService:
             OrderStatusHistoryModel(
                 from_status=current.value,
                 to_status=to_status.value,
-                actor=actor,
+                actor=actor.type,
+                actor_user_id=actor.user_id,
+                actor_label=actor.label,
                 note=note,
             )
         )
@@ -435,6 +454,8 @@ def _piece_response(piece: OrderPlacedPieceModel) -> PlacedPieceResponse:
         edges=piece.edges,
         cut=piece.cut_at is not None,
         cut_at=piece.cut_at,
+        cut_by=piece.cut_by,
+        cut_by_label=piece.cut_by_label,
     )
 
 

--- a/src/modules/preorders/model.py
+++ b/src/modules/preorders/model.py
@@ -6,6 +6,7 @@ from sqlalchemy import JSON, DateTime, ForeignKey, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.shared.database import Base
+from src.shared.mixins import AuditMixin
 
 
 class PreOrderStatus(str, Enum):
@@ -46,7 +47,7 @@ class ReviewLinkStatus(str, Enum):
     revoked = "revoked"
 
 
-class PreOrderModel(Base):
+class PreOrderModel(AuditMixin, Base):
     """Cotización mutable: inputs del optimizador + enlace de revisión del cliente.
 
     A diferencia de la Orden (snapshot inmutable congelado), la pre-orden guarda
@@ -96,6 +97,12 @@ class PreOrderModel(Base):
         cascade="all, delete-orphan",
         order_by="PreOrderReviewLinkModel.id",
     )
+    history: Mapped[list["PreOrderStatusHistoryModel"]] = relationship(
+        "PreOrderStatusHistoryModel",
+        back_populates="preorder",
+        cascade="all, delete-orphan",
+        order_by="PreOrderStatusHistoryModel.id",
+    )
 
 
 class PreOrderReviewLinkModel(Base):
@@ -123,4 +130,31 @@ class PreOrderReviewLinkModel(Base):
 
     preorder: Mapped["PreOrderModel"] = relationship(
         "PreOrderModel", back_populates="review_links"
+    )
+
+
+class PreOrderStatusHistoryModel(Base):
+    """Auditoría de transiciones de estado de una pre-orden (espejo de orders).
+
+    ``actor`` es el TIPO (``staff``/``client``/``system``); ``actor_user_id`` la FK
+    al usuario de staff (NULL para cliente/sistema) y ``actor_label`` el snapshot
+    legible del nombre al momento del hecho.
+    """
+
+    __tablename__ = "preorder_status_history"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    preorder_id: Mapped[int] = mapped_column(ForeignKey("preorders.id"), index=True)
+    from_status: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
+    to_status: Mapped[str] = mapped_column(String(32))
+    actor: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
+    actor_user_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("users.id"), nullable=True
+    )
+    actor_label: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
+    note: Mapped[Optional[str]] = mapped_column(String(512), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    preorder: Mapped["PreOrderModel"] = relationship(
+        "PreOrderModel", back_populates="history"
     )

--- a/src/modules/preorders/review_service.py
+++ b/src/modules/preorders/review_service.py
@@ -34,6 +34,7 @@ from src.modules.preorders.model import (
     ReviewLinkStatus,
 )
 from src.modules.preorders.service import PreOrderService
+from src.shared.audit import Actor, client_actor, system_actor
 from src.shared.config import config
 from src.shared.database import get_db
 from src.shared.exceptions import (
@@ -66,7 +67,9 @@ class PreOrderReviewService:
         self.preorders = PreOrderService(db)
         self.orders = OrderService(db)
 
-    def generate(self, preorder_id: int) -> Tuple[PreOrderReviewLinkModel, str]:
+    def generate(
+        self, preorder_id: int, actor: Optional[Actor] = None
+    ) -> Tuple[PreOrderReviewLinkModel, str]:
         """Crea un enlace nuevo (revocando el activo previo) y devuelve el token.
 
         Solo para pre-órdenes abiertas (``draft``/``sent``); exige que el cliente
@@ -74,6 +77,7 @@ class PreOrderReviewService:
         Transiciona la pre-orden a ``sent`` y refresca su vigencia. Devuelve
         ``(link, token_crudo)``; el token solo existe en esta respuesta.
         """
+        actor = actor or system_actor()
         preorder = self.preorders.get_or_404(preorder_id)
         if preorder.status not in {s.value for s in OPEN_STATUSES}:
             raise BusinessRuleError(
@@ -89,6 +93,14 @@ class PreOrderReviewService:
             "preorder_validity_days"
         ]
         now = datetime.utcnow()
+        if preorder.status != PreOrderStatus.sent.value:
+            self.preorders._record_transition(
+                preorder,
+                preorder.status,
+                PreOrderStatus.sent,
+                actor,
+                note="Enlace de revisión enviado",
+            )
         preorder.status = PreOrderStatus.sent.value
         preorder.sent_at = now
         preorder.expires_at = now + timedelta(days=validity_days)
@@ -139,6 +151,7 @@ class PreOrderReviewService:
         if status == PreOrderStatus.confirmed:
             return preorder  # ya confirmada: reintento benigno
 
+        actor = client_actor()
         order = self.orders.create(
             OrderCreate(
                 materials=preorder.materials,
@@ -146,10 +159,14 @@ class PreOrderReviewService:
                 client_id=preorder.client_id,
                 notes=preorder.notes,
                 source=preorder.source,
-            )
+            ),
+            actor=actor,
         )
 
         now = datetime.utcnow()
+        self.preorders._record_transition(
+            preorder, preorder.status, PreOrderStatus.confirmed, actor, note=note
+        )
         preorder.status = PreOrderStatus.confirmed.value
         preorder.confirmed_at = now
         preorder.order_id = order.id
@@ -180,6 +197,13 @@ class PreOrderReviewService:
             )
 
         now = datetime.utcnow()
+        self.preorders._record_transition(
+            preorder,
+            preorder.status,
+            PreOrderStatus.rejected,
+            client_actor(),
+            note=note,
+        )
         preorder.status = PreOrderStatus.rejected.value
         self._mark_used(link, "rejected", now, note, meta)
         self.db.commit()
@@ -209,6 +233,14 @@ class PreOrderReviewService:
 
         # 'sent' o 'changes_requested': registra/actualiza la solicitud y mantiene
         # el enlace activo (sin marcarlo usado).
+        if preorder.status != PreOrderStatus.changes_requested.value:
+            self.preorders._record_transition(
+                preorder,
+                preorder.status,
+                PreOrderStatus.changes_requested,
+                client_actor(),
+                note=note,
+            )
         preorder.status = PreOrderStatus.changes_requested.value
         preorder.client_note = note
         self.db.commit()

--- a/src/modules/preorders/router.py
+++ b/src/modules/preorders/router.py
@@ -17,7 +17,9 @@ from src.modules.preorders.schemas import (
     ReviewLinkResponse,
 )
 from src.modules.preorders.service import PreOrderService, preorder_service
-from src.modules.users.dependencies import require_permission
+from src.modules.users.dependencies import get_current_user, require_permission
+from src.modules.users.model import UserModel
+from src.shared.audit import staff_actor
 from src.shared.pagination import PageParams
 from src.shared.responses import (
     ERROR_RESPONSES,
@@ -63,15 +65,18 @@ def _detail(svc: PreOrderService, preorder: PreOrderModel) -> PreOrderResponse:
         materials=preorder.materials,
         requirements=preorder.requirements,
         optimization=svc.build_optimize_response(preorder),
+        history=preorder.history,
     )
 
 
 @router.post("/", response_model=DataResponse[PreOrderResponse], status_code=201)
 def create_preorder(
-    data: PreOrderCreate, svc: PreOrderService = Depends(preorder_service)
+    data: PreOrderCreate,
+    svc: PreOrderService = Depends(preorder_service),
+    current_user: UserModel = Depends(get_current_user),
 ):
     """Crea una pre-orden (cotización mutable) con los inputs del optimizador."""
-    return ok(_detail(svc, svc.create(data)))
+    return ok(_detail(svc, svc.create(data, actor=staff_actor(current_user))))
 
 
 @router.get("/", response_model=PaginatedResponse[PreOrderSummaryResponse])
@@ -103,9 +108,12 @@ def update_preorder(
     preorder_id: int,
     data: PreOrderUpdate,
     svc: PreOrderService = Depends(preorder_service),
+    current_user: UserModel = Depends(get_current_user),
 ):
     """Edita una pre-orden abierta (draft/sent)."""
-    return ok(_detail(svc, svc.update(preorder_id, data)))
+    return ok(
+        _detail(svc, svc.update(preorder_id, data, actor=staff_actor(current_user)))
+    )
 
 
 @router.delete("/{preorder_id}", status_code=204)
@@ -120,14 +128,16 @@ def delete_preorder(preorder_id: int, svc: PreOrderService = Depends(preorder_se
     status_code=201,
 )
 def create_review_link(
-    preorder_id: int, svc: PreOrderReviewService = Depends(preorder_review_service)
+    preorder_id: int,
+    svc: PreOrderReviewService = Depends(preorder_review_service),
+    current_user: UserModel = Depends(get_current_user),
 ):
     """Genera el enlace de revisión del cliente (revoca el anterior si existía).
 
     Transiciona la pre-orden a ``sent``. El token solo se expone en esta respuesta;
     si se pierde, se regenera.
     """
-    link, raw_token = svc.generate(preorder_id)
+    link, raw_token = svc.generate(preorder_id, actor=staff_actor(current_user))
     return ok(
         ReviewLinkResponse(
             token=raw_token,

--- a/src/modules/preorders/schemas.py
+++ b/src/modules/preorders/schemas.py
@@ -43,6 +43,25 @@ class PreOrderUpdate(CamelModel):
     source: Optional[str] = Field(default=None, max_length=32)
 
 
+class PreOrderStatusHistoryResponse(CamelModel):
+    """Entrada de auditoría de una transición de estado de la pre-orden."""
+
+    id: int
+    from_status: Optional[PreOrderStatus] = None
+    to_status: PreOrderStatus
+    actor: Optional[str] = Field(
+        default=None, description="Actor type: staff | client | system"
+    )
+    actor_user_id: Optional[int] = Field(
+        default=None, description="Staff user id (null for client/system)"
+    )
+    actor_label: Optional[str] = Field(
+        default=None, description="Frozen actor name at the time of the action"
+    )
+    note: Optional[str] = None
+    created_at: datetime
+
+
 class PreOrderResponse(CamelModel):
     """Detalle de una pre-orden con su optimización recalculada (precios vivos)."""
 
@@ -73,6 +92,7 @@ class PreOrderResponse(CamelModel):
     optimization: OptimizeResponse = Field(
         ..., description="Recomputed cutting result with live prices"
     )
+    history: List[PreOrderStatusHistoryResponse] = Field(default_factory=list)
 
 
 class PreOrderSummaryResponse(CamelModel):

--- a/src/modules/preorders/service.py
+++ b/src/modules/preorders/service.py
@@ -12,9 +12,11 @@ from src.modules.preorders.model import (
     OPEN_STATUSES,
     PreOrderModel,
     PreOrderStatus,
+    PreOrderStatusHistoryModel,
 )
 from src.modules.preorders.schemas import PreOrderCreate, PreOrderUpdate
 from src.modules.settings.service import SettingsService
+from src.shared.audit import Actor, system_actor
 from src.shared.database import get_db
 from src.shared.exceptions import BusinessRuleError, EntityNotFoundError
 
@@ -64,8 +66,11 @@ class PreOrderService:
         )
         return items, total
 
-    def create(self, data: PreOrderCreate) -> PreOrderModel:
+    def create(
+        self, data: PreOrderCreate, actor: Optional[Actor] = None
+    ) -> PreOrderModel:
         """Crea una pre-orden abierta (``draft``) con los inputs del optimizador."""
+        actor = actor or system_actor()
         if self.db.get(ClientModel, data.client_id) is None:
             raise EntityNotFoundError("Client", data.client_id)
         self._enforce_open_cap(data.client_id)
@@ -83,6 +88,10 @@ class PreOrderService:
             notes=data.notes,
             created_at=now,
             expires_at=now + timedelta(days=validity_days),
+            created_by=actor.user_id,
+        )
+        self._record_transition(
+            preorder, None, PreOrderStatus.draft, actor, note="Pre-orden creada"
         )
         self.db.add(preorder)
         self.db.flush()  # asigna id para componer el code legible
@@ -91,8 +100,11 @@ class PreOrderService:
         self.db.refresh(preorder)
         return preorder
 
-    def update(self, preorder_id: int, data: PreOrderUpdate) -> PreOrderModel:
+    def update(
+        self, preorder_id: int, data: PreOrderUpdate, actor: Optional[Actor] = None
+    ) -> PreOrderModel:
         """Edita una pre-orden abierta; rechaza si ya es terminal (confirmed/etc.)."""
+        actor = actor or system_actor()
         preorder = self.get_or_404(preorder_id)
         self._ensure_open(preorder)
         fields = data.model_dump(exclude_unset=True)
@@ -113,8 +125,16 @@ class PreOrderService:
         # Si el cliente había pedido cambios, editar = "atendido": la pre-orden
         # vuelve a 'sent' (la pelota regresa al cliente) y se limpia la solicitud.
         if preorder.status == PreOrderStatus.changes_requested.value:
+            self._record_transition(
+                preorder,
+                preorder.status,
+                PreOrderStatus.sent,
+                actor,
+                note="Cambios atendidos; reenviada al cliente",
+            )
             preorder.status = PreOrderStatus.sent.value
             preorder.client_note = None
+        preorder.updated_by = actor.user_id
         self.db.commit()
         self.db.refresh(preorder)
         return preorder
@@ -159,6 +179,26 @@ class PreOrderService:
             ],
         )
 
+    def _record_transition(
+        self,
+        preorder: PreOrderModel,
+        from_status: Optional[str],
+        to_status: PreOrderStatus,
+        actor: Actor,
+        note: Optional[str] = None,
+    ) -> None:
+        """Anexa una entrada de historial de transición (la persiste el llamador)."""
+        preorder.history.append(
+            PreOrderStatusHistoryModel(
+                from_status=from_status,
+                to_status=to_status.value,
+                actor=actor.type,
+                actor_user_id=actor.user_id,
+                actor_label=actor.label,
+                note=note,
+            )
+        )
+
     def _ensure_open(self, preorder: PreOrderModel) -> None:
         if preorder.status not in _OPEN_VALUES:
             raise BusinessRuleError(
@@ -186,6 +226,13 @@ class PreOrderService:
             and preorder.status in _OPEN_VALUES
             and preorder.expires_at < datetime.utcnow()
         ):
+            self._record_transition(
+                preorder,
+                preorder.status,
+                PreOrderStatus.expired,
+                system_actor(),
+                note="Vigencia vencida",
+            )
             preorder.status = PreOrderStatus.expired.value
             return True
         return False

--- a/src/modules/products/model.py
+++ b/src/modules/products/model.py
@@ -5,6 +5,7 @@ from sqlalchemy import JSON, Boolean, Float, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from src.shared.database import Base
+from src.shared.mixins import AuditMixin, TimestampMixin
 
 
 class ProductType(str, Enum):
@@ -19,7 +20,7 @@ class ProductType(str, Enum):
     HARDWARE = "hardware"  # herraje (futuro)
 
 
-class ProductModel(Base):
+class ProductModel(TimestampMixin, AuditMixin, Base):
     """Catálogo unificado: columnas comunes + ``attributes`` específicos por tipo.
 
     Lo común (``code``, ``name``, ``price``, ``type``, ``is_active``) son columnas

--- a/src/modules/settings/model.py
+++ b/src/modules/settings/model.py
@@ -4,12 +4,13 @@ from sqlalchemy import JSON, DateTime, Float, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from src.shared.database import Base
+from src.shared.mixins import AuditMixin
 
 # La configuración es única: una sola fila con este id fijo (patrón singleton).
 SETTINGS_ID = 1
 
 
-class SettingsModel(Base):
+class SettingsModel(AuditMixin, Base):
     """Configuración única de la aplicación (fila singleton, ``id=1``).
 
     Persiste lo que antes vivía solo en variables de entorno: los parámetros de
@@ -42,6 +43,7 @@ class SettingsModel(Base):
     company_phone: Mapped[str] = mapped_column(String(128))
     company_branches: Mapped[list] = mapped_column(JSON, default=list)
 
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
     )

--- a/src/modules/settings/service.py
+++ b/src/modules/settings/service.py
@@ -9,6 +9,7 @@ from src.modules.settings.schemas import (
     PreOrderSettingsUpdate,
 )
 from src.shared.config import config
+from src.shared.context import get_current_user_id
 from src.shared.database import get_db
 
 # Los datos de empresa se exponen en la API como ``name/tagline/...`` pero se
@@ -70,11 +71,18 @@ class SettingsService:
             self.db.rollback()
             return self.db.get(SettingsModel, SETTINGS_ID)
 
+    def _stamp_updated_by(self, settings: SettingsModel) -> None:
+        """Marca quién editó la fila singleton (no pasa por ``CRUDService``)."""
+        user_id = get_current_user_id()
+        if user_id is not None:
+            settings.updated_by = user_id
+
     def update_cutting(self, data: CuttingSettingsUpdate) -> SettingsModel:
         """Aplica un PATCH parcial a los parámetros de corte."""
         settings = self.get_or_init()
         for field, value in data.model_dump(exclude_unset=True).items():
             setattr(settings, field, value)
+        self._stamp_updated_by(settings)
         self.db.commit()
         self.db.refresh(settings)
         return settings
@@ -84,6 +92,7 @@ class SettingsService:
         settings = self.get_or_init()
         for field, value in data.model_dump(exclude_unset=True).items():
             setattr(settings, field, value)
+        self._stamp_updated_by(settings)
         self.db.commit()
         self.db.refresh(settings)
         return settings
@@ -106,6 +115,7 @@ class SettingsService:
         settings = self.get_or_init()
         for field, value in data.model_dump(exclude_unset=True).items():
             setattr(settings, _COMPANY_FIELD_MAP[field], value)
+        self._stamp_updated_by(settings)
         self.db.commit()
         self.db.refresh(settings)
         return settings

--- a/src/shared/audit.py
+++ b/src/shared/audit.py
@@ -1,0 +1,39 @@
+"""Identidad del actor para las tablas de historial (append-only).
+
+Un ``Actor`` describe quién origina una transición auditada: ``staff`` (con FK al
+usuario + etiqueta congelada), ``client`` (acción pública vía enlace de revisión)
+o ``system`` (automatismos como la expiración). Las tablas de historial guardan
+``actor`` (el tipo), ``actor_user_id`` (FK nullable) y ``actor_label`` (snapshot
+legible que sobrevive a borrados/renombrados del usuario).
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+ACTOR_STAFF = "staff"
+ACTOR_CLIENT = "client"
+ACTOR_SYSTEM = "system"
+
+
+@dataclass(frozen=True)
+class Actor:
+    """Origen de una acción auditada (tipo + atribución opcional)."""
+
+    type: str
+    user_id: Optional[int] = None
+    label: Optional[str] = None
+
+
+def staff_actor(user) -> Actor:
+    """Actor de staff a partir del ``UserModel`` autenticado (FK + snapshot)."""
+    return Actor(ACTOR_STAFF, user_id=user.id, label=user.full_name or user.email)
+
+
+def client_actor(label: Optional[str] = None) -> Actor:
+    """Actor de cliente (acción pública por enlace de revisión)."""
+    return Actor(ACTOR_CLIENT, label=label or "Cliente")
+
+
+def system_actor() -> Actor:
+    """Actor del sistema (automatismos sin usuario, p. ej. expiración)."""
+    return Actor(ACTOR_SYSTEM)

--- a/src/shared/context.py
+++ b/src/shared/context.py
@@ -1,16 +1,28 @@
-"""Contexto por request: identificador de correlación (requestId).
+"""Contexto por request: identificador de correlación (requestId) y usuario.
 
-Lo fija ``RequestIDMiddleware`` (ASGI puro) al inicio de cada request y lo leen
-tanto la ``Meta`` de las respuestas como los handlers de error, sin tener que
-propagar el valor por la firma de cada endpoint.
+Ambos los fija un middleware ASGI puro al inicio de cada request. El requestId lo
+leen la ``Meta`` de las respuestas y los handlers de error; el id de usuario lo
+lee ``CRUDService`` para estampar ``created_by``/``updated_by`` sin propagar el
+valor por la firma de cada endpoint. Se fijan en middleware (no en una dependencia)
+porque las dependencias sync corren en threadpool y su mutación del ContextVar no
+propaga al handler.
 """
 
 from contextvars import ContextVar
+from typing import Optional
 from uuid import uuid4
 
 request_id_ctx: ContextVar[str] = ContextVar("request_id", default="")
+current_user_ctx: ContextVar[Optional[int]] = ContextVar(
+    "current_user_id", default=None
+)
 
 
 def get_request_id() -> str:
     """requestId del request en curso, o uno nuevo como fallback defensivo."""
     return request_id_ctx.get() or str(uuid4())
+
+
+def get_current_user_id() -> Optional[int]:
+    """Id del usuario autenticado del request en curso, o ``None`` si es público."""
+    return current_user_ctx.get()

--- a/src/shared/crud.py
+++ b/src/shared/crud.py
@@ -1,11 +1,14 @@
 from typing import Generic, List, Optional, Tuple, Type, TypeVar
 
 from pydantic import BaseModel
+from sqlalchemy import inspect
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Query, Session
 
+from src.shared.context import get_current_user_id
 from src.shared.database import Base
 from src.shared.exceptions import ConflictError, EntityNotFoundError
+from src.shared.mixins import AuditMixin
 
 ModelT = TypeVar("ModelT", bound=Base)
 CreateT = TypeVar("CreateT", bound=BaseModel)
@@ -59,11 +62,29 @@ class CRUDService(Generic[ModelT, CreateT, UpdateT]):
             setattr(obj, field, value)
         return self._persist(obj)
 
+    def _stamp_actor(self, obj: ModelT) -> None:
+        """Estampa ``created_by``/``updated_by`` desde el usuario del request.
+
+        Centralizado en ``_persist`` para cubrir también los servicios que lo
+        invocan directo (p. ej. ``ProductService``). Distingue alta de edición por
+        la identidad del objeto (transitorio = aún sin PK = creación). No-op para
+        modelos sin ``AuditMixin`` o requests sin usuario (públicos).
+        """
+        if not isinstance(obj, AuditMixin):
+            return
+        user_id = get_current_user_id()
+        if user_id is None:
+            return
+        if inspect(obj).identity is None:  # transitorio: es un alta
+            obj.created_by = user_id
+        obj.updated_by = user_id
+
     def delete(self, id: int) -> None:
         self.db.delete(self.get_or_404(id))
         self.db.commit()
 
     def _persist(self, obj: ModelT) -> ModelT:
+        self._stamp_actor(obj)
         try:
             self.db.add(obj)
             self.db.commit()

--- a/src/shared/middleware.py
+++ b/src/shared/middleware.py
@@ -1,14 +1,16 @@
-"""Middleware ASGI puro para correlación de requests.
+"""Middlewares ASGI puros para contexto por request.
 
 Se usa ASGI puro (no ``BaseHTTPMiddleware``): este último ejecuta el endpoint en
 otra task y el ``ContextVar`` fijado antes de ``call_next`` no siempre propaga.
 ASGI puro corre en la misma task, así que el requestId queda visible durante la
-serialización del ``response_model`` (donde ``Meta`` lo lee).
+serialización del ``response_model`` (donde ``Meta`` lo lee) y el id de usuario
+queda visible para los servicios invocados desde el handler.
 """
 
 from uuid import uuid4
 
-from src.shared.context import request_id_ctx
+from src.shared.context import current_user_ctx, request_id_ctx
+from src.shared.security import decode_access_token
 
 
 class RequestIDMiddleware:
@@ -39,3 +41,39 @@ class RequestIDMiddleware:
             await self.app(scope, receive, send_with_request_id)
         finally:
             request_id_ctx.reset(token)
+
+
+class CurrentUserMiddleware:
+    """Fija el id del usuario autenticado en el contexto para auditoría genérica.
+
+    Decodifica el ``Authorization: Bearer`` de forma best-effort: un token ausente
+    o inválido deja ``current_user_ctx`` en ``None`` (la dependencia de auth sigue
+    devolviendo 401 donde corresponda). Solo necesita el ``sub`` (id) del JWT, que
+    ``CRUDService`` usa para estampar ``created_by``/``updated_by``.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        token = current_user_ctx.set(self._resolve_user_id(scope))
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            current_user_ctx.reset(token)
+
+    @staticmethod
+    def _resolve_user_id(scope):
+        headers = dict(scope["headers"])
+        auth = headers.get(b"authorization", b"").decode()
+        scheme, _, credentials = auth.partition(" ")
+        if scheme.lower() != "bearer" or not credentials:
+            return None
+        try:
+            return int(decode_access_token(credentials).get("sub"))
+        except Exception:
+            return None

--- a/src/shared/mixins.py
+++ b/src/shared/mixins.py
@@ -1,0 +1,38 @@
+"""Mixins declarativos reutilizables para columnas de auditoría.
+
+``TimestampMixin`` aporta ``created_at``/``updated_at``; ``AuditMixin`` aporta
+``created_by``/``updated_by`` (FK nullable a ``users``), que ``CRUDService``
+estampa automáticamente desde ``current_user_ctx``.
+"""
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import DateTime, ForeignKey
+from sqlalchemy.orm import Mapped, declared_attr, mapped_column
+
+
+class TimestampMixin:
+    """``created_at`` y ``updated_at`` gestionados por la aplicación."""
+
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+
+class AuditMixin:
+    """``created_by``/``updated_by``: FK nullable al usuario que tocó la fila.
+
+    Nullable porque los flujos públicos (cliente) o del sistema crean/modifican
+    filas sin un usuario autenticado. ``declared_attr`` da a cada tabla su propia
+    ``ForeignKey`` en vez de compartir el objeto entre modelos.
+    """
+
+    @declared_attr
+    def created_by(cls) -> Mapped[Optional[int]]:
+        return mapped_column(ForeignKey("users.id"), nullable=True)
+
+    @declared_attr
+    def updated_by(cls) -> Mapped[Optional[int]]:
+        return mapped_column(ForeignKey("users.id"), nullable=True)

--- a/tests/test_audit_trail.py
+++ b/tests/test_audit_trail.py
@@ -1,0 +1,166 @@
+"""Tests de la auditoría transversal: atribución de usuario (quién hizo qué).
+
+Cubre el estampado genérico ``created_by``/``updated_by`` (vía contexto del request),
+la atribución real del actor en los historiales de estado de orders y preorders, y
+el registro de quién cortó cada pieza. El fixture ``client`` autentica como el admin
+sembrado en ``conftest`` (``Conftest Admin``), que es el actor esperado.
+"""
+
+from src.modules.clients.model import ClientModel
+from src.modules.products.model import ProductModel
+from src.modules.users.service import UserService
+
+from .test_orders import (
+    _create_board,
+    _create_client,
+    _mint_order,
+    _order_payload,
+)
+
+_ADMIN_EMAIL = "conftest-admin@empresa.com"
+_ADMIN_NAME = "Conftest Admin"
+
+
+def _admin(db_session):
+    return UserService(db_session).get_by_email(_ADMIN_EMAIL)
+
+
+# ---------------------------------------------------------------------------
+# created_by / updated_by genéricos (CRUDService + contexto del request)
+# ---------------------------------------------------------------------------
+
+
+def test_client_create_stamps_created_by(client, db_session):
+    created = _create_client(client)
+    admin = _admin(db_session)
+
+    db_session.expire_all()
+    row = db_session.get(ClientModel, created["id"])
+    assert row.created_by == admin.id
+    assert row.updated_by == admin.id
+    assert row.created_at is not None
+
+
+def test_product_create_stamps_created_by(client, db_session):
+    created = _create_board(client)
+    admin = _admin(db_session)
+
+    db_session.expire_all()
+    row = db_session.get(ProductModel, created["id"])
+    assert row.created_by == admin.id
+    assert row.updated_by == admin.id
+
+
+def test_client_update_stamps_updated_by_only(client, db_session):
+    created = _create_client(client)
+    admin = _admin(db_session)
+    client.put(
+        f"/api/v1/clients/{created['id']}",
+        json={"identifier": "0991112233", "firstName": "Grace"},
+    )
+
+    db_session.expire_all()
+    row = db_session.get(ClientModel, created["id"])
+    assert row.updated_by == admin.id
+
+
+# ---------------------------------------------------------------------------
+# Atribución del actor en transiciones de orden
+# ---------------------------------------------------------------------------
+
+
+def test_order_status_transition_records_staff_actor(client, db_session):
+    c = _create_client(client)
+    b = _create_board(client)
+    order = _mint_order(db_session, _order_payload(c["id"], b["id"]))
+    admin = _admin(db_session)
+
+    resp = client.patch(
+        f"/api/v1/orders/{order.id}/status", json={"status": "approved"}
+    )
+    assert resp.status_code == 200
+
+    last = resp.json()["data"]["history"][-1]
+    assert last["toStatus"] == "approved"
+    assert last["actor"] == "staff"
+    assert last["actorUserId"] == admin.id
+    assert last["actorLabel"] == _ADMIN_NAME
+
+
+def test_mark_piece_cut_records_cut_by(client, db_session):
+    c = _create_client(client)
+    b = _create_board(client)
+    order = _mint_order(db_session, _order_payload(c["id"], b["id"]))
+    admin = _admin(db_session)
+    for status in ("approved", "in_production"):
+        client.patch(f"/api/v1/orders/{order.id}/status", json={"status": status})
+
+    plan = client.get(f"/api/v1/orders/{order.id}/cutting-plan").json()["data"]
+    piece_id = plan["boards"][0]["pieces"][0]["id"]
+
+    resp = client.patch(
+        f"/api/v1/orders/{order.id}/cutting-plan/pieces/{piece_id}", json={"cut": True}
+    )
+    assert resp.status_code == 200
+    piece = resp.json()["data"]["piece"]
+    assert piece["cut"] is True
+    assert piece["cutBy"] == admin.id
+    assert piece["cutByLabel"] == _ADMIN_NAME
+
+    # Desmarcar limpia la atribución junto con cut_at.
+    undo = client.patch(
+        f"/api/v1/orders/{order.id}/cutting-plan/pieces/{piece_id}", json={"cut": False}
+    )
+    undone = undo.json()["data"]["piece"]
+    assert undone["cut"] is False
+    assert undone["cutBy"] is None
+    assert undone["cutByLabel"] is None
+
+
+# ---------------------------------------------------------------------------
+# Historial de pre-órdenes + atribución de cliente al confirmar
+# ---------------------------------------------------------------------------
+
+
+def _create_preorder(client, c, b):
+    return client.post(
+        "/api/v1/preorders/", json=_order_payload(c["id"], b["id"])
+    ).json()["data"]
+
+
+def test_preorder_create_records_staff_draft(client, db_session):
+    c = _create_client(client)
+    b = _create_board(client)
+    admin = _admin(db_session)
+
+    pre = _create_preorder(client, c, b)
+    history = pre["history"]
+    assert len(history) == 1
+    assert history[0]["fromStatus"] is None
+    assert history[0]["toStatus"] == "draft"
+    assert history[0]["actor"] == "staff"
+    assert history[0]["actorUserId"] == admin.id
+    assert history[0]["actorLabel"] == _ADMIN_NAME
+
+
+def test_preorder_client_confirm_attributes_to_client(client, db_session):
+    c = _create_client(client)
+    b = _create_board(client)
+    pre = _create_preorder(client, c, b)
+
+    # Staff envía el enlace (transición a 'sent' por staff)...
+    link = client.post(f"/api/v1/preorders/{pre['id']}/review-link").json()["data"]
+    # ...y el cliente confirma desde el enlace público.
+    confirmed = client.post(f"/api/v1/public/review/{link['token']}/confirm")
+    assert confirmed.status_code == 200
+
+    detail = client.get(f"/api/v1/preorders/{pre['id']}").json()["data"]
+    by_status = {h["toStatus"]: h for h in detail["history"]}
+    assert by_status["sent"]["actor"] == "staff"
+    assert by_status["confirmed"]["actor"] == "client"
+    assert by_status["confirmed"]["actorUserId"] is None
+
+    # La orden minteada por la confirmación nace atribuida al cliente.
+    order = client.get(f"/api/v1/orders/{detail['orderId']}").json()["data"]
+    assert order["history"][0]["actor"] == "client"
+    assert order["history"][0]["actorUserId"] is None


### PR DESCRIPTION
  Nothing in the domain knew *who* did things. This threads the authenticated
  user into the data layer and adds per-event audit where it was missing.

  Infrastructure
  - CurrentUserMiddleware (pure ASGI) publishes the request user id in a ContextVar — set in middleware, not get_current_user, since sync deps run in a threadpool and their ContextVar mutation doesn't reach the handler.
  - TimestampMixin + AuditMixin (created_by/updated_by, nullable FK to users).
  - shared/audit.py: Actor value object (staff/client/system) reused by orders and preorders.
  - CRUDService._persist auto-stamps created_by/updated_by from context, telling
  - shared/audit.py: Actor value object (staff/client/system) reused by orders and preorders.
  - CRUDService._persist auto-stamps created_by/updated_by from context, telling insert from update by object identity (covers services that call _persist directly, e.g. ProductService).

  Attribution
  - orders: order_status_history records the real actor (actor_user_id + actor_label) instead of the hardcoded sales; order_placed_pieces records cut_by/cut_by_label; OrderModel.created_by. Routers capture the current_user that require_permission already returned.
  - preorders: new preorder_status_history table (no per-event record existed). Every transition — create→draft, send→sent (staff), confirm/reject/request changes (client), expire (system) — is attributed. The order minted on confirm is attributed to the client.
  - clients/products/settings: missing timestamps + created_by/updated_by.

  API: actorType/actorUserId/actorLabel on history responses, cutBy/cutByLabel
  on cutting-plan pieces.