### PR TITLE
feat: multi-branch isolation — branches module + scoped data access

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,9 @@ redis-cli: ## Abre redis-cli dentro del contenedor de Redis
 run-local: ## Ejecuta la aplicación localmente
 	ENVIRONMENT=local python main.py
 
+seed-local: ## Siembra tableros y tapacantos en PostgreSQL local (puerto 5433)
+	DATABASE_URL=postgresql://cutter:cutter@localhost:5433/cutter_db .venv/bin/python scripts/seed_boards.py
+
 setup: ## Configuración inicial del proyecto
 	cp .env.example .env || true
 	@echo "Archivo .env creado. Edítalo según tus necesidades."

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -8,6 +8,7 @@ from alembic import context
 
 # Importar los modelos de cada módulo puebla ``Base.metadata`` para que
 # ``alembic revision --autogenerate`` detecte las tablas.
+from src.modules.branches.model import BranchModel  # noqa: F401
 from src.modules.clients.model import ClientModel  # noqa: F401
 from src.modules.optimization_drafts.model import (  # noqa: F401
     OptimizationDraftModel,

--- a/alembic/versions/b1f2c3d4e5a6_multi_sucursal.py
+++ b/alembic/versions/b1f2c3d4e5a6_multi_sucursal.py
@@ -1,0 +1,134 @@
+"""multi sucursal: tabla branches + branch_id en orders/preorders/drafts/users
+
+Revision ID: b1f2c3d4e5a6
+Revises: 4685fa13b87b
+Create Date: 2026-06-17 16:00:00.000000
+
+Aísla las órdenes por sucursal. Crea la entidad ``branches`` (antes solo un JSON de
+membrete en ``settings.company_branches``), añade ``branch_id`` a las tablas que
+deben aislarse y rellena las filas existentes con una sucursal por defecto. El
+``branch_id`` de ``users`` queda nullable a propósito: NULL = administrador global.
+"""
+import json
+from datetime import datetime
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b1f2c3d4e5a6"
+down_revision: Union[str, None] = "4685fa13b87b"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# Tablas que se aíslan por sucursal con branch_id NOT NULL (se rellenan al migrar).
+_SCOPED_NOT_NULL = ("orders", "preorders", "optimization_drafts")
+
+
+def _seed_branches(conn) -> int:
+    """Crea las sucursales desde ``settings.company_branches`` (o una por defecto).
+
+    Devuelve el id de la primera sucursal, usada como destino del backfill.
+    """
+    branches: list = []
+    row = conn.execute(
+        sa.text("SELECT company_branches FROM settings WHERE id = 1")
+    ).fetchone()
+    if row and row[0]:
+        raw = row[0]
+        if isinstance(raw, str):  # SQLite guarda el JSON como texto
+            raw = json.loads(raw)
+        branches = raw or []
+    if not branches:
+        branches = [{"name": "Principal", "address": None}]
+
+    now = datetime.utcnow()
+    first_id = None
+    for i, b in enumerate(branches, start=1):
+        code = f"SUC-{i}"
+        conn.execute(
+            sa.text(
+                "INSERT INTO branches (code, name, address, is_active, "
+                "created_at, updated_at) VALUES "
+                "(:code, :name, :address, :active, :now, :now)"
+            ),
+            {
+                "code": code,
+                "name": b.get("name") or code,
+                "address": b.get("address"),
+                "active": True,
+                "now": now,
+            },
+        )
+        bid = conn.execute(
+            sa.text("SELECT id FROM branches WHERE code = :code"), {"code": code}
+        ).scalar()
+        if first_id is None:
+            first_id = bid
+    return first_id
+
+
+def upgrade() -> None:
+    op.create_table(
+        "branches",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("code", sa.String(length=32), nullable=False),
+        sa.Column("name", sa.String(length=128), nullable=False),
+        sa.Column("address", sa.String(length=256), nullable=True),
+        sa.Column("phone", sa.String(length=32), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.Column("created_by", sa.Integer(), nullable=True),
+        sa.Column("updated_by", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(["created_by"], ["users.id"]),
+        sa.ForeignKeyConstraint(["updated_by"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_branches_code"), "branches", ["code"], unique=True)
+
+    conn = op.get_bind()
+    default_branch_id = _seed_branches(conn)
+
+    # branch_id nullable + índice + FK en cada tabla aislada (+ users).
+    for table in (*_SCOPED_NOT_NULL, "users"):
+        op.add_column(table, sa.Column("branch_id", sa.Integer(), nullable=True))
+        op.create_index(
+            op.f(f"ix_{table}_branch_id"), table, ["branch_id"], unique=False
+        )
+        op.create_foreign_key(
+            f"fk_{table}_branch_id_branches", table, "branches", ["branch_id"], ["id"]
+        )
+
+    # Backfill: todo lo existente a la sucursal por defecto.
+    for table in _SCOPED_NOT_NULL:
+        conn.execute(
+            sa.text(f"UPDATE {table} SET branch_id = :bid WHERE branch_id IS NULL"),
+            {"bid": default_branch_id},
+        )
+    # Usuarios: el staff (no admin) a la sucursal por defecto; los admin quedan NULL
+    # (globales: ven y operan todas las sucursales).
+    conn.execute(
+        sa.text(
+            "UPDATE users SET branch_id = :bid "
+            "WHERE role != 'administrador' AND branch_id IS NULL"
+        ),
+        {"bid": default_branch_id},
+    )
+
+    # Cierra el NOT NULL en las tablas aisladas (users queda nullable).
+    for table in _SCOPED_NOT_NULL:
+        op.alter_column(table, "branch_id", existing_type=sa.Integer(), nullable=False)
+
+
+def downgrade() -> None:
+    for table in (*_SCOPED_NOT_NULL, "users"):
+        op.drop_constraint(
+            f"fk_{table}_branch_id_branches", table, type_="foreignkey"
+        )
+        op.drop_index(op.f(f"ix_{table}_branch_id"), table_name=table)
+        op.drop_column(table, "branch_id")
+    op.drop_index(op.f("ix_branches_code"), table_name="branches")
+    op.drop_table("branches")

--- a/docs/MULTISUCURSAL.md
+++ b/docs/MULTISUCURSAL.md
@@ -1,0 +1,57 @@
+# Multi-sucursal — contrato de API
+
+Cutter ahora aísla **órdenes, pre-órdenes y borradores** por sucursal. Este documento
+resume lo que cambia para el frontend (dashboard React). Detalle de auth en
+[`AUTH.md`](AUTH.md).
+
+## Modelo
+
+- **Sucursal (`branch`)** es una entidad real (`/branches`). Reemplaza al JSON de
+  membrete que vivía en `settings.company_branches`.
+- Cada **usuario** staff (`vendedor`/`operador`) está atado a **una** sucursal
+  (`branchId`). El **administrador** es global (`branchId` nulo): ve y opera todas.
+- **Órdenes, pre-órdenes y borradores** guardan su `branchId`. Es un hecho histórico:
+  reasignar la sucursal de un usuario **no** mueve sus documentos previos.
+- **Clientes y productos siguen siendo globales** (una sola cartera / catálogo).
+
+## Aislamiento (qué ve/hace cada quién)
+
+| Rol | Listados y acceso | Crear |
+|-----|-------------------|-------|
+| `administrador` | **Todas** las sucursales; filtro opcional `?branchId=` | Debe indicar `branchId` |
+| `vendedor`/`operador` | Solo **su** sucursal | Hereda su sucursal (el `branchId` del body se ignora) |
+
+Un recurso de otra sucursal devuelve **404** (no 403): no se revela que existe.
+
+## Endpoints nuevos
+
+### `/branches` (CRUD, solo admin escribe; cualquier staff lee)
+- `POST /api/v1/branches` — `{ code, name, address?, phone? }`
+- `GET /api/v1/branches` — paginado, `?search=`
+- `GET /api/v1/branches/{id}`
+- `PUT /api/v1/branches/{id}` — incluye `isActive` (baja lógica)
+- `DELETE /api/v1/branches/{id}`
+
+### Analítica por sucursal (admin)
+- `GET /api/v1/analytics/breakdown/branch` — comparativo (conteo + ingreso) por almacén.
+- Todos los endpoints de analytics aceptan `?branchId=` para acotar a una sucursal.
+
+## Cambios en endpoints existentes
+
+- **Usuarios** (`POST/PUT /users`, respuesta de login): el body/objeto `user` incluye
+  `branchId`. Obligatorio para `vendedor`/`operador`; ignorado para `administrador`
+  (queda nulo). Mostrar un selector de sucursal en el alta/edición de staff.
+- **Pre-órdenes** (`POST /preorders`): acepta `branchId`. El staff puede omitirlo
+  (hereda el suyo); el admin debe enviarlo. `GET /preorders` acepta `?branchId=` (admin).
+- **Órdenes** (`GET /orders`): acepta `?branchId=` (admin). La orden nace con la
+  sucursal de la pre-orden al confirmar; su proforma/hoja de producción muestran esa
+  sucursal en el membrete.
+- **Borradores** (`POST /optimization-drafts`): acepta `branchId` (mismo criterio que
+  pre-órdenes); `GET` acepta `?branchId=` (admin).
+
+## Errores relevantes
+
+- `422 VALIDATION_ERROR` (`field: "branchId"`): admin creando sin indicar sucursal, o
+  sucursal inactiva.
+- `403 FORBIDDEN`: staff sin sucursal asignada (estado inválido a corregir por el admin).
+- `404 NOT_FOUND`: acceso a un recurso de otra sucursal (uniforme con "no existe").

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse
 
 from src.modules.analytics.router import router as analytics_router
+from src.modules.branches.router import router as branches_router
 from src.modules.clients.router import router as clients_router
 from src.modules.optimization_drafts.router import router as optimization_drafts_router
 from src.modules.optimizations.router import router as optimizations_router
@@ -16,10 +17,14 @@ from src.modules.products.router import router as products_router
 from src.modules.settings.router import router as settings_router
 from src.modules.system.router import router as system_router
 from src.modules.users.auth_router import router as auth_router
+from src.modules.users.enums import UserRole
+from src.modules.users.model import UserModel
 from src.modules.users.router import router as users_router
 from src.shared.config import config
+from src.shared.database import SessionLocal
 from src.shared.errors import register_exception_handlers
 from src.shared.middleware import CurrentUserMiddleware, RequestIDMiddleware
+from src.shared.security import hash_password
 
 # Configurar logging
 logging.basicConfig(
@@ -29,10 +34,35 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
+def _seed_admin() -> None:
+    """Crea el primer administrador si ADMIN_EMAIL/ADMIN_PASSWORD están definidos y el email no existe aún."""
+    if not config.ADMIN_EMAIL or not config.ADMIN_PASSWORD:
+        return
+    db = SessionLocal()
+    try:
+        exists = (
+            db.query(UserModel).filter(UserModel.email == config.ADMIN_EMAIL).first()
+        )
+        if not exists:
+            db.add(
+                UserModel(
+                    email=config.ADMIN_EMAIL,
+                    hashed_password=hash_password(config.ADMIN_PASSWORD),
+                    role=UserRole.ADMIN.value,
+                    is_active=True,
+                )
+            )
+            db.commit()
+            logger.info("Admin sembrado: %s", config.ADMIN_EMAIL)
+    finally:
+        db.close()
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Manejo del ciclo de vida de la aplicación"""
     logger.info("Iniciando aplicación FastAPI")
+    _seed_admin()
     yield
     logger.info("Cerrando aplicación FastAPI")
 
@@ -68,6 +98,7 @@ register_exception_handlers(app)
 app.include_router(system_router, prefix="/api/v1")
 app.include_router(auth_router, prefix="/api/v1")
 app.include_router(users_router, prefix="/api/v1")
+app.include_router(branches_router, prefix="/api/v1")
 app.include_router(products_router, prefix="/api/v1")
 app.include_router(clients_router, prefix="/api/v1")
 app.include_router(optimizations_router, prefix="/api/v1")

--- a/scripts/seed_boards.py
+++ b/scripts/seed_boards.py
@@ -6,6 +6,9 @@ import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from src.modules.products.model import ProductModel, ProductType
+from src.modules.users.model import (
+    UserModel,  # noqa: F401 — registers users table for FK resolution
+)
 from src.shared.database import SessionLocal
 
 TEXTURE_DESC = {

--- a/src/modules/analytics/router.py
+++ b/src/modules/analytics/router.py
@@ -4,6 +4,8 @@ Cuatro endpoints cohesivos, uno por familia de gráfico. Todos devuelven payload
 agregados listos para graficar, envueltos en ``DataResponse[T]``.
 """
 
+from typing import Optional
+
 from fastapi import APIRouter, Depends, Query
 
 from src.modules.analytics.constants import Granularity
@@ -18,7 +20,8 @@ from src.modules.analytics.service import AnalyticsService, analytics_service
 from src.modules.users.dependencies import require_permission
 from src.shared.responses import ERROR_RESPONSES, DataResponse, ok
 
-# Analítica del dashboard: solo "administrador" (RESOURCE_ROLES["analytics"]).
+# Analítica del dashboard: solo "administrador" (RESOURCE_ROLES["analytics"]). El
+# admin es global, así que ``branchId`` es un filtro OPCIONAL para revisar un almacén.
 router = APIRouter(
     prefix="/analytics",
     tags=["analytics"],
@@ -26,14 +29,21 @@ router = APIRouter(
     dependencies=[Depends(require_permission("analytics"))],
 )
 
+_BRANCH_QUERY = Query(
+    default=None,
+    alias="branchId",
+    description="Filtra las métricas a una sucursal (vacío = todas)",
+)
+
 
 @router.get("/summary", response_model=DataResponse[AnalyticsSummary])
 def get_summary(
     dr: DateRange = Depends(),
+    branch_id: Optional[int] = _BRANCH_QUERY,
     svc: AnalyticsService = Depends(analytics_service),
 ):
     """Tarjetas KPI del periodo: operación, pipeline y tendencia base."""
-    return ok(svc.summary(dr))
+    return ok(svc.summary(dr, branch_id=branch_id))
 
 
 @router.get("/timeseries", response_model=DataResponse[TimeSeries])
@@ -42,25 +52,37 @@ def get_timeseries(
     granularity: Granularity = Query(
         Granularity.day, description="Tamaño de bucket: day | week | month"
     ),
+    branch_id: Optional[int] = _BRANCH_QUERY,
     svc: AnalyticsService = Depends(analytics_service),
 ):
     """Tendencias temporales (eje denso, huecos en cero)."""
-    return ok(svc.timeseries(dr, granularity))
+    return ok(svc.timeseries(dr, granularity, branch_id=branch_id))
 
 
 @router.get("/breakdown/status", response_model=DataResponse[Breakdown])
 def get_breakdown_status(
     dr: DateRange = Depends(),
+    branch_id: Optional[int] = _BRANCH_QUERY,
     svc: AnalyticsService = Depends(analytics_service),
 ):
     """Embudo de estados: conteo e ingreso por estado (todos los estados, incl. cero)."""
-    return ok(svc.breakdown_status(dr))
+    return ok(svc.breakdown_status(dr, branch_id=branch_id))
+
+
+@router.get("/breakdown/branch", response_model=DataResponse[Breakdown])
+def get_breakdown_branch(
+    dr: DateRange = Depends(),
+    svc: AnalyticsService = Depends(analytics_service),
+):
+    """Comparativo por sucursal: conteo e ingreso por almacén (revisión gerencial)."""
+    return ok(svc.breakdown_branch(dr))
 
 
 @router.get("/operations", response_model=DataResponse[OperationsReport])
 def get_operations(
     dr: DateRange = Depends(),
+    branch_id: Optional[int] = _BRANCH_QUERY,
     svc: AnalyticsService = Depends(analytics_service),
 ):
     """Eficiencia de material (ponderada por área), merma y ciclo de vida."""
-    return ok(svc.operations(dr))
+    return ok(svc.operations(dr, branch_id=branch_id))

--- a/src/modules/analytics/service.py
+++ b/src/modules/analytics/service.py
@@ -7,6 +7,7 @@ Redis), así que todo se construye sobre ``orders`` + ``order_lines`` + ``order_
 """
 
 from collections import defaultdict
+from typing import Optional
 
 from fastapi import Depends
 from sqlalchemy import distinct, func
@@ -31,6 +32,7 @@ from src.modules.analytics.schemas import (
     TimeSeries,
     TimeSeriesData,
 )
+from src.modules.branches.model import BranchModel
 from src.modules.orders.model import OrderLineModel, OrderModel, OrderStatus
 from src.shared.database import get_db
 
@@ -42,19 +44,21 @@ class AnalyticsService:
         self.db = db
 
     # ------------------------------------------------------------------ summary
-    def summary(self, dr: DateRange) -> AnalyticsSummary:
-        order_count = self._count(dr)
-        completed_count = self._count(dr, REALIZED_STATUSES)
-        cancelled = self._count(dr, {OrderStatus.cancelled})
+    def summary(
+        self, dr: DateRange, branch_id: Optional[int] = None
+    ) -> AnalyticsSummary:
+        order_count = self._count(dr, branch_id=branch_id)
+        completed_count = self._count(dr, REALIZED_STATUSES, branch_id=branch_id)
+        cancelled = self._count(dr, {OrderStatus.cancelled}, branch_id=branch_id)
 
-        realized_revenue = self._revenue(dr, REALIZED_STATUSES)
-        boards = self._boards_consumed(dr)
-        avg_eff, area = self._efficiency_and_area(dr)
+        realized_revenue = self._revenue(dr, REALIZED_STATUSES, branch_id=branch_id)
+        boards = self._boards_consumed(dr, branch_id=branch_id)
+        avg_eff, area = self._efficiency_and_area(dr, branch_id=branch_id)
         waste = round(area * (1 - avg_eff / 100), 4)
 
         active_clients = (
             self.db.query(func.count(distinct(OrderModel.client_id)))
-            .filter(*self._range(dr))
+            .filter(*self._range(dr, branch_id))
             .scalar()
         ) or 0
 
@@ -64,7 +68,7 @@ class AnalyticsService:
             average_efficiency=avg_eff,
             total_area_cut_m2=area,
             waste_estimate_m2=waste,
-            pending_orders_count=self._count(dr, PENDING_STATUSES),
+            pending_orders_count=self._count(dr, PENDING_STATUSES, branch_id=branch_id),
             cancellation_rate=round(safe_div(cancelled, order_count), 4),
             order_count=order_count,
             realized_revenue=realized_revenue,
@@ -73,7 +77,12 @@ class AnalyticsService:
         )
 
     # --------------------------------------------------------------- timeseries
-    def timeseries(self, dr: DateRange, granularity: Granularity) -> TimeSeries:
+    def timeseries(
+        self,
+        dr: DateRange,
+        granularity: Granularity,
+        branch_id: Optional[int] = None,
+    ) -> TimeSeries:
         buckets = iter_buckets(dr.date_from, dr.date_to, granularity)
         labels = [b.isoformat() for b in buckets]
         index = {b: i for i, b in enumerate(buckets)}
@@ -91,7 +100,7 @@ class AnalyticsService:
                 OrderModel.status,
                 OrderModel.total_boards_used,
             )
-            .filter(*self._range(dr))
+            .filter(*self._range(dr, branch_id))
             .all()
         )
         for created_at, total, status, tboards in rows:
@@ -105,11 +114,13 @@ class AnalyticsService:
 
         # Clientes nuevos: primer pedido (MIN created_at) por cliente sobre TODA la
         # historia; se cuenta en el bucket de ese primer pedido si cae en el rango.
-        first_orders = (
-            self.db.query(OrderModel.client_id, func.min(OrderModel.created_at))
-            .group_by(OrderModel.client_id)
-            .all()
+        # Con sucursal: el "primer pedido" se evalúa dentro de esa sucursal.
+        first_orders_q = self.db.query(
+            OrderModel.client_id, func.min(OrderModel.created_at)
         )
+        if branch_id is not None:
+            first_orders_q = first_orders_q.filter(OrderModel.branch_id == branch_id)
+        first_orders = first_orders_q.group_by(OrderModel.client_id).all()
         for _, first_dt in first_orders:
             if dr.start <= first_dt < dr.end:
                 i = index.get(bucket_key(first_dt.date(), granularity))
@@ -128,14 +139,16 @@ class AnalyticsService:
         )
 
     # ----------------------------------------------------------- breakdown/status
-    def breakdown_status(self, dr: DateRange) -> Breakdown:
+    def breakdown_status(
+        self, dr: DateRange, branch_id: Optional[int] = None
+    ) -> Breakdown:
         rows = (
             self.db.query(
                 OrderModel.status,
                 func.count(OrderModel.id),
                 func.coalesce(func.sum(OrderModel.total), 0.0),
             )
-            .filter(*self._range(dr))
+            .filter(*self._range(dr, branch_id))
             .group_by(OrderModel.status)
             .all()
         )
@@ -151,12 +164,44 @@ class AnalyticsService:
         ]
         return Breakdown(dimension="status", items=items)
 
+    # ----------------------------------------------------------- breakdown/branch
+    def breakdown_branch(self, dr: DateRange) -> Breakdown:
+        """Desglose por sucursal: conteo e ingreso por almacén (comparativo gerencial).
+
+        Densifica con todas las sucursales (incluso las que no tuvieron órdenes en el
+        periodo) para que el comparativo sea estable.
+        """
+        rows = (
+            self.db.query(
+                OrderModel.branch_id,
+                func.count(OrderModel.id),
+                func.coalesce(func.sum(OrderModel.total), 0.0),
+            )
+            .filter(*self._range(dr))
+            .group_by(OrderModel.branch_id)
+            .all()
+        )
+        by_branch = {bid: (count, rev) for bid, count, rev in rows}
+        branches = self.db.query(BranchModel).order_by(BranchModel.id).all()
+        items = [
+            BreakdownItem(
+                key=str(b.id),
+                label=b.name,
+                revenue=round(by_branch.get(b.id, (0, 0.0))[1], 2),
+                order_count=by_branch.get(b.id, (0, 0.0))[0],
+            )
+            for b in branches
+        ]
+        return Breakdown(dimension="branch", items=items)
+
     # ------------------------------------------------------------------ operations
-    def operations(self, dr: DateRange) -> OperationsReport:
-        avg_eff, area = self._efficiency_and_area(dr)
+    def operations(
+        self, dr: DateRange, branch_id: Optional[int] = None
+    ) -> OperationsReport:
+        avg_eff, area = self._efficiency_and_area(dr, branch_id=branch_id)
         waste = round(area * (1 - avg_eff / 100), 4)
 
-        orders = self.db.query(OrderModel).filter(*self._range(dr)).all()
+        orders = self.db.query(OrderModel).filter(*self._range(dr, branch_id)).all()
         return OperationsReport(
             average_efficiency=avg_eff,
             total_area_cut_m2=area,
@@ -165,36 +210,51 @@ class AnalyticsService:
         )
 
     # --------------------------------------------------------------------- helpers
-    def _range(self, dr: DateRange) -> list:
-        """Filtro medio-abierto ``[start, end)`` sobre ``created_at``."""
-        return [OrderModel.created_at >= dr.start, OrderModel.created_at < dr.end]
+    def _range(self, dr: DateRange, branch_id: Optional[int] = None) -> list:
+        """Filtro medio-abierto ``[start, end)`` sobre ``created_at`` (+ sucursal).
 
-    def _count(self, dr: DateRange, statuses=None) -> int:
-        query = self.db.query(func.count(OrderModel.id)).filter(*self._range(dr))
+        Cuando ``branch_id`` no es ``None``, restringe a esa sucursal: así el gerente
+        puede revisar el desempeño de un almacén concreto (``None`` = todas).
+        """
+        filters = [OrderModel.created_at >= dr.start, OrderModel.created_at < dr.end]
+        if branch_id is not None:
+            filters.append(OrderModel.branch_id == branch_id)
+        return filters
+
+    def _count(
+        self, dr: DateRange, statuses=None, branch_id: Optional[int] = None
+    ) -> int:
+        query = self.db.query(func.count(OrderModel.id)).filter(
+            *self._range(dr, branch_id)
+        )
         if statuses is not None:
             query = query.filter(OrderModel.status.in_(status_values(statuses)))
         return query.scalar() or 0
 
-    def _revenue(self, dr: DateRange, statuses) -> float:
+    def _revenue(
+        self, dr: DateRange, statuses, branch_id: Optional[int] = None
+    ) -> float:
         val = (
             self.db.query(func.coalesce(func.sum(OrderModel.total), 0.0))
-            .filter(*self._range(dr))
+            .filter(*self._range(dr, branch_id))
             .filter(OrderModel.status.in_(status_values(statuses)))
             .scalar()
         )
         return round(val or 0.0, 2)
 
-    def _boards_consumed(self, dr: DateRange) -> int:
+    def _boards_consumed(self, dr: DateRange, branch_id: Optional[int] = None) -> int:
         """Tableros de órdenes completadas (producción realizada)."""
         val = (
             self.db.query(func.coalesce(func.sum(OrderModel.total_boards_used), 0))
-            .filter(*self._range(dr))
+            .filter(*self._range(dr, branch_id))
             .filter(OrderModel.status.in_(status_values(REALIZED_STATUSES)))
             .scalar()
         )
         return int(val or 0)
 
-    def _efficiency_and_area(self, dr: DateRange) -> tuple[float, float]:
+    def _efficiency_and_area(
+        self, dr: DateRange, branch_id: Optional[int] = None
+    ) -> tuple[float, float]:
         """Eficiencia ponderada por área (0..100) y área total (m²) de líneas de tablero.
 
         Excluye líneas de tapacanto (``total_area_m2``/``avg_efficiency`` nulos). El
@@ -203,7 +263,7 @@ class AnalyticsService:
         rows = (
             self.db.query(OrderLineModel.avg_efficiency, OrderLineModel.total_area_m2)
             .join(OrderModel, OrderLineModel.order_id == OrderModel.id)
-            .filter(*self._range(dr))
+            .filter(*self._range(dr, branch_id))
             .filter(OrderModel.status.in_(status_values(REALIZED_STATUSES)))
             .filter(OrderLineModel.total_area_m2.isnot(None))
             .filter(OrderLineModel.avg_efficiency.isnot(None))

--- a/src/modules/branches/model.py
+++ b/src/modules/branches/model.py
@@ -1,0 +1,27 @@
+from typing import Optional
+
+from sqlalchemy import Boolean, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.shared.database import Base
+from src.shared.mixins import AuditMixin, TimestampMixin
+
+
+class BranchModel(TimestampMixin, AuditMixin, Base):
+    """Sucursal (almacén) del negocio: entidad raíz del aislamiento multi-sucursal.
+
+    Antes las sucursales solo existían como un JSON de membrete en ``settings``;
+    ahora son una entidad real a la que apuntan órdenes, pre-órdenes, borradores y
+    usuarios (``branch_id``). El staff (vendedor/operador) queda atado a una
+    sucursal; el administrador no (ve y opera todas). La baja es lógica
+    (``is_active``) para no romper las FKs históricas.
+    """
+
+    __tablename__ = "branches"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    code: Mapped[str] = mapped_column(String(32), unique=True, index=True)
+    name: Mapped[str] = mapped_column(String(128))
+    address: Mapped[Optional[str]] = mapped_column(String(256))
+    phone: Mapped[Optional[str]] = mapped_column(String(32))
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)

--- a/src/modules/branches/router.py
+++ b/src/modules/branches/router.py
@@ -1,0 +1,71 @@
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query
+
+from src.modules.branches.schemas import BranchCreate, BranchResponse, BranchUpdate
+from src.modules.branches.service import BranchService, branch_service
+from src.modules.users.dependencies import require_permission
+from src.shared.pagination import PageParams
+from src.shared.responses import (
+    ERROR_RESPONSES,
+    DataResponse,
+    PaginatedResponse,
+    ok,
+    page,
+)
+
+router = APIRouter(prefix="/branches", tags=["branches"], responses=ERROR_RESPONSES)
+
+# Administración (CRUD): solo "administrador". Lectura/listado: cualquier staff
+# (para selectores y mostrar el nombre de la sucursal propia).
+_READ = Depends(require_permission("branches:read"))
+_WRITE = Depends(require_permission("branches:manage"))
+
+
+@router.post(
+    "/",
+    response_model=DataResponse[BranchResponse],
+    status_code=201,
+    dependencies=[_WRITE],
+)
+def create_branch(data: BranchCreate, svc: BranchService = Depends(branch_service)):
+    """Crea una sucursal."""
+    return ok(svc.create(data))
+
+
+@router.get("/", response_model=PaginatedResponse[BranchResponse], dependencies=[_READ])
+def list_branches(
+    paging: PageParams = Depends(),
+    search: Optional[str] = Query(None, description="Búsqueda por código o nombre"),
+    svc: BranchService = Depends(branch_service),
+):
+    """Lista sucursales con búsqueda y paginación opcionales."""
+    if search:
+        items, total = svc.search_paginated(search, paging.limit, paging.offset)
+    else:
+        items, total = svc.list_paginated(paging.limit, paging.offset)
+    return page(items, total, paging.limit, paging.offset)
+
+
+@router.get(
+    "/{branch_id}", response_model=DataResponse[BranchResponse], dependencies=[_READ]
+)
+def get_branch(branch_id: int, svc: BranchService = Depends(branch_service)):
+    """Obtiene una sucursal por ID."""
+    return ok(svc.get_or_404(branch_id))
+
+
+@router.put(
+    "/{branch_id}", response_model=DataResponse[BranchResponse], dependencies=[_WRITE]
+)
+def update_branch(
+    branch_id: int, data: BranchUpdate, svc: BranchService = Depends(branch_service)
+):
+    """Actualiza una sucursal (incluye baja lógica vía ``isActive``)."""
+    return ok(svc.update(branch_id, data))
+
+
+@router.delete("/{branch_id}", status_code=204, dependencies=[_WRITE])
+def delete_branch(branch_id: int, svc: BranchService = Depends(branch_service)):
+    """Elimina una sucursal."""
+    svc.delete(branch_id)

--- a/src/modules/branches/schemas.py
+++ b/src/modules/branches/schemas.py
@@ -1,0 +1,41 @@
+from typing import Optional
+
+from pydantic import Field
+
+from src.shared.schemas import CamelModel
+
+
+class BranchBase(CamelModel):
+    code: str = Field(
+        ..., min_length=1, max_length=32, description="Código único de la sucursal"
+    )
+    name: str = Field(
+        ..., min_length=1, max_length=128, description="Nombre de la sucursal"
+    )
+    address: Optional[str] = Field(
+        None, max_length=256, description="Dirección (membrete de la proforma)"
+    )
+    phone: Optional[str] = Field(
+        None, max_length=32, description="Teléfono de contacto"
+    )
+
+
+class BranchCreate(BranchBase):
+    """Alta de una sucursal."""
+
+
+class BranchUpdate(CamelModel):
+    """Actualización parcial de una sucursal."""
+
+    code: Optional[str] = Field(None, min_length=1, max_length=32)
+    name: Optional[str] = Field(None, min_length=1, max_length=128)
+    address: Optional[str] = Field(None, max_length=256)
+    phone: Optional[str] = Field(None, max_length=32)
+    is_active: Optional[bool] = Field(None, description="Activa/inactiva (baja lógica)")
+
+
+class BranchResponse(BranchBase):
+    """Representación pública de una sucursal."""
+
+    id: int = Field(..., description="ID de la sucursal")
+    is_active: bool = Field(..., description="Activa/inactiva")

--- a/src/modules/branches/service.py
+++ b/src/modules/branches/service.py
@@ -1,0 +1,73 @@
+from typing import List, Optional, Tuple
+
+from fastapi import Depends
+from sqlalchemy.orm import Session
+
+from src.modules.branches.model import BranchModel
+from src.modules.branches.schemas import BranchCreate, BranchUpdate
+from src.shared.crud import CRUDService
+from src.shared.database import get_db
+from src.shared.exceptions import EntityNotFoundError, ValidationError
+
+
+def branch_letterhead(db: Session, branch_id: Optional[int]) -> Optional[dict]:
+    """Membrete de una sucursal para la proforma: ``{"name", "address"}`` o ``None``.
+
+    Acota el listado de sucursales del membrete a la sucursal dueña del documento.
+    """
+    if branch_id is None:
+        return None
+    branch = db.get(BranchModel, branch_id)
+    if branch is None:
+        return None
+    return {"name": branch.name, "address": branch.address or ""}
+
+
+def resolve_branch_for_create(
+    db: Session, branch_scope: Optional[int], requested_branch_id: Optional[int]
+) -> int:
+    """Resuelve y valida la sucursal destino de un alta (orden/pre-orden/borrador).
+
+    - staff (``branch_scope`` no None): siempre su propia sucursal (ignora lo pedido
+      en el body, para que no pueda crear en otra sucursal).
+    - admin (``branch_scope`` None): exige ``requested_branch_id`` explícito.
+
+    Verifica que la sucursal exista y esté activa.
+    """
+    branch_id = branch_scope if branch_scope is not None else requested_branch_id
+    if branch_id is None:
+        raise ValidationError(
+            "Debes indicar la sucursal de destino (branchId).", field="branchId"
+        )
+    branch = db.get(BranchModel, branch_id)
+    if branch is None:
+        raise EntityNotFoundError("Branch", branch_id)
+    if not branch.is_active:
+        raise ValidationError("La sucursal indicada está inactiva.", field="branchId")
+    return branch_id
+
+
+class BranchService(CRUDService[BranchModel, BranchCreate, BranchUpdate]):
+    """CRUD de sucursales + búsquedas específicas."""
+
+    model = BranchModel
+    conflict_messages = {"code": "El código de sucursal ya existe"}
+
+    def get_by_code(self, code: str) -> Optional[BranchModel]:
+        """Obtiene una sucursal por su código."""
+        return self.db.query(BranchModel).filter(BranchModel.code == code).first()
+
+    def search_paginated(
+        self, search: str, limit: int = 20, offset: int = 0
+    ) -> Tuple[List[BranchModel], int]:
+        """Busca sucursales por código o nombre; ``(items, total)``."""
+        pattern = f"%{search}%"
+        query = self.db.query(BranchModel).filter(
+            BranchModel.code.ilike(pattern) | BranchModel.name.ilike(pattern)
+        )
+        return self._paginate(query, limit, offset)
+
+
+def branch_service(db: Session = Depends(get_db)) -> BranchService:
+    """Provider de ``BranchService`` para inyección en rutas."""
+    return BranchService(db)

--- a/src/modules/optimization_drafts/model.py
+++ b/src/modules/optimization_drafts/model.py
@@ -23,6 +23,8 @@ class OptimizationDraftModel(TimestampMixin, AuditMixin, Base):
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     name: Mapped[str] = mapped_column(String(128))
+    # Sucursal dueña del borrador: aísla el trabajo en progreso entre sucursales.
+    branch_id: Mapped[int] = mapped_column(ForeignKey("branches.id"), index=True)
     client_id: Mapped[Optional[int]] = mapped_column(
         ForeignKey("clients.id"), nullable=True
     )

--- a/src/modules/optimization_drafts/router.py
+++ b/src/modules/optimization_drafts/router.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter, Depends
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query
 
 from src.modules.optimization_drafts.schemas import (
     DraftCreate,
@@ -10,7 +12,7 @@ from src.modules.optimization_drafts.service import (
     OptimizationDraftService,
     optimization_draft_service,
 )
-from src.modules.users.dependencies import require_permission
+from src.modules.users.dependencies import get_branch_scope, require_permission
 from src.shared.pagination import PageParams
 from src.shared.responses import (
     ERROR_RESPONSES,
@@ -33,18 +35,33 @@ router = APIRouter(
 def create_draft(
     data: DraftCreate,
     svc: OptimizationDraftService = Depends(optimization_draft_service),
+    branch_scope: Optional[int] = Depends(get_branch_scope),
 ):
-    """Crea un borrador del optimizador."""
-    return ok(svc.create(data))
+    """Crea un borrador del optimizador (en la sucursal del usuario)."""
+    return ok(svc.create_scoped(data, branch_scope=branch_scope))
 
 
 @router.get("/", response_model=PaginatedResponse[DraftSummaryResponse])
 def list_drafts(
+    branch_id: Optional[int] = Query(
+        default=None,
+        alias="branchId",
+        description="Solo admin: estrecha el listado a una sucursal (vacío = todas)",
+    ),
     paging: PageParams = Depends(),
     svc: OptimizationDraftService = Depends(optimization_draft_service),
+    branch_scope: Optional[int] = Depends(get_branch_scope),
 ):
-    """Lista borradores (resumen liviano, sin ``payload``) con paginación."""
-    items, total = svc.list_paginated(paging.limit, paging.offset)
+    """Lista borradores (resumen liviano, sin ``payload``) con paginación.
+
+    El staff solo ve los de su sucursal; el admin ve todos (o filtra con ``branchId``).
+    """
+    items, total = svc.list_scoped(
+        branch_scope=branch_scope,
+        branch_filter=branch_id,
+        limit=paging.limit,
+        offset=paging.offset,
+    )
     return page(items, total, paging.limit, paging.offset)
 
 
@@ -52,9 +69,10 @@ def list_drafts(
 def get_draft(
     draft_id: int,
     svc: OptimizationDraftService = Depends(optimization_draft_service),
+    branch_scope: Optional[int] = Depends(get_branch_scope),
 ):
     """Obtiene un borrador por ID (incluye el ``payload`` completo)."""
-    return ok(svc.get_or_404(draft_id))
+    return ok(svc.get_scoped_or_404(draft_id, branch_scope))
 
 
 @router.put("/{draft_id}", response_model=DataResponse[DraftResponse])
@@ -62,15 +80,17 @@ def update_draft(
     draft_id: int,
     data: DraftUpdate,
     svc: OptimizationDraftService = Depends(optimization_draft_service),
+    branch_scope: Optional[int] = Depends(get_branch_scope),
 ):
     """Actualiza (sobrescribe) un borrador."""
-    return ok(svc.update(draft_id, data))
+    return ok(svc.update_scoped(draft_id, data, branch_scope=branch_scope))
 
 
 @router.delete("/{draft_id}", status_code=204)
 def delete_draft(
     draft_id: int,
     svc: OptimizationDraftService = Depends(optimization_draft_service),
+    branch_scope: Optional[int] = Depends(get_branch_scope),
 ):
     """Elimina un borrador."""
-    svc.delete(draft_id)
+    svc.delete_scoped(draft_id, branch_scope=branch_scope)

--- a/src/modules/optimization_drafts/schemas.py
+++ b/src/modules/optimization_drafts/schemas.py
@@ -18,6 +18,13 @@ class DraftCreate(CamelModel):
     client_id: Optional[int] = Field(
         default=None, description="Optional client this draft is associated with"
     )
+    branch_id: Optional[int] = Field(
+        default=None,
+        description=(
+            "Target branch. Ignored for branch staff (forced to their own branch); "
+            "required for a global admin."
+        ),
+    )
     payload: dict = Field(
         ..., description="Opaque optimizer form state (materials + pieces, as-is)"
     )

--- a/src/modules/optimization_drafts/service.py
+++ b/src/modules/optimization_drafts/service.py
@@ -1,22 +1,62 @@
+from typing import List, Optional, Tuple
+
 from fastapi import Depends
 from sqlalchemy.orm import Session
 
+from src.modules.branches.service import resolve_branch_for_create
 from src.modules.optimization_drafts.model import OptimizationDraftModel
 from src.modules.optimization_drafts.schemas import DraftCreate, DraftUpdate
+from src.shared.branch_scope import BranchScopedMixin
 from src.shared.crud import CRUDService
 from src.shared.database import get_db
 
 
 class OptimizationDraftService(
-    CRUDService[OptimizationDraftModel, DraftCreate, DraftUpdate]
+    BranchScopedMixin, CRUDService[OptimizationDraftModel, DraftCreate, DraftUpdate]
 ):
-    """CRUD de borradores del optimizador.
+    """CRUD de borradores del optimizador, aislado por sucursal.
 
     Sin optimización, sin antiabuso, sin gate de teléfono ni cap: un borrador es
-    trabajo en progreso editable. La base genérica cubre todas las operaciones.
+    trabajo en progreso editable. El ``BranchScopedMixin`` aísla el trabajo en curso
+    entre sucursales (el admin —scope ``None``— ve todos).
     """
 
     model = OptimizationDraftModel
+
+    def create_scoped(
+        self, data: DraftCreate, branch_scope: Optional[int] = None
+    ) -> OptimizationDraftModel:
+        """Crea un borrador en la sucursal resuelta desde el scope (no del body)."""
+        branch_id = resolve_branch_for_create(self.db, branch_scope, data.branch_id)
+        draft = OptimizationDraftModel(
+            **data.model_dump(exclude={"branch_id"}), branch_id=branch_id
+        )
+        return self._persist(draft)
+
+    def list_scoped(
+        self,
+        branch_scope: Optional[int] = None,
+        branch_filter: Optional[int] = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> Tuple[List[OptimizationDraftModel], int]:
+        """Lista borradores aplicando el aislamiento por sucursal."""
+        query = self._apply_branch_scope(
+            self.db.query(OptimizationDraftModel), branch_scope, branch_filter
+        )
+        return self._paginate(query, limit, offset)
+
+    def update_scoped(
+        self, id: int, data: DraftUpdate, branch_scope: Optional[int] = None
+    ) -> OptimizationDraftModel:
+        """Actualiza un borrador verificando antes que sea de la sucursal del usuario."""
+        self.get_scoped_or_404(id, branch_scope)
+        return self.update(id, data)
+
+    def delete_scoped(self, id: int, branch_scope: Optional[int] = None) -> None:
+        """Elimina un borrador verificando antes que sea de la sucursal del usuario."""
+        self.get_scoped_or_404(id, branch_scope)
+        self.delete(id)
 
 
 def optimization_draft_service(

--- a/src/modules/optimizations/carrier.py
+++ b/src/modules/optimizations/carrier.py
@@ -42,17 +42,23 @@ class ProformaCarrier:
         reference: str,
         company: dict | None = None,
         validity_days: Optional[int] = None,
+        branch: dict | None = None,
     ) -> "ProformaCarrier":
         """Construye el portador desde un payload de optimización + el cliente.
 
         ``company`` es el membrete vigente (datos de la empresa) que se renderiza en
         vivo; no forma parte del snapshot con precio. ``validity_days`` es la vigencia
-        de la cotización que muestra la proforma (``None`` la omite).
+        de la cotización que muestra la proforma (``None`` la omite). ``branch``, si se
+        da, es la sucursal dueña del documento: reemplaza el listado de sucursales del
+        membrete para mostrar solo esa (``{"name", "address"}``).
         """
+        company = company or {}
+        if branch is not None:
+            company = {**company, "branches": [branch]}
         return cls(
             reference=reference,
             client=client,
-            company=company or {},
+            company=company,
             validity_days=validity_days,
             requirements=payload.get("requirements") or [],
             materials_summary=payload.get("materials_summary") or [],
@@ -67,17 +73,20 @@ class ProformaCarrier:
         )
 
     @classmethod
-    def from_order(cls, order, company: dict | None = None) -> "ProformaCarrier":
+    def from_order(
+        cls, order, company: dict | None = None, branch: dict | None = None
+    ) -> "ProformaCarrier":
         """Construye el portador desde una orden (snapshot + precios congelados).
 
         El desglose (tableros vs tapacantos) se toma del snapshot inmutable; el
         gran total congelado vive en ``order.total`` (= tableros + tapacantos). El
         membrete (``company``) se renderiza en vivo, no se congela en el snapshot.
+        ``branch`` (sucursal de la orden) acota el membrete a esa sucursal.
         """
         snapshot = order.optimization_snapshot or {}
         reference = order.code or f"ORD-{order.id:06d}"
         carrier = cls.from_payload(
-            snapshot, order.client, reference=reference, company=company
+            snapshot, order.client, reference=reference, company=company, branch=branch
         )
         # La orden congela el conteo de tableros al confirmar.
         carrier.total_boards_used = order.total_boards_used

--- a/src/modules/orders/model.py
+++ b/src/modules/orders/model.py
@@ -46,6 +46,9 @@ class OrderModel(TimestampMixin, AuditMixin, Base):
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     code: Mapped[Optional[str]] = mapped_column(String(32), unique=True, nullable=True)
     client_id: Mapped[int] = mapped_column(ForeignKey("clients.id"))
+    # Sucursal dueña de la orden: hecho histórico inmutable (heredado de la pre-orden
+    # al confirmar). Mover de sucursal a un vendedor no reasigna sus órdenes pasadas.
+    branch_id: Mapped[int] = mapped_column(ForeignKey("branches.id"), index=True)
     status: Mapped[str] = mapped_column(String(32), default=OrderStatus.confirmed.value)
 
     optimization_snapshot: Mapped[dict] = mapped_column(JSON)

--- a/src/modules/orders/router.py
+++ b/src/modules/orders/router.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, Query
 
+from src.modules.branches.service import branch_letterhead
 from src.modules.optimizations.carrier import ProformaCarrier
 from src.modules.optimizations.proforma import ProformaService, pdf_response
 from src.modules.orders.model import OrderStatus
@@ -16,7 +17,7 @@ from src.modules.orders.schemas import (
 )
 from src.modules.orders.service import OrderService, order_service
 from src.modules.settings.service import SettingsService, settings_service
-from src.modules.users.dependencies import require_permission
+from src.modules.users.dependencies import get_branch_scope, require_permission
 from src.modules.users.model import UserModel
 from src.shared.audit import staff_actor
 from src.shared.pagination import PageParams
@@ -49,12 +50,25 @@ def list_orders(
     status: Optional[OrderStatus] = Query(
         default=None, description="Filtra órdenes por estado"
     ),
+    branch_id: Optional[int] = Query(
+        default=None,
+        alias="branchId",
+        description="Solo admin: estrecha el listado a una sucursal (vacío = todas)",
+    ),
     paging: PageParams = Depends(),
     svc: OrderService = Depends(order_service),
+    branch_scope: Optional[int] = Depends(get_branch_scope),
 ):
-    """Lista órdenes con filtro por estado y paginación opcionales."""
+    """Lista órdenes con filtro por estado y paginación opcionales.
+
+    El staff solo ve las de su sucursal; el admin ve todas (o filtra con ``branchId``).
+    """
     items, total = svc.list_orders(
-        status=status, limit=paging.limit, offset=paging.offset
+        status=status,
+        branch_scope=branch_scope,
+        branch_filter=branch_id,
+        limit=paging.limit,
+        offset=paging.offset,
     )
     return page(items, total, paging.limit, paging.offset)
 
@@ -62,9 +76,13 @@ def list_orders(
 @router.get(
     "/{order_id}", response_model=DataResponse[OrderResponse], dependencies=[_READ]
 )
-def get_order(order_id: int, svc: OrderService = Depends(order_service)):
-    """Obtiene una orden por ID."""
-    return ok(svc.get_or_404(order_id))
+def get_order(
+    order_id: int,
+    svc: OrderService = Depends(order_service),
+    branch_scope: Optional[int] = Depends(get_branch_scope),
+):
+    """Obtiene una orden por ID (404 si es de otra sucursal y no eres admin)."""
+    return ok(svc.get_scoped_or_404(order_id, branch_scope))
 
 
 @router.patch(
@@ -76,11 +94,16 @@ def update_order_status(
     data: OrderStatusUpdate,
     svc: OrderService = Depends(order_service),
     current_user: UserModel = Depends(require_permission("orders:write")),
+    branch_scope: Optional[int] = Depends(get_branch_scope),
 ):
     """Transiciona el estado de una orden validando la máquina de estados."""
     return ok(
         svc.transition(
-            order_id, data.status, actor=staff_actor(current_user), note=data.note
+            order_id,
+            data.status,
+            actor=staff_actor(current_user),
+            note=data.note,
+            branch_scope=branch_scope,
         )
     )
 
@@ -90,9 +113,13 @@ def update_order_status(
     response_model=DataResponse[CuttingPlanResponse],
     dependencies=[_CUTTING],
 )
-def get_cutting_plan(order_id: int, svc: OrderService = Depends(order_service)):
+def get_cutting_plan(
+    order_id: int,
+    svc: OrderService = Depends(order_service),
+    branch_scope: Optional[int] = Depends(get_branch_scope),
+):
     """Plan de corte para la vista de taller: tableros físicos, piezas y avance."""
-    return ok(svc.get_cutting_plan(order_id))
+    return ok(svc.get_cutting_plan(order_id, branch_scope=branch_scope))
 
 
 @router.patch(
@@ -105,6 +132,7 @@ def mark_piece_cut(
     data: PieceCutUpdate,
     svc: OrderService = Depends(order_service),
     current_user: UserModel = Depends(require_permission("cutting_plan")),
+    branch_scope: Optional[int] = Depends(get_branch_scope),
 ):
     """Marca (o desmarca, ``cut=false``) una pieza colocada como cortada.
 
@@ -112,7 +140,11 @@ def mark_piece_cut(
     """
     return ok(
         svc.mark_piece_cut(
-            order_id, piece_id, data.cut, actor=staff_actor(current_user)
+            order_id,
+            piece_id,
+            data.cut,
+            actor=staff_actor(current_user),
+            branch_scope=branch_scope,
         )
     )
 
@@ -126,9 +158,14 @@ def set_order_invoice(
     order_id: int,
     data: OrderInvoiceUpdate,
     svc: OrderService = Depends(order_service),
+    branch_scope: Optional[int] = Depends(get_branch_scope),
 ):
     """Asocia el ID de la factura externa (costura con el proveedor de facturación)."""
-    return ok(svc.set_external_invoice_id(order_id, data.external_invoice_id))
+    return ok(
+        svc.set_external_invoice_id(
+            order_id, data.external_invoice_id, branch_scope=branch_scope
+        )
+    )
 
 
 @router.get(
@@ -136,9 +173,13 @@ def set_order_invoice(
     response_model=DataResponse[OrderExportResponse],
     dependencies=[_WRITE],
 )
-def export_order(order_id: int, svc: OrderService = Depends(order_service)):
+def export_order(
+    order_id: int,
+    svc: OrderService = Depends(order_service),
+    branch_scope: Optional[int] = Depends(get_branch_scope),
+):
     """Documento de facturación neutral para el proveedor externo (cobro=tableros)."""
-    return ok(svc.build_export(order_id))
+    return ok(svc.build_export(order_id, branch_scope=branch_scope))
 
 
 # Exentos de la envoltura JSON: transporte de archivo PDF (StreamingResponse) y su
@@ -149,10 +190,15 @@ def get_order_proforma(
     format: str = _FORMAT_QUERY,
     svc: OrderService = Depends(order_service),
     settings_svc: SettingsService = Depends(settings_service),
+    branch_scope: Optional[int] = Depends(get_branch_scope),
 ):
     """Proforma comercial (con precios congelados) renderizada desde el snapshot."""
-    order = svc.get_or_404(order_id)
-    carrier = ProformaCarrier.from_order(order, company=settings_svc.get_company())
+    order = svc.get_scoped_or_404(order_id, branch_scope)
+    carrier = ProformaCarrier.from_order(
+        order,
+        company=settings_svc.get_company(),
+        branch=branch_letterhead(svc.db, order.branch_id),
+    )
     pdf_buffer = ProformaService.generate_proforma_pdf(carrier)
     return pdf_response(pdf_buffer, f"proforma_{order.code or order.id}.pdf", format)
 
@@ -163,9 +209,14 @@ def get_order_production_sheet(
     format: str = _FORMAT_QUERY,
     svc: OrderService = Depends(order_service),
     settings_svc: SettingsService = Depends(settings_service),
+    branch_scope: Optional[int] = Depends(get_branch_scope),
 ):
     """Hoja de producción (lista de corte y disposición, SIN precios) para el taller."""
-    order = svc.get_or_404(order_id)
-    carrier = ProformaCarrier.from_order(order, company=settings_svc.get_company())
+    order = svc.get_scoped_or_404(order_id, branch_scope)
+    carrier = ProformaCarrier.from_order(
+        order,
+        company=settings_svc.get_company(),
+        branch=branch_letterhead(svc.db, order.branch_id),
+    )
     pdf_buffer = ProformaService.generate_production_sheet_pdf(carrier)
     return pdf_response(pdf_buffer, f"produccion_{order.code or order.id}.pdf", format)

--- a/src/modules/orders/schemas.py
+++ b/src/modules/orders/schemas.py
@@ -26,6 +26,10 @@ class OrderCreate(CamelModel):
         ..., min_length=1, description="Cut list to optimize and freeze into the order"
     )
     client_id: int = Field(..., description="Client ID placing the order")
+    branch_id: Optional[int] = Field(
+        default=None,
+        description="Owning branch (inherited from the pre-order on confirmation)",
+    )
     notes: Optional[str] = Field(default=None, max_length=512)
     source: Optional[str] = Field(default="telegram", max_length=32)
     status: Literal[OrderStatus.confirmed] = Field(

--- a/src/modules/orders/service.py
+++ b/src/modules/orders/service.py
@@ -4,6 +4,7 @@ from typing import List, Optional, Tuple
 from fastapi import Depends
 from sqlalchemy.orm import Session
 
+from src.modules.branches.service import resolve_branch_for_create
 from src.modules.clients.model import ClientModel
 from src.modules.clients.service import require_phone
 from src.modules.optimizations.patterns import base_label
@@ -31,12 +32,19 @@ from src.modules.orders.schemas import (
     PlacedPieceResponse,
 )
 from src.shared.audit import Actor, system_actor
+from src.shared.branch_scope import BranchScopedMixin
 from src.shared.database import get_db
 from src.shared.exceptions import BusinessRuleError, ConflictError, EntityNotFoundError
 
 
-class OrderService:
-    """Crea órdenes (snapshot inmutable), gestiona estados y antiabuso."""
+class OrderService(BranchScopedMixin):
+    """Crea órdenes (snapshot inmutable), gestiona estados y antiabuso.
+
+    Aislada por sucursal (``BranchScopedMixin``): los listados y accesos por id se
+    filtran por la sucursal del usuario; el administrador (scope ``None``) ve todas.
+    """
+
+    model = OrderModel
 
     def __init__(self, db: Session):
         self.db = db
@@ -51,13 +59,20 @@ class OrderService:
     def list_orders(
         self,
         status: Optional[OrderStatus] = None,
+        branch_scope: Optional[int] = None,
+        branch_filter: Optional[int] = None,
         limit: int = 20,
         offset: int = 0,
     ) -> Tuple[List[OrderModel], int]:
-        """Lista órdenes (más recientes primero) con conteo total: ``(items, total)``."""
+        """Lista órdenes (más recientes primero) con conteo total: ``(items, total)``.
+
+        ``branch_scope`` aísla al staff a su sucursal; el admin (``None``) ve todas y
+        puede estrechar a una con ``branch_filter``.
+        """
         query = self.db.query(OrderModel)
         if status is not None:
             query = query.filter(OrderModel.status == status.value)
+        query = self._apply_branch_scope(query, branch_scope, branch_filter)
         total = query.count()
         orders = query.order_by(OrderModel.id.desc()).offset(offset).limit(limit).all()
         return orders, total
@@ -75,6 +90,9 @@ class OrderService:
         if client is None:
             raise EntityNotFoundError("Client", data.client_id)
         require_phone(client)
+        # La sucursal viene del llamador de confianza (la pre-orden al confirmar);
+        # se valida que exista y esté activa. ``branch_scope=None`` ⇒ exige branchId.
+        branch_id = resolve_branch_for_create(self.db, None, data.branch_id)
 
         opt_request = OptimizeRequest(
             materials=data.materials,
@@ -87,7 +105,9 @@ class OrderService:
         # congelan tal cual el snapshot. Sus líneas/piezas quedan con ``product_id``
         # nulo y se identifican por ``product_code``/``product_name``.
 
-        existing = self._find_active_duplicate(data.client_id, optimization_hash)
+        existing = self._find_active_duplicate(
+            branch_id, data.client_id, optimization_hash
+        )
         if existing is not None:
             return existing
 
@@ -100,6 +120,7 @@ class OrderService:
         now = datetime.utcnow()
         order = OrderModel(
             client_id=data.client_id,
+            branch_id=branch_id,
             status=data.status.value,
             optimization_snapshot=payload,
             optimization_hash=optimization_hash,
@@ -183,6 +204,7 @@ class OrderService:
         to_status: OrderStatus,
         actor: Optional[Actor] = None,
         note: Optional[str] = None,
+        branch_scope: Optional[int] = None,
     ) -> OrderModel:
         """Valida y aplica una transición de estado, registrando el historial.
 
@@ -190,7 +212,7 @@ class OrderService:
         de corte estén marcadas como cortadas. ``actor`` audita quién la origina.
         """
         actor = actor or system_actor()
-        order = self.get_or_404(order_id)
+        order = self.get_scoped_or_404(order_id, branch_scope)
         if (
             to_status == OrderStatus.cut
             and order.status == OrderStatus.in_production.value
@@ -211,9 +233,11 @@ class OrderService:
         self.db.refresh(order)
         return order
 
-    def get_cutting_plan(self, order_id: int) -> CuttingPlanResponse:
+    def get_cutting_plan(
+        self, order_id: int, branch_scope: Optional[int] = None
+    ) -> CuttingPlanResponse:
         """Plan de corte para la vista de taller: tableros físicos + avance."""
-        order = self.get_or_404(order_id)
+        order = self.get_scoped_or_404(order_id, branch_scope)
         self._ensure_cutting_plan(order)
         boards = [
             OrderBoardResponse(
@@ -247,6 +271,7 @@ class OrderService:
         placed_piece_id: int,
         cut: bool,
         actor: Optional[Actor] = None,
+        branch_scope: Optional[int] = None,
     ) -> PieceCutResponse:
         """Marca (o desmarca) una pieza colocada como cortada, idempotente.
 
@@ -255,7 +280,7 @@ class OrderService:
         quién la cortó (FK + etiqueta), en sincronía con ``cut_at``.
         """
         actor = actor or system_actor()
-        order = self.get_or_404(order_id)
+        order = self.get_scoped_or_404(order_id, branch_scope)
         self._ensure_cutting_plan(order)
         if order.status != OrderStatus.in_production.value:
             raise BusinessRuleError(
@@ -324,14 +349,17 @@ class OrderService:
         order.status = to_status.value
 
     def set_external_invoice_id(
-        self, order_id: int, external_invoice_id: str
+        self,
+        order_id: int,
+        external_invoice_id: str,
+        branch_scope: Optional[int] = None,
     ) -> OrderModel:
         """Asocia (costura de facturación) el ID de la factura externa a la orden.
 
         Idempotente con el mismo ID; si ya hay otro asociado lanza ``ConflictError``
         para no pisar una factura ya emitida.
         """
-        order = self.get_or_404(order_id)
+        order = self.get_scoped_or_404(order_id, branch_scope)
         if (
             order.external_invoice_id is not None
             and order.external_invoice_id != external_invoice_id
@@ -345,9 +373,11 @@ class OrderService:
         self.db.refresh(order)
         return order
 
-    def build_export(self, order_id: int) -> OrderExportResponse:
+    def build_export(
+        self, order_id: int, branch_scope: Optional[int] = None
+    ) -> OrderExportResponse:
         """Proyecta la orden como documento de facturación neutral (cobro=tableros)."""
-        order = self.get_or_404(order_id)
+        order = self.get_scoped_or_404(order_id, branch_scope)
         lines = [
             OrderExportLine(
                 description=_line_description(line),
@@ -371,13 +401,18 @@ class OrderService:
         )
 
     def _find_active_duplicate(
-        self, client_id: int, optimization_hash: str
+        self, branch_id: int, client_id: int, optimization_hash: str
     ) -> Optional[OrderModel]:
-        """Orden no terminal del cliente con el mismo hash (idempotencia)."""
+        """Orden no terminal de la misma sucursal+cliente con igual hash (idempotencia).
+
+        Incluye la sucursal en la clave: el mismo cliente puede pedir lo mismo en dos
+        sucursales y son órdenes distintas.
+        """
         terminal = [s.value for s in TERMINAL_STATUSES]
         return (
             self.db.query(OrderModel)
             .filter(
+                OrderModel.branch_id == branch_id,
                 OrderModel.client_id == client_id,
                 OrderModel.optimization_hash == optimization_hash,
                 OrderModel.status.not_in(terminal),

--- a/src/modules/preorders/model.py
+++ b/src/modules/preorders/model.py
@@ -62,6 +62,8 @@ class PreOrderModel(TimestampMixin, AuditMixin, Base):
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     code: Mapped[Optional[str]] = mapped_column(String(32), unique=True, nullable=True)
     client_id: Mapped[int] = mapped_column(ForeignKey("clients.id"))
+    # Sucursal dueña de la cotización (heredada por la orden al confirmar).
+    branch_id: Mapped[int] = mapped_column(ForeignKey("branches.id"), index=True)
     status: Mapped[str] = mapped_column(String(16), default=PreOrderStatus.draft.value)
 
     # Inputs del optimizador, tal cual, para recalcular (no se guarda snapshot).

--- a/src/modules/preorders/review_service.py
+++ b/src/modules/preorders/review_service.py
@@ -68,7 +68,10 @@ class PreOrderReviewService:
         self.orders = OrderService(db)
 
     def generate(
-        self, preorder_id: int, actor: Optional[Actor] = None
+        self,
+        preorder_id: int,
+        actor: Optional[Actor] = None,
+        branch_scope: Optional[int] = None,
     ) -> Tuple[PreOrderReviewLinkModel, str]:
         """Crea un enlace nuevo (revocando el activo previo) y devuelve el token.
 
@@ -78,7 +81,7 @@ class PreOrderReviewService:
         ``(link, token_crudo)``; el token solo existe en esta respuesta.
         """
         actor = actor or system_actor()
-        preorder = self.preorders.get_or_404(preorder_id)
+        preorder = self.preorders.get_scoped_or_404(preorder_id, branch_scope)
         if preorder.status not in {s.value for s in OPEN_STATUSES}:
             raise BusinessRuleError(
                 "Solo se puede generar un enlace de revisión para una pre-orden "
@@ -117,9 +120,11 @@ class PreOrderReviewService:
         self.db.refresh(link)
         return link, raw_token
 
-    def get_latest_info(self, preorder_id: int) -> PreOrderReviewLinkModel:
+    def get_latest_info(
+        self, preorder_id: int, branch_scope: Optional[int] = None
+    ) -> PreOrderReviewLinkModel:
         """Último enlace de la pre-orden (metadatos; nunca expone el token)."""
-        preorder = self.preorders.get_or_404(preorder_id)
+        preorder = self.preorders.get_scoped_or_404(preorder_id, branch_scope)
         if not preorder.review_links:
             raise EntityNotFoundError("ReviewLink de la pre-orden", preorder_id)
         return preorder.review_links[-1]
@@ -157,6 +162,7 @@ class PreOrderReviewService:
                 materials=preorder.materials,
                 requirements=preorder.requirements,
                 client_id=preorder.client_id,
+                branch_id=preorder.branch_id,
                 notes=preorder.notes,
                 source=preorder.source,
             ),

--- a/src/modules/preorders/router.py
+++ b/src/modules/preorders/router.py
@@ -17,7 +17,11 @@ from src.modules.preorders.schemas import (
     ReviewLinkResponse,
 )
 from src.modules.preorders.service import PreOrderService, preorder_service
-from src.modules.users.dependencies import get_current_user, require_permission
+from src.modules.users.dependencies import (
+    get_branch_scope,
+    get_current_user,
+    require_permission,
+)
 from src.modules.users.model import UserModel
 from src.shared.audit import staff_actor
 from src.shared.pagination import PageParams
@@ -74,9 +78,20 @@ def create_preorder(
     data: PreOrderCreate,
     svc: PreOrderService = Depends(preorder_service),
     current_user: UserModel = Depends(get_current_user),
+    branch_scope: Optional[int] = Depends(get_branch_scope),
 ):
-    """Crea una pre-orden (cotización mutable) con los inputs del optimizador."""
-    return ok(_detail(svc, svc.create(data, actor=staff_actor(current_user))))
+    """Crea una pre-orden (cotización mutable) con los inputs del optimizador.
+
+    El staff la crea en su sucursal; el admin debe indicar ``branchId``.
+    """
+    return ok(
+        _detail(
+            svc,
+            svc.create(
+                data, actor=staff_actor(current_user), branch_scope=branch_scope
+            ),
+        )
+    )
 
 
 @router.get("/", response_model=PaginatedResponse[PreOrderSummaryResponse])
@@ -87,20 +102,38 @@ def list_preorders(
     client_id: Optional[int] = Query(
         default=None, alias="clientId", description="Filtra por cliente"
     ),
+    branch_id: Optional[int] = Query(
+        default=None,
+        alias="branchId",
+        description="Solo admin: estrecha el listado a una sucursal (vacío = todas)",
+    ),
     paging: PageParams = Depends(),
     svc: PreOrderService = Depends(preorder_service),
+    branch_scope: Optional[int] = Depends(get_branch_scope),
 ):
-    """Lista pre-órdenes (resumen liviano) con filtros y paginación opcionales."""
+    """Lista pre-órdenes (resumen liviano) con filtros y paginación opcionales.
+
+    El staff solo ve las de su sucursal; el admin ve todas (o filtra con ``branchId``).
+    """
     items, total = svc.list_preorders(
-        status=status, client_id=client_id, limit=paging.limit, offset=paging.offset
+        status=status,
+        client_id=client_id,
+        branch_scope=branch_scope,
+        branch_filter=branch_id,
+        limit=paging.limit,
+        offset=paging.offset,
     )
     return page(items, total, paging.limit, paging.offset)
 
 
 @router.get("/{preorder_id}", response_model=DataResponse[PreOrderResponse])
-def get_preorder(preorder_id: int, svc: PreOrderService = Depends(preorder_service)):
+def get_preorder(
+    preorder_id: int,
+    svc: PreOrderService = Depends(preorder_service),
+    branch_scope: Optional[int] = Depends(get_branch_scope),
+):
     """Obtiene una pre-orden por ID con su optimización recalculada."""
-    return ok(_detail(svc, svc.get_or_404(preorder_id)))
+    return ok(_detail(svc, svc.get_scoped_or_404(preorder_id, branch_scope)))
 
 
 @router.put("/{preorder_id}", response_model=DataResponse[PreOrderResponse])
@@ -109,17 +142,30 @@ def update_preorder(
     data: PreOrderUpdate,
     svc: PreOrderService = Depends(preorder_service),
     current_user: UserModel = Depends(get_current_user),
+    branch_scope: Optional[int] = Depends(get_branch_scope),
 ):
     """Edita una pre-orden abierta (draft/sent)."""
     return ok(
-        _detail(svc, svc.update(preorder_id, data, actor=staff_actor(current_user)))
+        _detail(
+            svc,
+            svc.update(
+                preorder_id,
+                data,
+                actor=staff_actor(current_user),
+                branch_scope=branch_scope,
+            ),
+        )
     )
 
 
 @router.delete("/{preorder_id}", status_code=204)
-def delete_preorder(preorder_id: int, svc: PreOrderService = Depends(preorder_service)):
+def delete_preorder(
+    preorder_id: int,
+    svc: PreOrderService = Depends(preorder_service),
+    branch_scope: Optional[int] = Depends(get_branch_scope),
+):
     """Elimina una pre-orden (salvo si ya fue confirmada)."""
-    svc.delete(preorder_id)
+    svc.delete(preorder_id, branch_scope=branch_scope)
 
 
 @router.post(
@@ -131,13 +177,16 @@ def create_review_link(
     preorder_id: int,
     svc: PreOrderReviewService = Depends(preorder_review_service),
     current_user: UserModel = Depends(get_current_user),
+    branch_scope: Optional[int] = Depends(get_branch_scope),
 ):
     """Genera el enlace de revisión del cliente (revoca el anterior si existía).
 
     Transiciona la pre-orden a ``sent``. El token solo se expone en esta respuesta;
     si se pierde, se regenera.
     """
-    link, raw_token = svc.generate(preorder_id, actor=staff_actor(current_user))
+    link, raw_token = svc.generate(
+        preorder_id, actor=staff_actor(current_user), branch_scope=branch_scope
+    )
     return ok(
         ReviewLinkResponse(
             token=raw_token,
@@ -153,10 +202,12 @@ def create_review_link(
     "/{preorder_id}/review-link", response_model=DataResponse[ReviewLinkInfoResponse]
 )
 def get_review_link_info(
-    preorder_id: int, svc: PreOrderReviewService = Depends(preorder_review_service)
+    preorder_id: int,
+    svc: PreOrderReviewService = Depends(preorder_review_service),
+    branch_scope: Optional[int] = Depends(get_branch_scope),
 ):
     """Metadatos del último enlace de revisión (sin el token, irrecuperable)."""
-    return ok(svc.get_latest_info(preorder_id))
+    return ok(svc.get_latest_info(preorder_id, branch_scope=branch_scope))
 
 
 # Exento de la envoltura JSON: transporte de archivo PDF (StreamingResponse/base64).
@@ -165,9 +216,10 @@ def get_preorder_proforma(
     preorder_id: int,
     format: str = _FORMAT_QUERY,
     svc: PreOrderService = Depends(preorder_service),
+    branch_scope: Optional[int] = Depends(get_branch_scope),
 ):
     """Proforma comercial recalculada (precios vivos) de la pre-orden."""
-    preorder = svc.get_or_404(preorder_id)
+    preorder = svc.get_scoped_or_404(preorder_id, branch_scope)
     carrier = svc.build_carrier(preorder)
     pdf_buffer = ProformaService.generate_proforma_pdf(carrier)
     return pdf_response(

--- a/src/modules/preorders/schemas.py
+++ b/src/modules/preorders/schemas.py
@@ -31,6 +31,13 @@ class PreOrderCreate(CamelModel):
     client_id: int = Field(..., description="Client the quote is for")
     notes: Optional[str] = Field(default=None, max_length=512)
     source: Optional[str] = Field(default="telegram", max_length=32)
+    branch_id: Optional[int] = Field(
+        default=None,
+        description=(
+            "Target branch. Ignored for branch staff (forced to their own branch); "
+            "required for a global admin."
+        ),
+    )
 
 
 class PreOrderUpdate(CamelModel):

--- a/src/modules/preorders/service.py
+++ b/src/modules/preorders/service.py
@@ -4,6 +4,7 @@ from typing import List, Optional, Tuple
 from fastapi import Depends
 from sqlalchemy.orm import Session
 
+from src.modules.branches.service import branch_letterhead, resolve_branch_for_create
 from src.modules.clients.model import ClientModel
 from src.modules.optimizations.carrier import ProformaCarrier
 from src.modules.optimizations.schemas import OptimizeRequest, OptimizeResponse
@@ -17,20 +18,26 @@ from src.modules.preorders.model import (
 from src.modules.preorders.schemas import PreOrderCreate, PreOrderUpdate
 from src.modules.settings.service import SettingsService
 from src.shared.audit import Actor, system_actor
+from src.shared.branch_scope import BranchScopedMixin
 from src.shared.database import get_db
 from src.shared.exceptions import BusinessRuleError, EntityNotFoundError
 
 _OPEN_VALUES = [s.value for s in OPEN_STATUSES]
 
 
-class PreOrderService:
+class PreOrderService(BranchScopedMixin):
     """Gestiona pre-órdenes: CRUD mutable, recálculo cache-first y antiabuso.
 
     No congela nada: guarda los inputs (``materials`` + ``requirements``) y delega
     el cómputo en ``OptimizationService.compute`` (cache-first) cada vez que hace
     falta mostrar la cotización o el PDF. La Orden inmutable se mintea aparte, al
     confirmar el cliente (ver ``PreOrderReviewService``).
+
+    Aislada por sucursal (``BranchScopedMixin``): el staff solo ve/edita las de su
+    sucursal; el admin (scope ``None``) todas.
     """
+
+    model = PreOrderModel
 
     def __init__(self, db: Session):
         self.db = db
@@ -50,16 +57,23 @@ class PreOrderService:
         self,
         status: Optional[PreOrderStatus] = None,
         client_id: Optional[int] = None,
+        branch_scope: Optional[int] = None,
+        branch_filter: Optional[int] = None,
         limit: int = 20,
         offset: int = 0,
     ) -> Tuple[List[PreOrderModel], int]:
-        """Lista pre-órdenes (más recientes primero) con conteo: ``(items, total)``."""
+        """Lista pre-órdenes (más recientes primero) con conteo: ``(items, total)``.
+
+        ``branch_scope`` aísla al staff a su sucursal; el admin (``None``) ve todas y
+        puede estrechar con ``branch_filter``.
+        """
         self._sweep_expired()
         query = self.db.query(PreOrderModel)
         if status is not None:
             query = query.filter(PreOrderModel.status == status.value)
         if client_id is not None:
             query = query.filter(PreOrderModel.client_id == client_id)
+        query = self._apply_branch_scope(query, branch_scope, branch_filter)
         total = query.count()
         items = (
             query.order_by(PreOrderModel.id.desc()).offset(offset).limit(limit).all()
@@ -67,13 +81,21 @@ class PreOrderService:
         return items, total
 
     def create(
-        self, data: PreOrderCreate, actor: Optional[Actor] = None
+        self,
+        data: PreOrderCreate,
+        actor: Optional[Actor] = None,
+        branch_scope: Optional[int] = None,
     ) -> PreOrderModel:
-        """Crea una pre-orden abierta (``draft``) con los inputs del optimizador."""
+        """Crea una pre-orden abierta (``draft``) con los inputs del optimizador.
+
+        La sucursal se resuelve desde ``branch_scope`` (staff → la suya; admin → la
+        indicada en ``data.branch_id``). El tope antiabuso se evalúa por sucursal.
+        """
         actor = actor or system_actor()
         if self.db.get(ClientModel, data.client_id) is None:
             raise EntityNotFoundError("Client", data.client_id)
-        self._enforce_open_cap(data.client_id)
+        branch_id = resolve_branch_for_create(self.db, branch_scope, data.branch_id)
+        self._enforce_open_cap(data.client_id, branch_id)
 
         validity_days = self.settings_service.get_preorder_config()[
             "preorder_validity_days"
@@ -81,6 +103,7 @@ class PreOrderService:
         now = datetime.utcnow()
         preorder = PreOrderModel(
             client_id=data.client_id,
+            branch_id=branch_id,
             status=PreOrderStatus.draft.value,
             materials=[m.model_dump(mode="json") for m in data.materials],
             requirements=[r.model_dump(mode="json") for r in data.requirements],
@@ -101,11 +124,15 @@ class PreOrderService:
         return preorder
 
     def update(
-        self, preorder_id: int, data: PreOrderUpdate, actor: Optional[Actor] = None
+        self,
+        preorder_id: int,
+        data: PreOrderUpdate,
+        actor: Optional[Actor] = None,
+        branch_scope: Optional[int] = None,
     ) -> PreOrderModel:
         """Edita una pre-orden abierta; rechaza si ya es terminal (confirmed/etc.)."""
         actor = actor or system_actor()
-        preorder = self.get_or_404(preorder_id)
+        preorder = self.get_scoped_or_404(preorder_id, branch_scope)
         self._ensure_open(preorder)
         fields = data.model_dump(exclude_unset=True)
         if data.client_id is not None:
@@ -139,9 +166,9 @@ class PreOrderService:
         self.db.refresh(preorder)
         return preorder
 
-    def delete(self, preorder_id: int) -> None:
+    def delete(self, preorder_id: int, branch_scope: Optional[int] = None) -> None:
         """Elimina una pre-orden (salvo si ya fue confirmada: tiene una orden viva)."""
-        preorder = self.get_or_404(preorder_id)
+        preorder = self.get_scoped_or_404(preorder_id, branch_scope)
         if preorder.status == PreOrderStatus.confirmed.value:
             raise BusinessRuleError(
                 "No se puede eliminar una pre-orden ya confirmada; la orden generada "
@@ -177,6 +204,7 @@ class PreOrderService:
             validity_days=self.settings_service.get_preorder_config()[
                 "preorder_validity_days"
             ],
+            branch=branch_letterhead(self.db, preorder.branch_id),
         )
 
     def _record_transition(
@@ -237,12 +265,17 @@ class PreOrderService:
             return True
         return False
 
-    def _enforce_open_cap(self, client_id: int) -> None:
-        """Bloquea si el cliente excede el tope de pre-órdenes abiertas."""
+    def _enforce_open_cap(self, client_id: int, branch_id: int) -> None:
+        """Bloquea si el cliente excede el tope de pre-órdenes abiertas en la sucursal.
+
+        El tope se cuenta por ``(sucursal, cliente)``: un mismo cliente puede tener
+        cotizaciones abiertas en sucursales distintas sin interferir entre sí.
+        """
         candidates = (
             self.db.query(PreOrderModel)
             .filter(
                 PreOrderModel.client_id == client_id,
+                PreOrderModel.branch_id == branch_id,
                 PreOrderModel.status.in_(_OPEN_VALUES),
             )
             .all()

--- a/src/modules/users/dependencies.py
+++ b/src/modules/users/dependencies.py
@@ -66,3 +66,22 @@ def require_permission(resource: str):
     con ``KeyError`` al **cargar el router** (no en runtime), atrapando typos en CI.
     """
     return require_role(*RESOURCE_ROLES[resource])
+
+
+def get_branch_scope(
+    current_user: UserModel = Depends(get_current_user),
+) -> Optional[int]:
+    """Resuelve el alcance por sucursal del usuario autenticado.
+
+    ``None`` para el administrador (global: ve y opera todas las sucursales); el
+    ``branch_id`` asignado para el staff (vendedor/operador). Como ``get_current_user``
+    lee el usuario fresco de la BD en cada request, reasignar su sucursal surte efecto
+    al instante. Un staff sin sucursal asignada es un estado inválido (403).
+    """
+    if current_user.role == UserRole.ADMIN.value:
+        return None
+    if current_user.branch_id is None:
+        raise AuthorizationError(
+            "Tu usuario no tiene una sucursal asignada; contacta al administrador."
+        )
+    return current_user.branch_id

--- a/src/modules/users/model.py
+++ b/src/modules/users/model.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from sqlalchemy import Boolean, String
+from sqlalchemy import Boolean, ForeignKey, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from src.modules.users.enums import UserRole
@@ -24,3 +24,9 @@ class UserModel(TimestampMixin, AuditMixin, Base):
     hashed_password: Mapped[str] = mapped_column(String(255))
     role: Mapped[str] = mapped_column(String(32), default=UserRole.OPERATOR.value)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    # Sucursal asignada al staff (vendedor/operador). NULL = administrador global,
+    # que ve y opera todas las sucursales. Editable por el admin (mueve de sucursal);
+    # el cambio surte efecto al instante (la sucursal no viaja en el JWT).
+    branch_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("branches.id"), index=True, nullable=True
+    )

--- a/src/modules/users/permissions.py
+++ b/src/modules/users/permissions.py
@@ -8,6 +8,8 @@ protegerá con ``require_role(*RESOURCE_ROLES[clave])`` (ver ``dependencies.py``
 |-------------------------------|---------------|----------|----------|
 | users:manage                  | sí            | no       | no       |
 | settings:manage               | sí            | no       | no       |
+| branches:manage               | sí            | no       | no       |
+| branches:read                 | sí            | sí       | sí       |
 | clients:manage                | sí            | sí       | no       |
 | products:write                | sí            | no       | no       |
 | products:read                 | sí            | sí       | no       |
@@ -28,6 +30,10 @@ _OPERATOR = UserRole.OPERATOR
 RESOURCE_ROLES: dict[str, tuple[UserRole, ...]] = {
     "users:manage": (_ADMIN,),
     "settings:manage": (_ADMIN,),
+    # Sucursales: solo el admin las administra (CRUD). La lectura la necesita
+    # cualquier staff para poblar selectores y mostrar el nombre de su sucursal.
+    "branches:manage": (_ADMIN,),
+    "branches:read": (_ADMIN, _SELLER, _OPERATOR),
     "clients:manage": (_ADMIN, _SELLER),
     "products:write": (_ADMIN,),
     "products:read": (_ADMIN, _SELLER),

--- a/src/modules/users/schemas.py
+++ b/src/modules/users/schemas.py
@@ -16,6 +16,13 @@ class UserBase(CamelModel):
         default=UserRole.OPERATOR,
         description="Rol: administrador, vendedor u operador",
     )
+    branch_id: Optional[int] = Field(
+        default=None,
+        description=(
+            "Sucursal asignada (obligatoria para vendedor/operador). El "
+            "administrador es global: se ignora y queda en null."
+        ),
+    )
 
 
 class UserCreate(UserBase):
@@ -33,6 +40,9 @@ class UserUpdate(CamelModel):
     )
     role: Optional[UserRole] = Field(None, description="Rol del usuario")
     is_active: Optional[bool] = Field(None, description="Activo/inactivo (baja lógica)")
+    branch_id: Optional[int] = Field(
+        None, description="Sucursal asignada (staff); null/ignorado para administrador"
+    )
     password: Optional[str] = Field(
         None, min_length=8, max_length=128, description="Nueva contraseña"
     )

--- a/src/modules/users/service.py
+++ b/src/modules/users/service.py
@@ -3,12 +3,17 @@ from typing import List, Optional, Tuple
 from fastapi import Depends
 from sqlalchemy.orm import Session
 
+from src.modules.branches.model import BranchModel
 from src.modules.users.enums import UserRole
 from src.modules.users.model import UserModel
 from src.modules.users.schemas import ProfileUpdate, UserCreate, UserUpdate
 from src.shared.crud import CRUDService
 from src.shared.database import get_db
-from src.shared.exceptions import AuthenticationError
+from src.shared.exceptions import (
+    AuthenticationError,
+    EntityNotFoundError,
+    ValidationError,
+)
 from src.shared.security import hash_password, verify_password
 
 
@@ -18,12 +23,32 @@ class UserService(CRUDService[UserModel, UserCreate, UserUpdate]):
     model = UserModel
     conflict_messages = {"email": "El email ya está registrado"}
 
+    def _normalize_branch(
+        self, role_value: str, branch_id: Optional[int]
+    ) -> Optional[int]:
+        """Concilia rol y sucursal: admin global (None); staff exige una válida.
+
+        El administrador ve y opera todas las sucursales, así que su ``branch_id``
+        se fuerza a ``None``. El vendedor/operador debe tener una sucursal existente.
+        """
+        if role_value == UserRole.ADMIN.value:
+            return None
+        if branch_id is None:
+            raise ValidationError(
+                "El vendedor/operador requiere una sucursal asignada (branchId).",
+                field="branchId",
+            )
+        if self.db.get(BranchModel, branch_id) is None:
+            raise EntityNotFoundError("Branch", branch_id)
+        return branch_id
+
     def create(self, data: UserCreate) -> UserModel:
         """Crea un usuario hasheando la contraseña; nunca la persiste en claro."""
-        payload = data.model_dump(exclude={"password", "role"})
+        payload = data.model_dump(exclude={"password", "role", "branch_id"})
         user = UserModel(
             **payload,
             role=data.role.value,
+            branch_id=self._normalize_branch(data.role.value, data.branch_id),
             hashed_password=hash_password(data.password),
         )
         return self._persist(user)
@@ -38,6 +63,9 @@ class UserService(CRUDService[UserModel, UserCreate, UserUpdate]):
             changes["role"] = UserRole(changes["role"]).value
         for field, value in changes.items():
             setattr(obj, field, value)
+        # Concilia rol↔sucursal sobre el estado resultante (cubre cambios de rol y/o
+        # de sucursal, y normaliza al admin a sucursal nula).
+        obj.branch_id = self._normalize_branch(obj.role, obj.branch_id)
         return self._persist(obj)
 
     def update_profile(self, user: UserModel, data: ProfileUpdate) -> UserModel:

--- a/src/shared/branch_scope.py
+++ b/src/shared/branch_scope.py
@@ -1,0 +1,60 @@
+"""Aislamiento por sucursal a nivel de servicio (infraestructura genérica).
+
+El *branch scope* expresa qué filas puede ver/tocar un usuario:
+
+- ``None`` → administrador global: ve y opera **todas** las sucursales (sin filtro).
+- ``int``  → staff atado a esa sucursal: solo ve/opera la suya.
+
+Se resuelve una vez por request (``users.dependencies.get_branch_scope``) y se
+propaga a los servicios. Este mixin centraliza el filtro de listado y la verificación
+de pertenencia para no repetirlo —ni arriesgar fugas— en cada servicio. Es ortogonal
+a ``require_permission`` (rol → *qué acciones*); el scope decide *qué filas*.
+
+Sin import de ningún módulo de dominio: opera sobre ``self.model`` (que debe tener
+una columna ``branch_id``) y ``self.get_or_404``, igual que ``CRUDService``.
+"""
+
+from typing import Optional
+
+from sqlalchemy.orm import Query
+
+from src.shared.exceptions import EntityNotFoundError
+
+
+class BranchScopedMixin:
+    """Filtro y guardia de pertenencia por sucursal para servicios con ``branch_id``.
+
+    La subclase define ``model`` (el modelo ORM con ``branch_id``) y aporta
+    ``get_or_404`` (vía ``CRUDService`` o propio).
+    """
+
+    model = None  # type: ignore[assignment]
+
+    def _apply_branch_scope(
+        self,
+        query: Query,
+        branch_scope: Optional[int],
+        branch_filter: Optional[int] = None,
+    ) -> Query:
+        """Aplica el aislamiento a un listado.
+
+        - staff (``branch_scope`` no None): bloqueado a su sucursal.
+        - admin (``branch_scope`` None): sin filtro, salvo que pida estrechar a una
+          sucursal concreta con ``branch_filter``.
+        """
+        if branch_scope is not None:
+            return query.filter(self.model.branch_id == branch_scope)
+        if branch_filter is not None:
+            return query.filter(self.model.branch_id == branch_filter)
+        return query
+
+    def get_scoped_or_404(self, id: int, branch_scope: Optional[int]):
+        """Obtiene por id verificando que pertenezca a la sucursal del usuario.
+
+        Un recurso de otra sucursal devuelve **404 uniforme** (no 403): no se revela
+        que existe, igual que los enlaces de revisión públicos.
+        """
+        obj = self.get_or_404(id)
+        if branch_scope is not None and obj.branch_id != branch_scope:
+            raise EntityNotFoundError(self.model.__name__, id)
+        return obj

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
 # Importar los modelos puebla ``Base.metadata`` antes de ``create_all``.
+import src.modules.branches.model  # noqa: F401,E402
 import src.modules.clients.model  # noqa: F401,E402
 import src.modules.optimization_drafts.model  # noqa: F401,E402
 import src.modules.optimizations.model  # noqa: F401,E402
@@ -17,6 +18,7 @@ import src.modules.settings.model  # noqa: F401,E402
 import src.modules.users.model  # noqa: F401,E402
 import src.modules.users.refresh_token_model  # noqa: F401,E402
 from main import app
+from src.modules.branches.model import BranchModel
 from src.modules.users.schemas import UserCreate
 from src.modules.users.service import UserService
 from src.shared.cache import cache
@@ -25,6 +27,10 @@ from src.shared.database import Base, get_db
 # Credenciales del admin que el cliente autenticado por defecto usa (ver ``client``).
 _CONFTEST_ADMIN_EMAIL = "conftest-admin@empresa.com"
 _CONFTEST_ADMIN_PWD = "conftest-admin-pwd"
+
+# Sucursal por defecto sembrada en cada base de prueba (primer insert ⇒ id estable).
+# Las suites la referencian al crear órdenes/pre-órdenes/borradores/usuarios staff.
+DEFAULT_BRANCH_ID = 1
 
 
 class _InMemoryRedis:
@@ -64,6 +70,10 @@ def db_session():
     Base.metadata.create_all(bind=engine)
     TestingSession = sessionmaker(autocommit=False, autoflush=False, bind=engine)
     session = TestingSession()
+    # Siembra la sucursal por defecto (id=1): el aislamiento multi-sucursal exige
+    # que órdenes/pre-órdenes/borradores y el staff cuelguen de una sucursal.
+    session.add(BranchModel(code="MATRIZ", name="Casa Matriz", is_active=True))
+    session.commit()
     try:
         yield session
     finally:

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -50,9 +50,11 @@ def _seed_order(
     lines=None,
     history=None,
     optimization_hash="h",
+    branch_id=1,
 ):
     order = OrderModel(
         client_id=client_id,
+        branch_id=branch_id,
         status=status,
         optimization_snapshot={},
         optimization_hash=optimization_hash,

--- a/tests/test_branches.py
+++ b/tests/test_branches.py
@@ -1,0 +1,187 @@
+"""Tests del aislamiento multi-sucursal.
+
+Cubre: CRUD de sucursales (solo admin), scope de pre-órdenes/órdenes por sucursal,
+la vista global del admin con filtro ``branchId``, la herencia de sucursal de la
+orden (hecho histórico inmutable) y el comparativo de analítica por sucursal.
+
+El ``client`` de conftest está autenticado como admin (su header de sesión); para
+actuar como staff de una sucursal se pasa ``headers=`` por request (httpx da
+precedencia al header explícito sobre el de sesión).
+"""
+
+from src.modules.orders.schemas import OrderCreate
+from src.modules.orders.service import OrderService
+from src.modules.users.schemas import UserCreate
+from src.modules.users.service import UserService
+
+from .test_orders import _create_board, _create_client, _order_payload
+
+_PWD = "supersecret123"
+_MATRIZ = 1  # sucursal por defecto sembrada por conftest
+
+
+def _staff_headers(client, db_session, role, email, branch_id):
+    """Siembra un usuario staff (rol + sucursal) y devuelve sus headers Bearer."""
+    svc = UserService(db_session)
+    if svc.get_by_email(email) is None:
+        svc.create(
+            UserCreate(
+                email=email,
+                password=_PWD,
+                role=role,
+                full_name=email,
+                branch_id=branch_id,
+            )
+        )
+    token = client.post(
+        "/api/v1/auth/login", json={"email": email, "password": _PWD}
+    ).json()["data"]["accessToken"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _make_branch(client, code="NORTE", name="Sucursal Norte"):
+    return client.post("/api/v1/branches/", json={"code": code, "name": name}).json()[
+        "data"
+    ]
+
+
+def _mint_order(db_session, client_id, product_id, branch_id, width=600):
+    payload = _order_payload(client_id, product_id, width=width)
+    payload["branchId"] = branch_id
+    return OrderService(db_session).create(OrderCreate.model_validate(payload))
+
+
+# --------------------------------------------------------------- branches CRUD
+def test_branch_crud_is_admin_only(client, db_session):
+    seller = _staff_headers(client, db_session, "vendedor", "s@e.com", _MATRIZ)
+
+    # Admin crea; el vendedor no puede administrar pero sí leer (poblar selectores).
+    created = client.post("/api/v1/branches/", json={"code": "NORTE", "name": "Norte"})
+    assert created.status_code == 201
+    assert (
+        client.post(
+            "/api/v1/branches/", json={"code": "X", "name": "X"}, headers=seller
+        ).status_code
+        == 403
+    )
+    assert client.get("/api/v1/branches/", headers=seller).status_code == 200
+
+
+def test_branch_duplicate_code_returns_409(client):
+    client.post("/api/v1/branches/", json={"code": "DUP", "name": "Uno"})
+    dup = client.post("/api/v1/branches/", json={"code": "DUP", "name": "Dos"})
+    assert dup.status_code == 409
+
+
+# ------------------------------------------------------- pre-orders aislamiento
+def test_preorders_isolated_by_branch(client, db_session):
+    norte = _make_branch(client)
+    a = _staff_headers(client, db_session, "vendedor", "a@e.com", _MATRIZ)
+    b = _staff_headers(client, db_session, "vendedor", "b@e.com", norte["id"])
+    c = _create_client(client)
+    board = _create_board(client)
+
+    # El vendedor crea en SU sucursal; el branchId del body se ignora (scope manda).
+    pre_a = client.post(
+        "/api/v1/preorders/", json=_order_payload(c["id"], board["id"]), headers=a
+    ).json()["data"]
+    pre_b = client.post(
+        "/api/v1/preorders/", json=_order_payload(c["id"], board["id"]), headers=b
+    ).json()["data"]
+
+    # A solo ve la suya; no puede acceder a la de B (404 uniforme).
+    a_list = client.get("/api/v1/preorders/", headers=a).json()["data"]
+    assert [p["id"] for p in a_list] == [pre_a["id"]]
+    assert client.get(f"/api/v1/preorders/{pre_b['id']}", headers=a).status_code == 404
+
+    # El admin ve ambas y puede filtrar por sucursal.
+    all_ids = {p["id"] for p in client.get("/api/v1/preorders/").json()["data"]}
+    assert {pre_a["id"], pre_b["id"]} <= all_ids
+    filtered = client.get(
+        "/api/v1/preorders/", params={"branchId": norte["id"]}
+    ).json()["data"]
+    assert [p["id"] for p in filtered] == [pre_b["id"]]
+
+
+# ------------------------------------------------------------ órdenes aislamiento
+def test_orders_isolated_by_branch_and_admin_sees_all(client, db_session):
+    norte = _make_branch(client)
+    a = _staff_headers(client, db_session, "vendedor", "a@e.com", _MATRIZ)
+    c = _create_client(client)
+    board = _create_board(client)
+
+    order_a = _mint_order(db_session, c["id"], board["id"], _MATRIZ, width=600)
+    order_b = _mint_order(db_session, c["id"], board["id"], norte["id"], width=500)
+    assert order_a.branch_id == _MATRIZ and order_b.branch_id == norte["id"]
+
+    # A (Matriz) solo ve la suya y no accede a la de B.
+    a_ids = [o["id"] for o in client.get("/api/v1/orders/", headers=a).json()["data"]]
+    assert a_ids == [order_a.id]
+    assert client.get(f"/api/v1/orders/{order_b.id}", headers=a).status_code == 404
+    assert client.get(f"/api/v1/orders/{order_a.id}", headers=a).status_code == 200
+
+    # El admin ve todas; ``branchId`` estrecha a una.
+    assert len(client.get("/api/v1/orders/").json()["data"]) == 2
+    only_norte = client.get("/api/v1/orders/", params={"branchId": norte["id"]}).json()[
+        "data"
+    ]
+    assert [o["id"] for o in only_norte] == [order_b.id]
+
+
+def test_reassigning_branch_changes_visibility_not_history(client, db_session):
+    """Mover de sucursal a un vendedor cambia lo que ve, no la sucursal de sus órdenes."""
+    norte = _make_branch(client)
+    seller_email = "mover@e.com"
+    a = _staff_headers(client, db_session, "vendedor", seller_email, _MATRIZ)
+    c = _create_client(client)
+    board = _create_board(client)
+    order_matriz = _mint_order(db_session, c["id"], board["id"], _MATRIZ)
+
+    assert [
+        o["id"] for o in client.get("/api/v1/orders/", headers=a).json()["data"]
+    ] == [order_matriz.id]
+
+    # El admin reasigna al vendedor a Norte; surte efecto al instante (rol/sucursal
+    # se leen de la BD en cada request, no del JWT).
+    svc = UserService(db_session)
+    user = svc.get_by_email(seller_email)
+    client.put(f"/api/v1/users/{user.id}", json={"branchId": norte["id"]})
+
+    # Ya no ve la orden de Matriz (sigue siendo de Matriz: hecho histórico).
+    assert client.get("/api/v1/orders/", headers=a).json()["data"] == []
+    assert order_matriz.branch_id == _MATRIZ
+
+
+def test_staff_without_branch_is_forbidden(client, db_session):
+    """Un staff sin sucursal asignada (estado inválido) recibe 403 al operar."""
+    headers = _staff_headers(client, db_session, "vendedor", "huerfano@e.com", _MATRIZ)
+    # Se le quita la sucursal directamente en BD (la API no permite dejarlo sin una).
+    svc = UserService(db_session)
+    user = svc.get_by_email("huerfano@e.com")
+    user.branch_id = None
+    db_session.commit()
+    assert client.get("/api/v1/orders/", headers=headers).status_code == 403
+
+
+# ------------------------------------------------------------------- analytics
+def test_analytics_breakdown_by_branch(client, db_session):
+    norte = _make_branch(client)
+    c = _create_client(client)
+    board = _create_board(client)
+    _mint_order(db_session, c["id"], board["id"], _MATRIZ, width=600)
+    _mint_order(db_session, c["id"], board["id"], norte["id"], width=500)
+
+    rng = {"from": "2020-01-01", "to": "2999-12-31"}
+    items = client.get("/api/v1/analytics/breakdown/branch", params=rng).json()["data"][
+        "items"
+    ]
+    by_label = {i["label"]: i for i in items}
+    # Densifica todas las sucursales; cada una con su conteo de órdenes.
+    assert by_label["Casa Matriz"]["orderCount"] == 1
+    assert by_label["Sucursal Norte"]["orderCount"] == 1
+
+    # El filtro branchId acota el summary a una sola sucursal.
+    only_norte = client.get(
+        "/api/v1/analytics/summary", params={**rng, "branchId": norte["id"]}
+    ).json()["data"]
+    assert only_norte["orderCount"] == 1

--- a/tests/test_edge_banding.py
+++ b/tests/test_edge_banding.py
@@ -416,6 +416,7 @@ def test_order_charges_edge_banding(client, db_session):
         db_session,
         {
             "clientId": c["id"],
+            "branchId": 1,
             "materials": _materials(b["id"]),
             "requirements": [_requirement(eb["id"], ["top", "bottom"])],
         },
@@ -454,6 +455,7 @@ def test_order_proforma_with_edge_banding_renders(client, db_session):
         db_session,
         {
             "clientId": c["id"],
+            "branchId": 1,
             "materials": _materials(b["id"]),
             "requirements": [_requirement(eb["id"], ["top", "bottom"])],
         },

--- a/tests/test_optimization_drafts.py
+++ b/tests/test_optimization_drafts.py
@@ -22,7 +22,11 @@ FORM_PAYLOAD = {
 
 
 def _payload(name="Cocina Pérez", payload=None, client_id=None):
-    body = {"name": name, "payload": payload if payload is not None else FORM_PAYLOAD}
+    body = {
+        "name": name,
+        "branchId": 1,  # sucursal por defecto sembrada por conftest
+        "payload": payload if payload is not None else FORM_PAYLOAD,
+    }
     if client_id is not None:
         body["clientId"] = client_id
     return body

--- a/tests/test_order_cutting_plan.py
+++ b/tests/test_order_cutting_plan.py
@@ -33,6 +33,7 @@ def _create_board(client, code="MEL18"):
 def _order_payload(client_id, product_id, height=400, width=600, quantity=3):
     return {
         "clientId": client_id,
+        "branchId": 1,  # sucursal por defecto sembrada por conftest
         "materials": [{"key": "b1", "source": "catalog", "productId": product_id}],
         "requirements": [
             {

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -40,9 +40,14 @@ def _create_board(client, code="MEL18"):
     ).json()["data"]
 
 
+# Sucursal por defecto sembrada por conftest (id=1).
+_BRANCH = 1
+
+
 def _order_payload(client_id, product_id, height=400, width=600, quantity=2):
     return {
         "clientId": client_id,
+        "branchId": _BRANCH,
         "materials": [{"key": "b1", "source": "catalog", "productId": product_id}],
         "requirements": [
             {
@@ -312,6 +317,7 @@ def _manual_material_payload(client_id):
     """Orden con un único material 'manual' (fuera del catálogo)."""
     return {
         "clientId": client_id,
+        "branchId": _BRANCH,
         "materials": [
             {
                 "key": "m1",
@@ -366,6 +372,7 @@ def test_create_mixed_catalog_and_offcut_order(client, db_session):
 
     payload = {
         "clientId": c["id"],
+        "branchId": _BRANCH,
         "materials": [
             {"key": "b1", "source": "catalog", "productId": b["id"]},
             {

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -28,6 +28,7 @@ def _create_board(client, code="MEL18"):
 def _optimize_payload(client_id, product_id):
     return {
         "clientId": client_id,
+        "branchId": 1,  # sucursal por defecto sembrada por conftest
         "materials": [{"key": "b1", "source": "catalog", "productId": product_id}],
         "requirements": [
             {

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -29,17 +29,23 @@ def client(anon_client):
     return anon_client
 
 
+# Sucursal por defecto sembrada por conftest (id=1); el staff cuelga de ella.
+_BRANCH = 1
+
+
 def _user_payload(
     email="seller@empresa.com",
     password="supersecret",
     role="vendedor",
     full_name="Vendedor Uno",
+    branch_id=_BRANCH,
 ):
     return {
         "email": email,
         "password": password,
         "role": role,
         "fullName": full_name,
+        "branchId": branch_id,
     }
 
 
@@ -69,9 +75,16 @@ def auth(client, db_session):
         email = email or f"{role}@empresa.com"
         svc = UserService(db_session)
         if svc.get_by_email(email) is None:
+            # El staff (vendedor/operador) cuelga de la sucursal por defecto; el
+            # admin es global (branch_id se ignora y queda en null).
+            branch_id = None if role == "administrador" else _BRANCH
             svc.create(
                 UserCreate(
-                    email=email, password=_PWD, role=role, full_name=role.title()
+                    email=email,
+                    password=_PWD,
+                    role=role,
+                    full_name=role.title(),
+                    branch_id=branch_id,
                 )
             )
         return _auth_header(_token(client, email))


### PR DESCRIPTION
  Add branch-level data isolation so each location only sees its own
  orders, preorders, and drafts, while admins retain global visibility.

  - New  module (model, schemas, service, router) with CRUD under  +  permissions
  -  FK links staff (vendedor/operador) to a branch; admins have no branch and see everything (branch_scope = None)
  -  in  — centralises (list filtering) and (uniform 404 when a resource belongs to another branch)
  -  FastAPI dependency resolves scope per request from the live DB user; unassigned staff gets an immediate 403
  - Applied to , , and  services and routers; analytics broken down by branch
  - Alembic migration  adds  table + FK
  - Full test coverage in ; existing test fixtures updated with a default branch