### PR TITLE
feat: embed owning branch in order/preorder/draft responses

### DIFF
--- a/docs/MULTISUCURSAL.md
+++ b/docs/MULTISUCURSAL.md
@@ -11,7 +11,10 @@ resume lo que cambia para el frontend (dashboard React). Detalle de auth en
 - Cada **usuario** staff (`vendedor`/`operador`) está atado a **una** sucursal
   (`branchId`). El **administrador** es global (`branchId` nulo): ve y opera todas.
 - **Órdenes, pre-órdenes y borradores** guardan su `branchId`. Es un hecho histórico:
-  reasignar la sucursal de un usuario **no** mueve sus documentos previos.
+  reasignar la sucursal de un usuario **no** mueve sus documentos previos. Sus
+  respuestas (detalle y listado) **incrustan** la sucursal dueña como un objeto
+  compacto `branch: { id, code, name }`, para que el dashboard pueda mostrar la columna
+  "Sucursal" sin una llamada extra.
 - **Clientes y productos siguen siendo globales** (una sola cartera / catálogo).
 
 ## Aislamiento (qué ve/hace cada quién)

--- a/src/modules/branches/schemas.py
+++ b/src/modules/branches/schemas.py
@@ -39,3 +39,16 @@ class BranchResponse(BranchBase):
 
     id: int = Field(..., description="ID de la sucursal")
     is_active: bool = Field(..., description="Activa/inactiva")
+
+
+class BranchRefResponse(CamelModel):
+    """Referencia compacta a una sucursal para incrustar en otras respuestas.
+
+    La consumen órdenes, pre-órdenes y borradores para que el frontend muestre a qué
+    sucursal pertenece cada documento sin arrastrar los datos de contacto del
+    membrete (``address``/``phone``) en cada fila de un listado.
+    """
+
+    id: int = Field(..., description="ID de la sucursal")
+    code: str = Field(..., description="Código único de la sucursal")
+    name: str = Field(..., description="Nombre de la sucursal")

--- a/src/modules/optimization_drafts/model.py
+++ b/src/modules/optimization_drafts/model.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from sqlalchemy import JSON, ForeignKey, String
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.shared.database import Base
 from src.shared.mixins import AuditMixin, TimestampMixin
@@ -29,3 +29,5 @@ class OptimizationDraftModel(TimestampMixin, AuditMixin, Base):
         ForeignKey("clients.id"), nullable=True
     )
     payload: Mapped[dict] = mapped_column(JSON)
+
+    branch: Mapped["BranchModel"] = relationship("BranchModel")  # noqa: F821

--- a/src/modules/optimization_drafts/schemas.py
+++ b/src/modules/optimization_drafts/schemas.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from pydantic import Field
 
+from src.modules.branches.schemas import BranchRefResponse
 from src.shared.schemas import CamelModel
 
 
@@ -44,6 +45,7 @@ class DraftResponse(CamelModel):
     id: int
     name: str
     client_id: Optional[int] = None
+    branch: BranchRefResponse = Field(..., description="Owning branch")
     payload: dict
     created_at: datetime
     updated_at: datetime
@@ -55,5 +57,6 @@ class DraftSummaryResponse(CamelModel):
     id: int
     name: str
     client_id: Optional[int] = None
+    branch: BranchRefResponse = Field(..., description="Owning branch")
     created_at: datetime
     updated_at: datetime

--- a/src/modules/orders/model.py
+++ b/src/modules/orders/model.py
@@ -68,6 +68,7 @@ class OrderModel(TimestampMixin, AuditMixin, Base):
     confirmed_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
 
     client: Mapped["ClientModel"] = relationship("ClientModel")  # noqa: F821
+    branch: Mapped["BranchModel"] = relationship("BranchModel")  # noqa: F821
     lines: Mapped[list["OrderLineModel"]] = relationship(
         "OrderLineModel", back_populates="order", cascade="all, delete-orphan"
     )

--- a/src/modules/orders/schemas.py
+++ b/src/modules/orders/schemas.py
@@ -3,6 +3,7 @@ from typing import List, Literal, Optional
 
 from pydantic import Field
 
+from src.modules.branches.schemas import BranchRefResponse
 from src.modules.clients.schemas import ClientResponse
 from src.modules.optimizations.schemas import (
     CutSegment,
@@ -136,6 +137,7 @@ class OrderResponse(CamelModel):
     id: int
     code: Optional[str] = None
     client: ClientResponse = Field(..., description="Client information")
+    branch: BranchRefResponse = Field(..., description="Owning branch")
     status: OrderStatus
     currency: str
     subtotal: float

--- a/src/modules/preorders/model.py
+++ b/src/modules/preorders/model.py
@@ -86,6 +86,7 @@ class PreOrderModel(TimestampMixin, AuditMixin, Base):
     expires_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
 
     client: Mapped["ClientModel"] = relationship("ClientModel")  # noqa: F821
+    branch: Mapped["BranchModel"] = relationship("BranchModel")  # noqa: F821
     order: Mapped[Optional["OrderModel"]] = relationship(  # noqa: F821
         "OrderModel", foreign_keys=[order_id]
     )

--- a/src/modules/preorders/router.py
+++ b/src/modules/preorders/router.py
@@ -56,6 +56,7 @@ def _detail(svc: PreOrderService, preorder: PreOrderModel) -> PreOrderResponse:
         id=preorder.id,
         code=preorder.code,
         client=preorder.client,
+        branch=preorder.branch,
         status=PreOrderStatus(preorder.status),
         notes=preorder.notes,
         client_note=preorder.client_note,

--- a/src/modules/preorders/schemas.py
+++ b/src/modules/preorders/schemas.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 
 from pydantic import Field
 
+from src.modules.branches.schemas import BranchRefResponse
 from src.modules.clients.schemas import ClientResponse
 from src.modules.optimizations.schemas import (
     MaterialInput,
@@ -75,6 +76,7 @@ class PreOrderResponse(CamelModel):
     id: int
     code: Optional[str] = None
     client: ClientResponse = Field(..., description="Client information")
+    branch: BranchRefResponse = Field(..., description="Owning branch")
     status: PreOrderStatus
     notes: Optional[str] = None
     client_note: Optional[str] = Field(
@@ -108,6 +110,7 @@ class PreOrderSummaryResponse(CamelModel):
     id: int
     code: Optional[str] = None
     client: ClientResponse
+    branch: BranchRefResponse = Field(..., description="Owning branch")
     status: PreOrderStatus
     source: Optional[str] = None
     order_id: Optional[int] = None

--- a/tests/test_optimization_drafts.py
+++ b/tests/test_optimization_drafts.py
@@ -46,6 +46,9 @@ def test_create_and_get_draft_roundtrips_payload(client):
     created = resp.json()["data"]
     assert created["name"] == "Cocina Pérez"
     assert created["clientId"] is None
+    # El borrador expone su sucursal dueña (referencia compacta).
+    assert created["branch"]["id"] == 1
+    assert created["branch"]["code"] == "MATRIZ"
     assert "id" in created
     assert "createdAt" in created and "updatedAt" in created
 

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -83,6 +83,10 @@ def test_create_order_freezes_snapshot_and_charges_boards(client, db_session):
     assert data["status"] == "confirmed"
     assert data["code"] == f"ORD-{datetime.utcnow().year}-{data['id']:04d}"
     assert data["client"]["id"] == c["id"]
+    # La orden expone su sucursal dueña (referencia compacta) para el dashboard.
+    assert data["branch"]["id"] == _BRANCH
+    assert data["branch"]["code"] == "MATRIZ"
+    assert data["branch"]["name"] == "Casa Matriz"
     assert len(data["optimizationHash"]) == 64
 
     # Cobro = tableros: una línea por tipo de tablero (desde materials_summary).

--- a/tests/test_preorders.py
+++ b/tests/test_preorders.py
@@ -27,6 +27,9 @@ def test_create_preorder_is_draft_with_live_optimization(client):
     assert data["code"].startswith("PRE-")
     assert data["orderId"] is None
     assert data["client"]["id"] == c["id"]
+    # La pre-orden expone su sucursal dueña (referencia compacta).
+    assert data["branch"]["id"] == 1
+    assert data["branch"]["code"] == "MATRIZ"
     assert data["expiresAt"] is not None
 
     # Inputs crudos editables (lo que el formulario del optimizador re-renderiza).


### PR DESCRIPTION
    The branchId set on orders, pre-orders and drafts (PR #41) only lived on the
    create payloads, so the dashboard could filter by branch but had no way to show
    which branch a row belongs to.

    - Add BranchRefResponse { id, code, name }: a compact branch reference for embedding, without leaking letterhead fields (address/phone) into list rows.
    - Add a read-only  relationship to OrderModel, PreOrderModel and OptimizationDraftModel (ORM-only; branch_id already exists, no migration).
    - Expose  on OrderResponse, PreOrderResponse/PreOrderSummaryResponse and DraftResponse/DraftSummaryResponse (detail and list). It is required, mirroring the non-nullable FK, so the frontend can rely on it always being present.
    - Cover the new field in the orders/preorders/drafts tests; update docs/MULTISUCURSAL.md.