### PR TITLE
feat: redesign production sheet as B&W workshop doc and add multi-status order filter

### DIFF
--- a/src/modules/optimizations/labels.py
+++ b/src/modules/optimizations/labels.py
@@ -5,6 +5,9 @@ from typing import Iterable, Optional
 # Abreviatura del tipo de canto: Suave→CS, Duro→CD (valores canónicos de BandType).
 _BAND_TYPE_ABBR = {"Soft": "CS", "Hard": "CD"}
 
+# Etiqueta legible del tipo de canto para tablas/leyendas (valores canónicos de BandType).
+BAND_TYPE_LABEL = {"Soft": "Suave", "Hard": "Duro"}
+
 
 def edge_banding_notation(sides: Iterable[str], band_type: Optional[str] = None) -> str:
     """Notación de taller de los lados canteados: ``'2L1C CS'`` (largos/cortos + tipo).

--- a/src/modules/optimizations/proforma.py
+++ b/src/modules/optimizations/proforma.py
@@ -1,5 +1,6 @@
 import base64
 import io
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import List, Union
@@ -23,7 +24,7 @@ from reportlab.platypus import (
 )
 
 from src.modules.optimizations.carrier import ProformaCarrier
-from src.modules.optimizations.labels import edge_banding_notation
+from src.modules.optimizations.labels import BAND_TYPE_LABEL, edge_banding_notation
 from src.modules.optimizations.patterns import group_layouts
 from src.modules.optimizations.visualization import VisualizationService
 
@@ -34,6 +35,39 @@ BRAND_BLACK = colors.HexColor("#1D1D1B")  # logo / texto / reglas
 LIGHT_CORAL = colors.HexColor("#FCE9E6")  # fondo de la caja de totales
 ZEBRA_GREY = colors.HexColor("#F5F5F5")
 TEXT_GREY = colors.HexColor("#424242")
+
+
+@dataclass(frozen=True)
+class Palette:
+    """Colores temáticos de un PDF. Permite que la proforma vaya con marca y la
+    hoja de producción en blanco y negro reutilizando los mismos builders."""
+
+    accent: colors.Color  # cabecera de tabla, regla de sección, borde de totales
+    accent_fill: colors.Color  # fondo de la caja de totales / fila TOTAL
+    text: colors.Color  # títulos y reglas oscuras
+    text_grey: colors.Color  # texto secundario en celdas
+    zebra: colors.Color  # filas alternas
+    header_text: colors.Color  # texto sobre la cabecera de tabla
+
+
+# Proforma comercial: paleta de marca. Hoja de producción: monocromo para taller
+# (cabecera negra con texto blanco e impresión/fotocopia legible en B/N).
+BRAND_PALETTE = Palette(
+    accent=BRAND_CORAL,
+    accent_fill=LIGHT_CORAL,
+    text=BRAND_BLACK,
+    text_grey=TEXT_GREY,
+    zebra=ZEBRA_GREY,
+    header_text=colors.whitesmoke,
+)
+MONO_PALETTE = Palette(
+    accent=BRAND_BLACK,
+    accent_fill=colors.HexColor("#EAEAEA"),
+    text=BRAND_BLACK,
+    text_grey=colors.HexColor("#333333"),
+    zebra=colors.HexColor("#F2F2F2"),
+    header_text=colors.white,
+)
 
 PAGE_WIDTH, PAGE_HEIGHT = A4
 LEFT_MARGIN = RIGHT_MARGIN = 0.5 * inch
@@ -115,13 +149,40 @@ def _draw_page_decoration(canvas, doc) -> None:
     canvas.restoreState()
 
 
-def _new_doc(buffer: io.BytesIO) -> SimpleDocTemplate:
-    """Documento A4 con los márgenes estándar de los PDFs de Cutter."""
+def _draw_page_decoration_plain(canvas, doc) -> None:
+    """Pie mínimo para la hoja de producción: solo fecha de generación y página.
+
+    Sin marca de agua ni banda de pie (la hoja de taller va en blanco y negro).
+    """
+    canvas.saveState()
+    canvas.setFont("Helvetica", 8)
+    canvas.setFillColor(colors.grey)
+    canvas.drawString(
+        LEFT_MARGIN,
+        0.35 * inch,
+        f"Generado el {datetime.now().strftime('%d/%m/%Y %H:%M')}",
+    )
+    canvas.drawRightString(
+        PAGE_WIDTH - RIGHT_MARGIN,
+        0.35 * inch,
+        f"Página {canvas.getPageNumber()}",
+    )
+    canvas.restoreState()
+
+
+def _new_doc(
+    buffer: io.BytesIO,
+    top: float = 0.5 * inch,
+    bottom: float = 0.6 * inch,
+) -> SimpleDocTemplate:
+    """Documento A4 de Cutter. ``top``/``bottom`` se ajustan para la hoja de
+    producción (más compacta); el margen horizontal se mantiene para no recalcular
+    el ancho de las tablas."""
     return SimpleDocTemplate(
         buffer,
         pagesize=A4,
-        topMargin=0.5 * inch,
-        bottomMargin=0.6 * inch,
+        topMargin=top,
+        bottomMargin=bottom,
         leftMargin=LEFT_MARGIN,
         rightMargin=RIGHT_MARGIN,
     )
@@ -192,55 +253,63 @@ class ProformaService:
 
     @staticmethod
     def generate_production_sheet_pdf(carrier: ProformaCarrier) -> io.BytesIO:
-        """Hoja de producción para el taller: lista de corte y disposición, SIN precios."""
+        """Hoja de producción para el taller: en blanco y negro, sin membrete, lista
+        de corte y disposición SIN precios. Aprovecha al máximo el papel (márgenes y
+        espaciados compactos) y diferencia el tipo de canto (suave/duro)."""
         buffer = io.BytesIO()
-        doc = _new_doc(buffer)
+        doc = _new_doc(buffer, top=0.4 * inch, bottom=0.45 * inch)
+        pal = MONO_PALETTE
+        pad = 4
 
         styles = getSampleStyleSheet()
         heading_style = _heading_style(styles)
         cell_style = _cell_style(styles)
 
         story = []
-        story.extend(
-            ProformaService._build_header(carrier, styles, "HOJA DE PRODUCCIÓN")
+        story.extend(ProformaService._build_production_header(carrier, styles, pal))
+        story.append(Spacer(1, 0.12 * inch))
+
+        story.extend(_section("LISTA DE CORTE", heading_style, pal, space_after=4))
+        story.append(
+            ProformaService._build_requirements_table(carrier, cell_style, pal, pad)
         )
-        story.append(Spacer(1, 0.25 * inch))
+        story.append(Spacer(1, 0.12 * inch))
 
-        story.extend(_section("CLIENTE", heading_style))
-        story.append(ProformaService._build_client_table(carrier))
-        story.append(Spacer(1, 0.25 * inch))
-
-        story.extend(_section("LISTA DE CORTE", heading_style))
-        story.append(ProformaService._build_requirements_table(carrier, cell_style))
-        story.append(Spacer(1, 0.25 * inch))
-
-        story.extend(_section("TABLEROS A UTILIZAR", heading_style))
-        story.append(ProformaService._build_materials_plain_table(carrier, cell_style))
-        story.append(Spacer(1, 0.2 * inch))
-        story.append(ProformaService._build_boards_total_table(carrier))
+        story.extend(_section("TABLEROS A UTILIZAR", heading_style, pal, space_after=4))
+        story.append(
+            ProformaService._build_materials_plain_table(carrier, cell_style, pal, pad)
+        )
+        story.append(Spacer(1, 0.1 * inch))
+        story.append(ProformaService._build_boards_total_table(carrier, pal))
 
         if carrier.edge_bandings_summary:
-            story.append(Spacer(1, 0.25 * inch))
-            story.extend(_section("TAPACANTOS A APLICAR", heading_style))
+            story.append(Spacer(1, 0.12 * inch))
+            story.extend(
+                _section("TAPACANTOS A APLICAR", heading_style, pal, space_after=4)
+            )
             story.append(
                 ProformaService._build_edge_bandings_table(
-                    carrier, cell_style, with_prices=False
+                    carrier, cell_style, with_prices=False, palette=pal, pad=pad
                 )
             )
 
-        story.append(Spacer(1, 0.25 * inch))
-        story.extend(_section("RESUMEN DE CORTE Y CANTO", heading_style))
-        story.append(ProformaService._build_cut_summary_table(carrier))
+        story.append(Spacer(1, 0.12 * inch))
+        story.extend(
+            _section("RESUMEN DE CORTE Y CANTO", heading_style, pal, space_after=4)
+        )
+        story.append(ProformaService._build_cut_summary_table(carrier, pal, pad))
 
         story.append(PageBreak())
-        story.extend(_section("DISPOSICIÓN DE CORTES", heading_style))
+        story.extend(
+            _section("DISPOSICIÓN DE CORTES", heading_style, pal, space_after=4)
+        )
         story.append(Spacer(1, 0.08 * inch))
-        story.extend(ProformaService._build_layout_pages(carrier))
+        story.extend(ProformaService._build_layout_pages(carrier, mono=True))
 
         doc.build(
             story,
-            onFirstPage=_draw_page_decoration,
-            onLaterPages=_draw_page_decoration,
+            onFirstPage=_draw_page_decoration_plain,
+            onLaterPages=_draw_page_decoration_plain,
         )
         buffer.seek(0)
         return buffer
@@ -376,6 +445,72 @@ class ProformaService:
         return table
 
     @staticmethod
+    def _build_production_header(
+        carrier: ProformaCarrier, styles, palette: Palette = MONO_PALETTE
+    ) -> List:
+        """Cabecera compacta de taller: título + N°/fecha/cliente, sin logo ni
+        membrete. El nombre del cliente va aquí (la hoja ya no lleva sección CLIENTE).
+        """
+        client = carrier.client
+        client_name = (
+            f"{getattr(client, 'first_name', '') or ''} "
+            f"{getattr(client, 'last_name', '') or ''}".strip()
+            or "N/A"
+        )
+
+        title_style = ParagraphStyle(
+            "ProdTitle",
+            parent=styles["Normal"],
+            fontSize=15,
+            leading=18,
+            textColor=palette.text,
+            fontName="Helvetica-Bold",
+            alignment=TA_LEFT,
+        )
+        meta_style = ParagraphStyle(
+            "ProdMeta",
+            parent=styles["Normal"],
+            fontSize=9,
+            leading=12,
+            textColor=palette.text,
+            alignment=TA_RIGHT,
+        )
+
+        header = Table(
+            [
+                [
+                    Paragraph("HOJA DE PRODUCCIÓN", title_style),
+                    Paragraph(
+                        f"N° {carrier.reference}<br/>"
+                        f"Fecha: {datetime.now().strftime('%d/%m/%Y')}<br/>"
+                        f"Cliente: {client_name}",
+                        meta_style,
+                    ),
+                ]
+            ],
+            colWidths=[CONTENT_WIDTH * 0.5, CONTENT_WIDTH * 0.5],
+        )
+        header.setStyle(
+            TableStyle(
+                [
+                    ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                    ("LEFTPADDING", (0, 0), (-1, -1), 0),
+                    ("RIGHTPADDING", (0, 0), (-1, -1), 0),
+                    ("TOPPADDING", (0, 0), (-1, -1), 0),
+                    ("BOTTOMPADDING", (0, 0), (-1, -1), 0),
+                ]
+            )
+        )
+        rule = HRFlowable(
+            width="100%",
+            thickness=1.0,
+            color=palette.text,
+            spaceBefore=4,
+            spaceAfter=4,
+        )
+        return [header, rule]
+
+    @staticmethod
     def _build_client_table(carrier: ProformaCarrier) -> Table:
         client = carrier.client
         client_name = (
@@ -408,7 +543,12 @@ class ProformaService:
         return client_table
 
     @staticmethod
-    def _build_requirements_table(carrier: ProformaCarrier, cell_style) -> Table:
+    def _build_requirements_table(
+        carrier: ProformaCarrier,
+        cell_style,
+        palette: Palette = BRAND_PALETTE,
+        pad: int = 7,
+    ) -> Table:
         requirements = carrier.requirements
         req_data = [["#", "Alto", "Ancho", "Cant.", "Tablero", "Cantos", "Etiqueta"]]
         if isinstance(requirements, list):
@@ -438,32 +578,40 @@ class ProformaService:
             ],
             repeatRows=1,
         )
-        req_table.setStyle(_data_table_style(header_size=10, body_size=9))
+        req_table.setStyle(
+            _data_table_style(header_size=10, body_size=9, palette=palette, pad=pad)
+        )
         return req_table
 
     @staticmethod
     def _build_edge_bandings_table(
-        carrier: ProformaCarrier, cell_style, with_prices: bool = True
+        carrier: ProformaCarrier,
+        cell_style,
+        with_prices: bool = True,
+        palette: Palette = BRAND_PALETTE,
+        pad: int = 7,
     ) -> Table:
         """Resumen de tapacantos por tipo. Con precios (proforma) o sin ellos
-        (hoja de producción)."""
+        (hoja de producción), con una columna ``Tipo`` (Suave/Duro) para el taller."""
         summary = carrier.edge_bandings_summary
         if with_prices:
             header = [
                 "Código",
                 "Descripción",
+                "Tipo",
                 "Espesor",
                 "Metros",
                 "P. Unit.",
                 "Subtotal",
             ]
         else:
-            header = ["Código", "Descripción", "Espesor", "Metros"]
+            header = ["Código", "Descripción", "Tipo", "Espesor", "Metros"]
         eb_data = [header]
         for entry in summary:
             row = [
                 entry.get("product_code", "N/A"),
                 Paragraph(entry.get("product_name", "N/A"), cell_style),
+                BAND_TYPE_LABEL.get(entry.get("band_type"), "-"),
                 f"{(entry.get('thickness') or 0):.2f} mm",
                 f"{entry.get('billed_linear_m', 0)} m",
             ]
@@ -475,7 +623,8 @@ class ProformaService:
         if with_prices:
             col_widths = [
                 0.9 * inch,
-                CONTENT_WIDTH - 4.3 * inch,
+                CONTENT_WIDTH - 5.1 * inch,
+                0.8 * inch,  # Tipo
                 0.9 * inch,
                 0.8 * inch,
                 0.8 * inch,
@@ -484,7 +633,8 @@ class ProformaService:
         else:
             col_widths = [
                 1.4 * inch,  # Código (más ancho: códigos largos tipo TAP-SL-CSH-22)
-                CONTENT_WIDTH - 3.0 * inch,  # Descripción (flexible)
+                CONTENT_WIDTH - 3.8 * inch,  # Descripción (flexible)
+                0.8 * inch,  # Tipo (Suave/Duro)
                 0.8 * inch,  # Espesor
                 0.8 * inch,  # Metros
             ]
@@ -493,6 +643,8 @@ class ProformaService:
             _data_table_style(
                 header_size=9 if with_prices else 10,
                 body_size=8 if with_prices else 9,
+                palette=palette,
+                pad=pad,
             )
         )
         return eb_table
@@ -545,7 +697,12 @@ class ProformaService:
         return mat_table
 
     @staticmethod
-    def _build_materials_plain_table(carrier: ProformaCarrier, cell_style) -> Table:
+    def _build_materials_plain_table(
+        carrier: ProformaCarrier,
+        cell_style,
+        palette: Palette = BRAND_PALETTE,
+        pad: int = 7,
+    ) -> Table:
         """Tableros a usar SIN precios (hoja de producción): código, dimensiones, cant.
 
         Ocupa el ancho completo del contenido para alinear con la lista de corte."""
@@ -576,7 +733,9 @@ class ProformaService:
             ],
             repeatRows=1,
         )
-        mat_table.setStyle(_data_table_style(header_size=10, body_size=9))
+        mat_table.setStyle(
+            _data_table_style(header_size=10, body_size=9, palette=palette, pad=pad)
+        )
         return mat_table
 
     @staticmethod
@@ -595,14 +754,21 @@ class ProformaService:
         return _totals_table(summary_data)
 
     @staticmethod
-    def _build_boards_total_table(carrier: ProformaCarrier) -> Table:
+    def _build_boards_total_table(
+        carrier: ProformaCarrier, palette: Palette = BRAND_PALETTE
+    ) -> Table:
         """Total de tableros a cortar, sin costos (hoja de producción)."""
         return _totals_table(
-            [["Total de tableros a cortar:", str(carrier.total_boards_used)]]
+            [["Total de tableros a cortar:", str(carrier.total_boards_used)]],
+            palette=palette,
         )
 
     @staticmethod
-    def _build_cut_summary_table(carrier: ProformaCarrier) -> Table:
+    def _build_cut_summary_table(
+        carrier: ProformaCarrier,
+        palette: Palette = BRAND_PALETTE,
+        pad: int = 7,
+    ) -> Table:
         """Metros lineales de corte y canto por plancha + total general (taller).
 
         Una fila por patrón de corte (deduplicado) con los valores por plancha; la
@@ -642,16 +808,16 @@ class ProformaService:
             ],
             repeatRows=1,
         )
-        style = _data_table_style(header_size=10, body_size=9)
+        style = _data_table_style(header_size=10, body_size=9, palette=palette, pad=pad)
         # Resalta la fila TOTAL (última) como caja de totales.
-        style.add("BACKGROUND", (0, -1), (-1, -1), LIGHT_CORAL)
+        style.add("BACKGROUND", (0, -1), (-1, -1), palette.accent_fill)
         style.add("FONTNAME", (0, -1), (-1, -1), "Helvetica-Bold")
-        style.add("TEXTCOLOR", (0, -1), (-1, -1), BRAND_BLACK)
+        style.add("TEXTCOLOR", (0, -1), (-1, -1), palette.text)
         table.setStyle(style)
         return table
 
     @staticmethod
-    def _build_layout_pages(carrier: ProformaCarrier) -> List:
+    def _build_layout_pages(carrier: ProformaCarrier, mono: bool = False) -> List:
         """Una imagen por patrón, cada una a página completa ocupando el máximo."""
         layouts = carrier.layouts
         if not (isinstance(layouts, list) and layouts):
@@ -672,7 +838,7 @@ class ProformaService:
                 flowables.append(PageBreak())
 
             img_buffer, (img_w, img_h) = VisualizationService.generate_layout_image(
-                group
+                group, mono=mono
             )
             draw_width = CONTENT_WIDTH
             draw_height = draw_width * (img_h / img_w)
@@ -738,28 +904,37 @@ def _cell_style(styles) -> ParagraphStyle:
     )
 
 
-def _section(title: str, heading_style) -> List:
+def _section(
+    title: str,
+    heading_style,
+    palette: Palette = BRAND_PALETTE,
+    space_after: int = 8,
+) -> List:
     """Título de sección con regla de color debajo."""
     return [
         Paragraph(title, heading_style),
         HRFlowable(
-            width="100%", thickness=1.2, color=BRAND_CORAL, spaceBefore=2, spaceAfter=8
+            width="100%",
+            thickness=1.2,
+            color=palette.accent,
+            spaceBefore=2,
+            spaceAfter=space_after,
         ),
     ]
 
 
-def _totals_table(rows: List[List[str]]) -> Table:
+def _totals_table(rows: List[List[str]], palette: Palette = BRAND_PALETTE) -> Table:
     """Caja resaltada de totales (clave a la izquierda, valor a la derecha)."""
     table = Table(rows, colWidths=[CONTENT_WIDTH - 2.0 * inch, 2.0 * inch])
     table.setStyle(
         TableStyle(
             [
-                ("BACKGROUND", (0, 0), (-1, -1), LIGHT_CORAL),
-                ("BOX", (0, 0), (-1, -1), 1, BRAND_CORAL),
+                ("BACKGROUND", (0, 0), (-1, -1), palette.accent_fill),
+                ("BOX", (0, 0), (-1, -1), 1, palette.accent),
                 ("LINEBELOW", (0, 0), (-1, 0), 0.5, colors.HexColor("#F5C9C3")),
                 ("FONTNAME", (0, 0), (-1, -1), "Helvetica-Bold"),
                 ("FONTSIZE", (0, 0), (-1, -1), 11),
-                ("TEXTCOLOR", (0, 0), (-1, -1), BRAND_BLACK),
+                ("TEXTCOLOR", (0, 0), (-1, -1), palette.text),
                 ("ALIGN", (0, 0), (0, -1), "LEFT"),
                 ("ALIGN", (1, 0), (1, -1), "RIGHT"),
                 ("TOPPADDING", (0, 0), (-1, -1), 8),
@@ -772,21 +947,26 @@ def _totals_table(rows: List[List[str]]) -> Table:
     return table
 
 
-def _data_table_style(header_size: int, body_size: int) -> TableStyle:
-    """Estilo común para tablas de datos con cabecera azul y filas zebra."""
+def _data_table_style(
+    header_size: int,
+    body_size: int,
+    palette: Palette = BRAND_PALETTE,
+    pad: int = 7,
+) -> TableStyle:
+    """Estilo común para tablas de datos: cabecera de acento + filas zebra."""
     return TableStyle(
         [
-            ("BACKGROUND", (0, 0), (-1, 0), BRAND_CORAL),
-            ("TEXTCOLOR", (0, 0), (-1, 0), colors.whitesmoke),
+            ("BACKGROUND", (0, 0), (-1, 0), palette.accent),
+            ("TEXTCOLOR", (0, 0), (-1, 0), palette.header_text),
             ("ALIGN", (0, 0), (-1, -1), "CENTER"),
             ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
             ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
             ("FONTSIZE", (0, 0), (-1, 0), header_size),
             ("FONTNAME", (0, 1), (-1, -1), "Helvetica"),
             ("FONTSIZE", (0, 1), (-1, -1), body_size),
-            ("TOPPADDING", (0, 0), (-1, -1), 7),
-            ("BOTTOMPADDING", (0, 0), (-1, -1), 7),
+            ("TOPPADDING", (0, 0), (-1, -1), pad),
+            ("BOTTOMPADDING", (0, 0), (-1, -1), pad),
             ("GRID", (0, 0), (-1, -1), 0.5, colors.grey),
-            ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.white, ZEBRA_GREY]),
+            ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.white, palette.zebra]),
         ]
     )

--- a/src/modules/optimizations/schemas.py
+++ b/src/modules/optimizations/schemas.py
@@ -83,6 +83,9 @@ class EdgeBandingSummary(CamelModel):
     product_name: str
     thickness: float
     color: Optional[str] = None
+    band_type: Optional[str] = Field(
+        default=None, description="Canonical band type: 'Soft' / 'Hard'"
+    )
     net_linear_m: float = Field(
         ..., description="Net linear meters (sum of banded sides)"
     )

--- a/src/modules/optimizations/service.py
+++ b/src/modules/optimizations/service.py
@@ -352,6 +352,9 @@ class OptimizationService:
             "product_id": spec.product_id,
             "code": product.code if product else None,
             "color": attrs.get("color"),
+            # Tipo canónico (``Soft``/``Hard``) para diferenciar la franja en el
+            # diagrama (suave = sólida, duro = rayada). ``None`` en snapshots viejos.
+            "band_type": attrs.get("bandType"),
             # Notación de taller calculada desde los lados NOMINALES (estable bajo
             # rotación); ``geo`` solo sirve para pintar las bandas en el lado correcto.
             # ``attributes`` se persiste en camelCase → ``bandType``.
@@ -415,6 +418,7 @@ class OptimizationService:
                     "product_name": product.name,
                     "thickness": attrs.get("thickness"),
                     "color": attrs.get("color"),
+                    "band_type": attrs.get("bandType"),
                     "net_linear_m": round(net_m, 2),
                     "linear_m": round(with_waste, 2),
                     "billed_linear_m": billed,

--- a/src/modules/optimizations/visualization.py
+++ b/src/modules/optimizations/visualization.py
@@ -1,5 +1,6 @@
 import io
-from typing import Optional, Tuple
+from dataclasses import dataclass
+from typing import Optional, Set, Tuple
 
 from PIL import Image, ImageDraw, ImageFont
 
@@ -24,10 +25,81 @@ COLOR_EFFICIENCY = "#2E7D32"
 COLOR_WASTE_FILL = "#ECECEC"  # gris neutro: contrasta con el coral de las piezas
 COLOR_WASTE_OUTLINE = "#9E9E9E"
 
-# Grosor del borde de la pieza. Los lados canteados se resaltan con el mismo color
-# del borde, solo que con una línea más gruesa (sin franja de color por tipo).
+# Grosor del borde de la pieza. Los lados canteados se resaltan con una franja más
+# gruesa pegada al borde, por dentro de la pieza.
 PIECE_OUTLINE_WIDTH = 2
 EDGE_BANDING_WIDTH = PIECE_OUTLINE_WIDTH + 5
+# Paso (px) del rayado diagonal que distingue el canto duro en modo monocromo.
+HATCH_STEP = 6
+
+
+@dataclass(frozen=True)
+class _DiagramTheme:
+    """Colores del diagrama. ``brand`` (proforma, con marca) o ``mono`` (hoja de
+    producción, blanco y negro para el taller)."""
+
+    board_outline: str
+    piece_fill: str
+    piece_outline: str
+    dim: str
+    label: str
+    efficiency: str
+    waste_fill: str
+    waste_outline: str
+    edge: str  # color de la franja del canto
+
+
+_BRAND_THEME = _DiagramTheme(
+    board_outline=COLOR_BOARD_OUTLINE,
+    piece_fill=COLOR_PIECE_FILL,
+    piece_outline=COLOR_PIECE_OUTLINE,
+    dim=COLOR_DIM,
+    label=COLOR_LABEL,
+    efficiency=COLOR_EFFICIENCY,
+    waste_fill=COLOR_WASTE_FILL,
+    waste_outline=COLOR_WASTE_OUTLINE,
+    edge=COLOR_PIECE_OUTLINE,
+)
+# Monocromo: contornos/cotas/etiquetas en negro, pieza en blanco; el retazo gris ya
+# es neutro y sirve igual. El canto se diferencia por relleno (sólido vs. rayado).
+_MONO_THEME = _DiagramTheme(
+    board_outline="black",
+    piece_fill="white",
+    piece_outline="black",
+    dim="black",
+    label="black",
+    efficiency="black",
+    waste_fill=COLOR_WASTE_FILL,
+    waste_outline=COLOR_WASTE_OUTLINE,
+    edge="black",
+)
+
+
+def _draw_edge_strip(
+    img: Image.Image,
+    draw: ImageDraw.ImageDraw,
+    rect: Tuple[int, int, int, int],
+    color: str,
+    hatched: bool,
+) -> None:
+    """Pinta la franja de un canto dentro de ``rect``. Sólida (canto suave) o con
+    rayado diagonal (canto duro). El rayado se dibuja en una imagen temporal del
+    tamaño de la franja y se pega, de modo que queda recortado a la franja."""
+    x0, y0, x1, y1 = rect
+    if not hatched:
+        draw.rectangle(rect, fill=color)
+        return
+    w, h = x1 - x0, y1 - y0
+    if w <= 0 or h <= 0:
+        return
+    draw.rectangle(rect, outline=color, width=1)
+    strip = Image.new("RGBA", (w, h), (0, 0, 0, 0))
+    sdraw = ImageDraw.Draw(strip)
+    offset = -h
+    while offset < w:
+        sdraw.line([(offset, h), (offset + h, 0)], fill=color, width=1)
+        offset += HATCH_STEP
+    img.paste(strip, (x0, y0), strip)
 
 
 def _load_font(size: int) -> ImageFont.FreeTypeFont:
@@ -75,7 +147,7 @@ def _fit_label(
 class VisualizationService:
     @staticmethod
     def generate_layout_image(
-        group: dict, target_long: int = 2000
+        group: dict, target_long: int = 2000, mono: bool = False
     ) -> Tuple[io.BytesIO, Tuple[int, int]]:
         """Dibuja un único patrón de corte ocupando todo el lienzo.
 
@@ -109,14 +181,27 @@ class VisualizationService:
         label_font = _load_font(30)
         legend_font = _load_font(32)
 
-        # ¿Hay alguna pieza canteada en este patrón? (para la entrada de leyenda).
-        has_edge_banding = any(
-            (piece.get("edges") or {}).get("sides")
-            for piece in layout.get("placed_pieces", [])
-        )
+        theme = _MONO_THEME if mono else _BRAND_THEME
+
+        # Tipos de canto presentes en el patrón (para la leyenda). Un canteado sin
+        # tipo conocido (snapshots viejos) se trata como sólido → "Soft".
+        band_types: Set[str] = set()
+        for piece in layout.get("placed_pieces", []):
+            edges = piece.get("edges") or {}
+            if edges.get("sides"):
+                bt = edges.get("band_type")
+                band_types.add(bt if bt in ("Soft", "Hard") else "Soft")
 
         VisualizationService._draw_legend(
-            draw, margin, 24, legend_font, has_edge_banding, max_x=canvas_width - margin
+            img,
+            draw,
+            margin,
+            24,
+            legend_font,
+            theme,
+            mono=mono,
+            band_types=band_types,
+            max_x=canvas_width - margin,
         )
 
         board_x = margin
@@ -133,7 +218,7 @@ class VisualizationService:
         draw.text(
             (board_x + label_w + 30, board_y - 48),
             f"Eficiencia: {efficiency:.1f}%",
-            fill=COLOR_EFFICIENCY,
+            fill=theme.efficiency,
             font=header_font,
         )
 
@@ -144,13 +229,22 @@ class VisualizationService:
                 board_x + scaled_board_width,
                 board_y + scaled_board_height,
             ],
-            outline=COLOR_BOARD_OUTLINE,
+            outline=theme.board_outline,
             width=3,
         )
 
         for piece in layout.get("placed_pieces", []):
             VisualizationService._draw_piece(
-                img, draw, board_x, board_y, scale, piece, dim_font, label_font
+                img,
+                draw,
+                board_x,
+                board_y,
+                scale,
+                piece,
+                dim_font,
+                label_font,
+                theme,
+                mono=mono,
             )
 
         for remainder in layout.get("remainders", []):
@@ -161,8 +255,8 @@ class VisualizationService:
             if rw > 5 and rh > 5:
                 draw.rectangle(
                     [rx, ry, rx + rw, ry + rh],
-                    fill=COLOR_WASTE_FILL,
-                    outline=COLOR_WASTE_OUTLINE,
+                    fill=theme.waste_fill,
+                    outline=theme.waste_outline,
                     width=1,
                 )
 
@@ -173,45 +267,69 @@ class VisualizationService:
 
     @staticmethod
     def _draw_legend(
+        img: Image.Image,
         draw: ImageDraw.ImageDraw,
         x: int,
         y: int,
         legend_font: ImageFont.ImageFont,
-        has_edge_banding: bool = False,
+        theme: _DiagramTheme,
+        mono: bool = False,
+        band_types: Optional[Set[str]] = None,
         max_x: Optional[int] = None,
     ) -> None:
-        """Dibuja la leyenda de colores (pieza, retazo y, si aplica, lado canteado).
+        """Dibuja la leyenda (pieza, retazo y, según el patrón, los cantos).
 
+        En monocromo desglosa el canto suave (muestra sólida) y el duro (muestra
+        rayada) según los tipos presentes; con marca usa una sola "Lado canteado".
         Envuelve en una nueva fila cuando una entrada se saldría de ``max_x``.
         """
+        band_types = band_types or set()
+        # entradas: (fill, outline, width, text, hatched)
         legend = [
-            (COLOR_PIECE_FILL, COLOR_PIECE_OUTLINE, PIECE_OUTLINE_WIDTH, "Pieza"),
             (
-                COLOR_WASTE_FILL,
-                COLOR_WASTE_OUTLINE,
+                theme.piece_fill,
+                theme.piece_outline,
+                PIECE_OUTLINE_WIDTH,
+                "Pieza",
+                False,
+            ),
+            (
+                theme.waste_fill,
+                theme.waste_outline,
                 PIECE_OUTLINE_WIDTH,
                 "Retazo / Desperdicio",
+                False,
             ),
         ]
-        if has_edge_banding:
+        if mono:
+            if "Soft" in band_types:
+                legend.append((theme.edge, theme.edge, 1, "Canto suave", False))
+            if "Hard" in band_types:
+                legend.append(("white", theme.edge, 1, "Canto duro", True))
+        elif band_types:
             legend.append(
-                ("white", COLOR_PIECE_OUTLINE, EDGE_BANDING_WIDTH, "Lado canteado")
+                ("white", theme.edge, EDGE_BANDING_WIDTH, "Lado canteado", False)
             )
+
+        text_color = theme.label if mono else "black"
         box = 32
         start_x = x
-        for fill, outline, width, text in legend:
+        for fill, outline, width, text, hatched in legend:
             tw, th = _text_size(text, legend_font)
             item_w = box + 12 + tw + 50
             if max_x is not None and x > start_x and x + box + 12 + tw > max_x:
                 x = start_x
                 y += box + 16
-            draw.rectangle(
-                [x, y, x + box, y + box], fill=fill, outline=outline, width=width
-            )
+            if hatched:
+                _draw_edge_strip(img, draw, (x, y, x + box, y + box), outline, True)
+            else:
+                draw.rectangle(
+                    [x, y, x + box, y + box], fill=fill, outline=outline, width=width
+                )
             draw.text(
                 (x + box + 12, y + (box - th) // 2),
                 text,
-                fill="black",
+                fill=text_color,
                 font=legend_font,
             )
             x += item_w
@@ -226,6 +344,8 @@ class VisualizationService:
         piece: dict,
         dim_font: ImageFont.ImageFont,
         label_font: ImageFont.ImageFont,
+        theme: _DiagramTheme,
+        mono: bool = False,
     ) -> None:
         """Dibuja una pieza con el alto acotado a la izquierda, el ancho abajo y la
         etiqueta al centro."""
@@ -236,35 +356,37 @@ class VisualizationService:
 
         draw.rectangle(
             [px, py, px + pw, py + ph],
-            fill=COLOR_PIECE_FILL,
-            outline=COLOR_PIECE_OUTLINE,
+            fill=theme.piece_fill,
+            outline=theme.piece_outline,
             width=PIECE_OUTLINE_WIDTH,
         )
 
-        # Lados canteados: se resaltan con el mismo color del borde de la pieza, solo
-        # que con una banda más gruesa pintada DESDE el borde HACIA ADENTRO (se dibujan
-        # antes de las cotas para que los números queden legibles encima).
+        # Lados canteados: franja gruesa pegada al borde, por dentro de la pieza. En
+        # monocromo el canto duro va rayado en diagonal y el suave (o desconocido)
+        # sólido. Se dibujan antes de las cotas para que los números queden encima.
         edges = piece.get("edges") or {}
         sides = set(edges.get("sides") or [])
         if sides:
+            hatched = mono and edges.get("band_type") == "Hard"
             w = EDGE_BANDING_WIDTH
+            color = theme.edge
             if "top" in sides:
-                draw.rectangle([px, py, px + pw, py + w], fill=COLOR_PIECE_OUTLINE)
+                _draw_edge_strip(img, draw, (px, py, px + pw, py + w), color, hatched)
             if "bottom" in sides:
-                draw.rectangle(
-                    [px, py + ph - w, px + pw, py + ph], fill=COLOR_PIECE_OUTLINE
+                _draw_edge_strip(
+                    img, draw, (px, py + ph - w, px + pw, py + ph), color, hatched
                 )
             if "left" in sides:
-                draw.rectangle([px, py, px + w, py + ph], fill=COLOR_PIECE_OUTLINE)
+                _draw_edge_strip(img, draw, (px, py, px + w, py + ph), color, hatched)
             if "right" in sides:
-                draw.rectangle(
-                    [px + pw - w, py, px + pw, py + ph], fill=COLOR_PIECE_OUTLINE
+                _draw_edge_strip(
+                    img, draw, (px + pw - w, py, px + pw, py + ph), color, hatched
                 )
 
         pad = 4
 
         # Ancho (segunda medida) sobre el borde inferior, texto horizontal.
-        ancho = _text_image(str(int(piece["width"])), dim_font, COLOR_DIM)
+        ancho = _text_image(str(int(piece["width"])), dim_font, theme.dim)
         if ancho.width <= pw - 2 * pad and ancho.height <= ph - 2 * pad:
             img.paste(
                 ancho,
@@ -273,7 +395,7 @@ class VisualizationService:
             )
 
         # Alto (primera medida) sobre el borde izquierdo, texto vertical.
-        alto = _text_image(str(int(piece["height"])), dim_font, COLOR_DIM).rotate(
+        alto = _text_image(str(int(piece["height"])), dim_font, theme.dim).rotate(
             90, expand=True
         )
         if alto.height <= ph - 2 * pad and alto.width <= pw - 2 * pad:
@@ -288,13 +410,13 @@ class VisualizationService:
         if piece_id and not piece_id.startswith("piece_"):
             label = _fit_label(piece_id, label_font, pw - 2 * pad, ph - 2 * pad)
             if label:
-                stack.append(_text_image(label, label_font, COLOR_LABEL))
+                stack.append(_text_image(label, label_font, theme.label))
 
         notation = edges.get("notation")
         if notation:
             fitted = _fit_label(notation, dim_font, pw - 2 * pad, ph - 2 * pad)
             if fitted:
-                stack.append(_text_image(fitted, dim_font, COLOR_LABEL))
+                stack.append(_text_image(fitted, dim_font, theme.label))
 
         if stack:
             gap = 2

--- a/src/modules/orders/router.py
+++ b/src/modules/orders/router.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional
 
 from fastapi import APIRouter, Depends, Query
 
@@ -50,8 +50,9 @@ _FORMAT_QUERY = Query(
 
 @router.get("/", response_model=PaginatedResponse[OrderResponse], dependencies=[_READ])
 def list_orders(
-    status: Optional[OrderStatus] = Query(
-        default=None, description="Filtra órdenes por estado"
+    status: Optional[List[OrderStatus]] = Query(
+        default=None,
+        description="Filtra órdenes por uno o varios estados (repetir el parámetro)",
     ),
     branch_id: Optional[int] = Query(
         default=None,

--- a/src/modules/orders/service.py
+++ b/src/modules/orders/service.py
@@ -64,7 +64,7 @@ class OrderService(BranchScopedMixin):
 
     def list_orders(
         self,
-        status: Optional[OrderStatus] = None,
+        status: Optional[List[OrderStatus]] = None,
         branch_scope: Optional[int] = None,
         branch_filter: Optional[int] = None,
         limit: int = 20,
@@ -72,12 +72,13 @@ class OrderService(BranchScopedMixin):
     ) -> Tuple[List[OrderModel], int]:
         """Lista órdenes (más recientes primero) con conteo total: ``(items, total)``.
 
+        ``status`` filtra por uno o varios estados (lista vacía/``None`` = todos).
         ``branch_scope`` aísla al staff a su sucursal; el admin (``None``) ve todas y
         puede estrechar a una con ``branch_filter``.
         """
         query = self.db.query(OrderModel)
-        if status is not None:
-            query = query.filter(OrderModel.status == status.value)
+        if status:
+            query = query.filter(OrderModel.status.in_([s.value for s in status]))
         query = self._apply_branch_scope(query, branch_scope, branch_filter)
         total = query.count()
         orders = query.order_by(OrderModel.id.desc()).offset(offset).limit(limit).all()

--- a/tests/test_edge_banding.py
+++ b/tests/test_edge_banding.py
@@ -395,6 +395,9 @@ def test_placed_piece_notation_includes_band_type(client):
     placed = resp.json()["data"]["layouts"][0]["placedPieces"][0]
     assert placed["rotated"] is False
     assert placed["edges"]["notation"] == "2L1C CS"
+    # El tipo canónico viaja en la pieza colocada (diferencia suave/duro en el diagrama).
+    # ``edges`` es un dict crudo → la clave se serializa tal cual (snake_case).
+    assert placed["edges"]["band_type"] == "Soft"
 
 
 # --------------------------------------------------------------------------- #
@@ -465,6 +468,38 @@ def test_order_proforma_with_edge_banding_renders(client, db_session):
     assert proforma.status_code == 200
     assert len(proforma.content) > 1000
 
+    sheet = client.get(f"/api/v1/orders/{order['id']}/production-sheet")
+    assert sheet.status_code == 200
+    assert len(sheet.content) > 1000
+
+
+def test_production_sheet_renders_soft_and_hard_bands(client, db_session):
+    """La hoja de producción (B/N) renderiza piezas con canto suave y duro: ejercita
+    el rayado del canto duro y ambas entradas de leyenda. El summary expone bandType."""
+    c = _create_client(client)
+    b = _create_board(client)
+    soft = _create_edge_banding(client, code="TAP-SOFT", price=2.0, band_type="Soft")
+    hard = _create_edge_banding(client, code="TAP-HARD", price=3.0, band_type="Hard")
+
+    payload = {
+        "clientId": c["id"],
+        "branchId": 1,
+        "materials": _materials(b["id"]),
+        "requirements": [
+            _requirement(soft["id"], ["top", "bottom"]),
+            _requirement(hard["id"], ["left", "right"]),
+        ],
+    }
+
+    # El resumen de tapacantos expone el tipo (campo Pydantic → camelCase ``bandType``).
+    summary = client.post("/api/v1/optimize/", json=payload).json()["data"][
+        "edgeBandingsSummary"
+    ]
+    by_code = {entry["productCode"]: entry for entry in summary}
+    assert by_code["TAP-SOFT"]["bandType"] == "Soft"
+    assert by_code["TAP-HARD"]["bandType"] == "Hard"
+
+    order = _mint_order(client, db_session, payload)
     sheet = client.get(f"/api/v1/orders/{order['id']}/production-sheet")
     assert sheet.status_code == 200
     assert len(sheet.content) > 1000

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -201,6 +201,28 @@ def test_list_orders_filter_by_status(client, db_session):
     assert len(confirmed["data"]) == 1
 
 
+def test_list_orders_filter_by_multiple_statuses(client, db_session):
+    c = _create_client(client)
+    b = _create_board(client)
+    o1 = _create_order(client, db_session, _order_payload(c["id"], b["id"], width=600))
+    o2 = _create_order(client, db_session, _order_payload(c["id"], b["id"], width=500))
+    o3 = _create_order(client, db_session, _order_payload(c["id"], b["id"], width=400))
+
+    # o1: confirmed → in_production → cutting; o2: queda confirmed; o3: in_production.
+    client.patch(f"/api/v1/orders/{o1['id']}/status", json={"status": "in_production"})
+    client.patch(f"/api/v1/orders/{o1['id']}/status", json={"status": "cutting"})
+    client.patch(f"/api/v1/orders/{o3['id']}/status", json={"status": "in_production"})
+
+    # Repetir el parámetro filtra por varios estados a la vez.
+    resp = client.get(
+        "/api/v1/orders/", params={"status": ["confirmed", "cutting"]}
+    ).json()
+    ids = {o["id"] for o in resp["data"]}
+    assert ids == {o1["id"], o2["id"]}
+    assert o3["id"] not in ids
+    assert resp["meta"]["pagination"]["total"] == 2
+
+
 def test_get_order_404(client):
     assert client.get("/api/v1/orders/999999").status_code == 404
 


### PR DESCRIPTION

  - Introduce Palette and _DiagramTheme dataclasses to decouple brand colors from monochrome rendering; production sheet now uses MONO_PALETTE (black table headers, white pieces, no logo) with compact margins
  - Surface band_type (Soft/Hard) from product attributes through the whole optimization pipeline: placed pieces, edge banding summary, and PDF tables
  - Differentiate hard edge banding with diagonal hatch pattern in the cutting diagram (mono mode); legend shows separate entries for soft and hard bands
  - Add Tipo column (Suave/Duro) to the edge bandings table in production sheet
  - Replace branded header/footer with a compact plain header (title + reference/date/client) and a minimal date/page-number footer
  - Allow filtering orders by multiple statuses (?status=confirmed&status=cutting) via List[OrderStatus] in the router and .in_() query in the service